### PR TITLE
Add Layer 0 foundation paths and record builders

### DIFF
--- a/core/data/ohlcv.py
+++ b/core/data/ohlcv.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from datetime import date as Date
+from typing import Any
+
+from core.contracts.schemas import OHLCVRecord
+
+REQUIRED_OHLCV_FIELDS = (
+    "date",
+    "ticker",
+    "open",
+    "high",
+    "low",
+    "close",
+    "volume",
+    "adj_close",
+    "dollar_volume",
+)
+
+
+def build_ohlcv_record(row: Mapping[str, Any]) -> OHLCVRecord:
+    """Build a validated OHLCVRecord from a vendor-neutral mapping."""
+    _require_fields(row, REQUIRED_OHLCV_FIELDS)
+
+    date = _coerce_date(row["date"])
+    ticker = _coerce_ticker(row["ticker"])
+    open_price = _coerce_positive_finite_float(row["open"], "open")
+    high = _coerce_positive_finite_float(row["high"], "high")
+    low = _coerce_positive_finite_float(row["low"], "low")
+    close = _coerce_positive_finite_float(row["close"], "close")
+    adj_close = _coerce_positive_finite_float(row["adj_close"], "adj_close")
+    volume = _coerce_non_negative_int(row["volume"], "volume")
+    dollar_volume = _coerce_non_negative_finite_float(row["dollar_volume"], "dollar_volume")
+
+    _validate_ohlc_relationships(
+        open_price=open_price,
+        high=high,
+        low=low,
+        close=close,
+    )
+
+    return OHLCVRecord(
+        date=date,
+        ticker=ticker,
+        open=open_price,
+        high=high,
+        low=low,
+        close=close,
+        volume=volume,
+        adj_close=adj_close,
+        dollar_volume=dollar_volume,
+    )
+
+
+def _require_fields(row: Mapping[str, Any], fields: tuple[str, ...]) -> None:
+    """Require all fields to exist and be non-null."""
+    missing = [field for field in fields if field not in row or row[field] is None]
+    if missing:
+        raise ValueError(f"Missing required OHLCV field(s): {', '.join(missing)}")
+
+
+def _coerce_date(value: Any) -> str:
+    """Coerce and validate a YYYY-MM-DD date string."""
+    if not isinstance(value, str):
+        raise TypeError("date must be a YYYY-MM-DD string")
+    stripped = value.strip()
+    if not _is_extended_iso_date(stripped):
+        raise ValueError(f"date must be YYYY-MM-DD: {value}")
+    try:
+        return Date.fromisoformat(stripped).isoformat()
+    except ValueError as exc:
+        raise ValueError(f"date must be YYYY-MM-DD: {value}") from exc
+
+
+def _coerce_ticker(value: Any) -> str:
+    """Coerce ticker text to uppercase."""
+    if not isinstance(value, str):
+        raise TypeError("ticker must be a string")
+    stripped = value.strip().upper()
+    if not stripped:
+        raise ValueError("ticker cannot be empty")
+    return stripped
+
+
+def _coerce_positive_finite_float(value: Any, field_name: str) -> float:
+    """Coerce a strictly positive finite float."""
+    number = _coerce_finite_float(value, field_name)
+    if number <= 0.0:
+        raise ValueError(f"{field_name} must be positive")
+    return number
+
+
+def _coerce_non_negative_finite_float(value: Any, field_name: str) -> float:
+    """Coerce a non-negative finite float."""
+    number = _coerce_finite_float(value, field_name)
+    if number < 0.0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return number
+
+
+def _coerce_finite_float(value: Any, field_name: str) -> float:
+    """Coerce a finite float."""
+    if isinstance(value, bool):
+        raise TypeError(f"{field_name} must be numeric")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{field_name} must be numeric") from exc
+    if not math.isfinite(number):
+        raise ValueError(f"{field_name} must be finite")
+    return number
+
+
+def _coerce_non_negative_int(value: Any, field_name: str) -> int:
+    """Coerce a non-negative integer."""
+    if isinstance(value, bool):
+        raise TypeError(f"{field_name} must be an integer")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError(f"{field_name} must be an integer") from exc
+    if not math.isfinite(number) or not number.is_integer():
+        raise ValueError(f"{field_name} must be an integer")
+    integer = int(number)
+    if integer < 0:
+        raise ValueError(f"{field_name} must be non-negative")
+    return integer
+
+
+def _validate_ohlc_relationships(
+    *,
+    open_price: float,
+    high: float,
+    low: float,
+    close: float,
+) -> None:
+    """Validate OHLC price relationships."""
+    if high < low:
+        raise ValueError("high must be greater than or equal to low")
+    if not low <= open_price <= high:
+        raise ValueError("open must be inside the [low, high] range")
+    if not low <= close <= high:
+        raise ValueError("close must be inside the [low, high] range")
+
+
+def _is_extended_iso_date(value: str) -> bool:
+    """Return True for YYYY-MM-DD strings only."""
+    return (
+        len(value) == 10
+        and value[4] == "-"
+        and value[7] == "-"
+        and value[:4].isdigit()
+        and value[5:7].isdigit()
+        and value[8:10].isdigit()
+    )

--- a/core/data/ohlcv.py
+++ b/core/data/ohlcv.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import math
 from collections.abc import Mapping
 from datetime import date as Date
+from decimal import Decimal
 from typing import Any
 
 from core.contracts.schemas import OHLCVRecord
@@ -102,12 +103,9 @@ def _coerce_non_negative_finite_float(value: Any, field_name: str) -> float:
 
 def _coerce_finite_float(value: Any, field_name: str) -> float:
     """Coerce a finite float."""
-    if isinstance(value, bool):
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
         raise TypeError(f"{field_name} must be numeric")
-    try:
-        number = float(value)
-    except (TypeError, ValueError) as exc:
-        raise TypeError(f"{field_name} must be numeric") from exc
+    number = float(value)
     if not math.isfinite(number):
         raise ValueError(f"{field_name} must be finite")
     return number
@@ -115,12 +113,9 @@ def _coerce_finite_float(value: Any, field_name: str) -> float:
 
 def _coerce_non_negative_int(value: Any, field_name: str) -> int:
     """Coerce a non-negative integer."""
-    if isinstance(value, bool):
+    if isinstance(value, bool) or not isinstance(value, (int, float, Decimal)):
         raise TypeError(f"{field_name} must be an integer")
-    try:
-        number = float(value)
-    except (TypeError, ValueError) as exc:
-        raise TypeError(f"{field_name} must be an integer") from exc
+    number = float(value)
     if not math.isfinite(number) or not number.is_integer():
         raise ValueError(f"{field_name} must be an integer")
     integer = int(number)

--- a/core/data/universe.py
+++ b/core/data/universe.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import date as Date
+from typing import Any
+
+from core.contracts.schemas import UniverseRecord
+
+REQUIRED_UNIVERSE_FIELDS = ("date", "ticker", "in_universe")
+BOOLEAN_FIELDS = ("in_universe", "tradable", "liquid", "halted", "data_quality_ok")
+DEFAULT_UNIVERSE_VALUES = {
+    "tradable": True,
+    "liquid": True,
+    "halted": False,
+    "data_quality_ok": True,
+    "reason": None,
+}
+TRUE_VALUES = {"1", "true", "t", "yes", "y"}
+FALSE_VALUES = {"0", "false", "f", "no", "n"}
+
+
+def build_universe_record(row: Mapping[str, Any]) -> UniverseRecord:
+    """Build a validated UniverseRecord from a vendor-neutral mapping."""
+    _require_fields(row, REQUIRED_UNIVERSE_FIELDS)
+
+    values: dict[str, Any] = {
+        "date": _coerce_date(row["date"]),
+        "ticker": _coerce_ticker(row["ticker"]),
+        "in_universe": _coerce_bool(row["in_universe"], "in_universe"),
+        **DEFAULT_UNIVERSE_VALUES,
+    }
+
+    for field in BOOLEAN_FIELDS:
+        if field in row and row[field] is not None:
+            values[field] = _coerce_bool(row[field], field)
+
+    if "reason" in row:
+        values["reason"] = _coerce_optional_reason(row["reason"])
+
+    return UniverseRecord(**values)
+
+
+def _require_fields(row: Mapping[str, Any], fields: tuple[str, ...]) -> None:
+    """Require all fields to exist and be non-null."""
+    missing = [field for field in fields if field not in row or row[field] is None]
+    if missing:
+        raise ValueError(f"Missing required universe field(s): {', '.join(missing)}")
+
+
+def _coerce_date(value: Any) -> str:
+    """Coerce and validate a YYYY-MM-DD date string."""
+    if not isinstance(value, str):
+        raise TypeError("date must be a YYYY-MM-DD string")
+    stripped = value.strip()
+    if not _is_extended_iso_date(stripped):
+        raise ValueError(f"date must be YYYY-MM-DD: {value}")
+    try:
+        return Date.fromisoformat(stripped).isoformat()
+    except ValueError as exc:
+        raise ValueError(f"date must be YYYY-MM-DD: {value}") from exc
+
+
+def _coerce_ticker(value: Any) -> str:
+    """Coerce ticker text to uppercase."""
+    if not isinstance(value, str):
+        raise TypeError("ticker must be a string")
+    stripped = value.strip().upper()
+    if not stripped:
+        raise ValueError("ticker cannot be empty")
+    return stripped
+
+
+def _coerce_bool(value: Any, field_name: str) -> bool:
+    """Coerce common boolean representations."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in {0, 1}:
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in TRUE_VALUES:
+            return True
+        if normalized in FALSE_VALUES:
+            return False
+    raise ValueError(f"{field_name} must be a boolean value")
+
+
+def _coerce_optional_reason(value: Any) -> str | None:
+    """Coerce an optional reason string."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        raise TypeError("reason must be a string or None")
+    stripped = value.strip()
+    return stripped or None
+
+
+def _is_extended_iso_date(value: str) -> bool:
+    """Return True for YYYY-MM-DD strings only."""
+    return (
+        len(value) == 10
+        and value[4] == "-"
+        and value[7] == "-"
+        and value[:4].isdigit()
+        and value[5:7].isdigit()
+        and value[8:10].isdigit()
+    )

--- a/core/data/universe.py
+++ b/core/data/universe.py
@@ -7,7 +7,7 @@ from typing import Any
 from core.contracts.schemas import UniverseRecord
 
 REQUIRED_UNIVERSE_FIELDS = ("date", "ticker", "in_universe")
-BOOLEAN_FIELDS = ("in_universe", "tradable", "liquid", "halted", "data_quality_ok")
+OPTIONAL_BOOLEAN_FIELDS = ("tradable", "liquid", "halted", "data_quality_ok")
 DEFAULT_UNIVERSE_VALUES = {
     "tradable": True,
     "liquid": True,
@@ -30,7 +30,7 @@ def build_universe_record(row: Mapping[str, Any]) -> UniverseRecord:
         **DEFAULT_UNIVERSE_VALUES,
     }
 
-    for field in BOOLEAN_FIELDS:
+    for field in OPTIONAL_BOOLEAN_FIELDS:
         if field in row and row[field] is not None:
             values[field] = _coerce_bool(row[field], field)
 

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import date as Date
+from datetime import datetime
+from pathlib import PurePosixPath
+
+
+def build_r2_key(*parts: str) -> str:
+    """Build a safe POSIX object key from validated path parts."""
+    if not parts:
+        raise ValueError("R2 key requires at least one path part")
+
+    cleaned_parts = [_validate_key_part(part) for part in parts]
+    key = PurePosixPath(*cleaned_parts).as_posix()
+    path = PurePosixPath(key)
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"Unsafe R2 key: {key}")
+    return key
+
+
+def raw_price_path(permaticker: str) -> str:
+    """Return the canonical raw OHLCV Parquet path for one Tiingo permaTicker."""
+    safe_permaticker = _validate_key_part(permaticker)
+    return build_r2_key("raw", "prices", f"{safe_permaticker}.parquet")
+
+
+def raw_news_path(as_of_date: str | Date | datetime) -> str:
+    """Return the canonical raw news JSON Lines path for one date."""
+    return build_r2_key("raw", "news", f"{_format_date(as_of_date)}.jsonl")
+
+
+def raw_universe_path(as_of_date: str | Date | datetime) -> str:
+    """Return the canonical raw universe eligibility-mask CSV path for one date."""
+    return build_r2_key("raw", "universe", f"{_format_date(as_of_date)}.csv")
+
+
+def raw_reference_path(name: str, extension: str = "json") -> str:
+    """Return the canonical raw reference snapshot path."""
+    safe_name = _validate_key_part(name)
+    safe_extension = _validate_extension(extension)
+    return build_r2_key("raw", "reference", f"{safe_name}.{safe_extension}")
+
+
+def raw_security_master_path(as_of_date: str | Date | datetime) -> str:
+    """Return the canonical raw security-master snapshot path for one date."""
+    return build_r2_key("raw", "reference", "security_master", f"{_format_date(as_of_date)}.json")
+
+
+def pipeline_manifest_path(stage: str, run_id: str) -> str:
+    """Return the canonical pipeline manifest path for one stage/run pair."""
+    safe_stage = _validate_key_part(stage)
+    safe_run_id = _validate_key_part(run_id)
+    return build_r2_key("artifacts", "manifests", safe_stage, f"{safe_run_id}.json")
+
+
+def _format_date(value: str | Date | datetime) -> str:
+    """Normalize a date-like value to YYYY-MM-DD."""
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, Date):
+        return value.isoformat()
+    if not isinstance(value, str):
+        raise TypeError("Date value must be a string, date, or datetime")
+
+    stripped = value.strip()
+    if not _is_extended_iso_date(stripped):
+        raise ValueError(f"Date must be YYYY-MM-DD: {value}")
+    try:
+        return Date.fromisoformat(stripped).isoformat()
+    except ValueError as exc:
+        raise ValueError(f"Date must be YYYY-MM-DD: {value}") from exc
+
+
+def _validate_key_part(part: str) -> str:
+    """Validate one object-key part and return its stripped value."""
+    if not isinstance(part, str):
+        raise TypeError("R2 key parts must be strings")
+
+    stripped = part.strip()
+    if not stripped:
+        raise ValueError("R2 key parts cannot be empty")
+    if stripped in {".", ".."}:
+        raise ValueError(f"Unsafe R2 key part: {part}")
+    if stripped.startswith("/") or "\\" in stripped or "/" in stripped:
+        raise ValueError(f"Unsafe R2 key part: {part}")
+    if "\x00" in stripped:
+        raise ValueError("R2 key parts cannot contain null bytes")
+    return stripped
+
+
+def _validate_extension(extension: str) -> str:
+    """Validate a file extension without a leading dot."""
+    safe_extension = _validate_key_part(extension)
+    if safe_extension.startswith(".") or "." in safe_extension:
+        raise ValueError(f"File extension must not contain dots: {extension}")
+    return safe_extension
+
+
+def _is_extended_iso_date(value: str) -> bool:
+    """Return True for YYYY-MM-DD strings only."""
+    return (
+        len(value) == 10
+        and value[4] == "-"
+        and value[7] == "-"
+        and value[:4].isdigit()
+        and value[5:7].isdigit()
+        and value[8:10].isdigit()
+    )

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -18,10 +18,10 @@ def build_r2_key(*parts: str) -> str:
     return key
 
 
-def raw_price_path(permaticker: str) -> str:
-    """Return the canonical raw OHLCV Parquet path for one Tiingo permaTicker."""
-    safe_permaticker = _validate_key_part(permaticker)
-    return build_r2_key("raw", "prices", f"{safe_permaticker}.parquet")
+def raw_price_path(security_id: str) -> str:
+    """Return the canonical raw OHLCV Parquet path for one stable security identifier."""
+    safe_security_id = _validate_key_part(security_id)
+    return build_r2_key("raw", "prices", f"{safe_security_id}.parquet")
 
 
 def raw_news_path(as_of_date: str | Date | datetime) -> str:

--- a/tests/unit/test_data_ohlcv.py
+++ b/tests/unit/test_data_ohlcv.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+from decimal import Decimal
 from typing import Any
 
 import pytest
@@ -36,6 +37,16 @@ def test_build_ohlcv_record_happy_path() -> None:
     assert record.volume == 1234
     assert record.adj_close == 103.5
     assert record.dollar_volume == 128336.0
+
+
+def test_build_ohlcv_record_accepts_decimal_numeric_values() -> None:
+    """Decimal numeric inputs are explicit numeric types and remain valid."""
+    row = _valid_row()
+    row["close"] = Decimal("104.0")
+
+    record = build_ohlcv_record(row)
+
+    assert record.close == 104.0
 
 
 @pytest.mark.parametrize("field", ["date", "ticker"])
@@ -74,6 +85,15 @@ def test_build_ohlcv_record_rejects_non_finite_prices(bad_value: float) -> None:
     row["close"] = bad_value
 
     with pytest.raises(ValueError, match="finite"):
+        build_ohlcv_record(row)
+
+
+def test_build_ohlcv_record_rejects_string_price_values() -> None:
+    """Numeric strings must be parsed explicitly by the upstream adapter."""
+    row = _valid_row()
+    row["close"] = "104.0"
+
+    with pytest.raises(TypeError, match="numeric"):
         build_ohlcv_record(row)
 
 
@@ -126,4 +146,13 @@ def test_build_ohlcv_record_rejects_bad_volume_values(
     row[field] = value
 
     with pytest.raises(ValueError, match=message):
+        build_ohlcv_record(row)
+
+
+def test_build_ohlcv_record_rejects_string_volume_values() -> None:
+    """Volume strings must be parsed explicitly by the upstream adapter."""
+    row = _valid_row()
+    row["volume"] = "1234"
+
+    with pytest.raises(TypeError, match="integer"):
         build_ohlcv_record(row)

--- a/tests/unit/test_data_ohlcv.py
+++ b/tests/unit/test_data_ohlcv.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import pytest
+
+from core.data.ohlcv import build_ohlcv_record
+
+
+def _valid_row() -> dict[str, Any]:
+    """Return a valid vendor-neutral OHLCV row."""
+    return {
+        "date": "2025-01-02",
+        "ticker": " aapl ",
+        "open": 100.0,
+        "high": 105.0,
+        "low": 99.0,
+        "close": 104.0,
+        "volume": 1234,
+        "adj_close": 103.5,
+        "dollar_volume": 128336.0,
+    }
+
+
+def test_build_ohlcv_record_happy_path() -> None:
+    """A complete valid row becomes a schema-valid OHLCVRecord."""
+    record = build_ohlcv_record(_valid_row())
+
+    assert record.date == "2025-01-02"
+    assert record.ticker == "AAPL"
+    assert record.open == 100.0
+    assert record.high == 105.0
+    assert record.low == 99.0
+    assert record.close == 104.0
+    assert record.volume == 1234
+    assert record.adj_close == 103.5
+    assert record.dollar_volume == 128336.0
+
+
+@pytest.mark.parametrize("field", ["date", "ticker"])
+def test_build_ohlcv_record_rejects_missing_identity_fields(field: str) -> None:
+    """Date and ticker are required identity fields."""
+    row = _valid_row()
+    row.pop(field)
+
+    with pytest.raises(ValueError, match=field):
+        build_ohlcv_record(row)
+
+
+def test_build_ohlcv_record_rejects_invalid_date() -> None:
+    """OHLCV dates must be ISO calendar dates."""
+    row = _valid_row()
+    row["date"] = "20250102"
+
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        build_ohlcv_record(row)
+
+
+@pytest.mark.parametrize("field", ["open", "high", "low", "close", "adj_close"])
+def test_build_ohlcv_record_rejects_missing_price_fields(field: str) -> None:
+    """All required price fields must be present."""
+    row = _valid_row()
+    row.pop(field)
+
+    with pytest.raises(ValueError, match=field):
+        build_ohlcv_record(row)
+
+
+@pytest.mark.parametrize("bad_value", [math.nan, math.inf, -math.inf])
+def test_build_ohlcv_record_rejects_non_finite_prices(bad_value: float) -> None:
+    """Price fields cannot be NaN or infinite."""
+    row = _valid_row()
+    row["close"] = bad_value
+
+    with pytest.raises(ValueError, match="finite"):
+        build_ohlcv_record(row)
+
+
+@pytest.mark.parametrize("field", ["open", "high", "low", "close", "adj_close"])
+def test_build_ohlcv_record_rejects_non_positive_prices(field: str) -> None:
+    """Equity price fields must be positive."""
+    row = _valid_row()
+    row[field] = 0
+
+    with pytest.raises(ValueError, match="positive"):
+        build_ohlcv_record(row)
+
+
+@pytest.mark.parametrize(
+    ("updates", "message"),
+    [
+        ({"high": 98.0}, "high"),
+        ({"open": 98.0}, "open"),
+        ({"close": 106.0}, "close"),
+    ],
+)
+def test_build_ohlcv_record_rejects_invalid_ohlc_relationships(
+    updates: dict[str, float],
+    message: str,
+) -> None:
+    """High/low/open/close relationships are validated before record creation."""
+    row = _valid_row()
+    row.update(updates)
+
+    with pytest.raises(ValueError, match=message):
+        build_ohlcv_record(row)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("volume", -1, "non-negative"),
+        ("volume", 1.5, "integer"),
+        ("dollar_volume", -0.01, "non-negative"),
+        ("dollar_volume", math.nan, "finite"),
+    ],
+)
+def test_build_ohlcv_record_rejects_bad_volume_values(
+    field: str,
+    value: float,
+    message: str,
+) -> None:
+    """Volume and dollar-volume fields must be non-negative and finite."""
+    row = _valid_row()
+    row[field] = value
+
+    with pytest.raises(ValueError, match=message):
+        build_ohlcv_record(row)

--- a/tests/unit/test_data_universe.py
+++ b/tests/unit/test_data_universe.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from core.data.universe import build_universe_record
+
+
+def _valid_row() -> dict[str, Any]:
+    """Return a valid vendor-neutral universe row."""
+    return {
+        "date": "2025-01-02",
+        "ticker": " aapl ",
+        "in_universe": True,
+    }
+
+
+def test_build_universe_record_happy_path_uses_explicit_defaults() -> None:
+    """A minimal row becomes a schema-valid UniverseRecord with explicit defaults."""
+    record = build_universe_record(_valid_row())
+
+    assert record.date == "2025-01-02"
+    assert record.ticker == "AAPL"
+    assert record.in_universe is True
+    assert record.tradable is True
+    assert record.liquid is True
+    assert record.halted is False
+    assert record.data_quality_ok is True
+    assert record.reason is None
+
+
+def test_build_universe_record_accepts_explicit_optional_fields() -> None:
+    """Optional flags and reason text are preserved when supplied."""
+    row = {
+        **_valid_row(),
+        "tradable": "false",
+        "liquid": 0,
+        "halted": "yes",
+        "data_quality_ok": "n",
+        "reason": " data issue ",
+    }
+
+    record = build_universe_record(row)
+
+    assert record.tradable is False
+    assert record.liquid is False
+    assert record.halted is True
+    assert record.data_quality_ok is False
+    assert record.reason == "data issue"
+
+
+@pytest.mark.parametrize("field", ["date", "ticker", "in_universe"])
+def test_build_universe_record_rejects_missing_required_fields(field: str) -> None:
+    """Date, ticker, and in_universe are required."""
+    row = _valid_row()
+    row.pop(field)
+
+    with pytest.raises(ValueError, match=field):
+        build_universe_record(row)
+
+
+def test_build_universe_record_rejects_invalid_date() -> None:
+    """Universe dates must be ISO calendar dates."""
+    row = _valid_row()
+    row["date"] = "20250102"
+
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        build_universe_record(row)
+
+
+def test_build_universe_record_rejects_empty_ticker() -> None:
+    """Ticker identity cannot be blank."""
+    row = _valid_row()
+    row["ticker"] = "   "
+
+    with pytest.raises(ValueError, match="ticker"):
+        build_universe_record(row)
+
+
+@pytest.mark.parametrize("field", ["in_universe", "tradable", "liquid", "halted", "data_quality_ok"])
+def test_build_universe_record_rejects_invalid_bool_values(field: str) -> None:
+    """Boolean fields must use recognized boolean values."""
+    row = _valid_row()
+    row[field] = "maybe"
+
+    with pytest.raises(ValueError, match=field):
+        build_universe_record(row)
+
+
+def test_build_universe_record_rejects_non_string_reason() -> None:
+    """Reason metadata must be text when present."""
+    row = _valid_row()
+    row["reason"] = 123
+
+    with pytest.raises(TypeError, match="reason"):
+        build_universe_record(row)

--- a/tests/unit/test_r2_paths.py
+++ b/tests/unit/test_r2_paths.py
@@ -22,7 +22,7 @@ def test_build_r2_key_joins_posix_parts() -> None:
 
 def test_layer0_raw_path_builders_return_canonical_keys() -> None:
     """Layer 0 path builders return the documented raw artifact locations."""
-    assert raw_price_path("12345") == "raw/prices/12345.parquet"
+    assert raw_price_path("AAPL") == "raw/prices/AAPL.parquet"
     assert raw_news_path("2025-01-02") == "raw/news/2025-01-02.jsonl"
     assert raw_news_path(datetime(2025, 1, 2, 15, 30)) == "raw/news/2025-01-02.jsonl"
     assert raw_universe_path(date(2025, 1, 2)) == "raw/universe/2025-01-02.csv"

--- a/tests/unit/test_r2_paths.py
+++ b/tests/unit/test_r2_paths.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+
+import pytest
+
+from services.r2.paths import (
+    build_r2_key,
+    pipeline_manifest_path,
+    raw_news_path,
+    raw_price_path,
+    raw_reference_path,
+    raw_security_master_path,
+    raw_universe_path,
+)
+
+
+def test_build_r2_key_joins_posix_parts() -> None:
+    """R2 keys use deterministic POSIX separators."""
+    assert build_r2_key("raw", "prices", "123.parquet") == "raw/prices/123.parquet"
+
+
+def test_layer0_raw_path_builders_return_canonical_keys() -> None:
+    """Layer 0 path builders return the documented raw artifact locations."""
+    assert raw_price_path("12345") == "raw/prices/12345.parquet"
+    assert raw_news_path("2025-01-02") == "raw/news/2025-01-02.jsonl"
+    assert raw_news_path(datetime(2025, 1, 2, 15, 30)) == "raw/news/2025-01-02.jsonl"
+    assert raw_universe_path(date(2025, 1, 2)) == "raw/universe/2025-01-02.csv"
+    assert raw_reference_path("tiingo_security_master") == "raw/reference/tiingo_security_master.json"
+    assert (
+        raw_security_master_path("2025-01-02")
+        == "raw/reference/security_master/2025-01-02.json"
+    )
+
+
+def test_pipeline_manifest_path_returns_canonical_key() -> None:
+    """Pipeline manifests are stored under artifact manifests by stage and run."""
+    assert (
+        pipeline_manifest_path("layer0", "run-001")
+        == "artifacts/manifests/layer0/run-001.json"
+    )
+
+
+@pytest.mark.parametrize("bad_part", ["", "   ", ".", "..", "/absolute", "raw/news", r"raw\\news"])
+def test_build_r2_key_rejects_unsafe_parts(bad_part: str) -> None:
+    """Unsafe key parts must fail before reaching object storage."""
+    with pytest.raises((TypeError, ValueError)):
+        build_r2_key("raw", bad_part, "file.json")
+
+
+def test_build_r2_key_requires_parts() -> None:
+    """At least one path part is required."""
+    with pytest.raises(ValueError, match="at least one"):
+        build_r2_key()
+
+
+@pytest.mark.parametrize("bad_date", ["20250102", "2025-99-02", "not-a-date"])
+def test_date_paths_reject_invalid_dates(bad_date: str) -> None:
+    """Date-based paths require ISO calendar dates."""
+    with pytest.raises(ValueError, match="YYYY-MM-DD"):
+        raw_news_path(bad_date)
+
+
+@pytest.mark.parametrize("bad_extension", [".json", "json.gz", "", ".."])
+def test_raw_reference_path_rejects_unsafe_extensions(bad_extension: str) -> None:
+    """Reference extensions cannot smuggle path segments or extra dots."""
+    with pytest.raises(ValueError):
+        raw_reference_path("security_master", bad_extension)


### PR DESCRIPTION
## What this PR does
Adds the shared Layer 0 foundation that downstream ingestion work depends on: canonical R2 path builders for raw Layer 0 artifacts/manifests, plus vendor-neutral builders for `UniverseRecord` and `OHLCVRecord` with strict validation before schema construction.

## Closes
Closes #62

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — pending human review

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, missing fields, bad dates, non-finite values, invalid OHLC relationships, unsafe paths, and invalid boolean values
- [x] No live API calls in unit tests — inline fixtures only

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
```text
/home/juyoungoh/Projects/AI-Stock-Trader/.venv/bin/python -m ruff check .
All checks passed!

/home/juyoungoh/Projects/AI-Stock-Trader/.venv/bin/python -m pytest tests/unit/ -v --tb=short
150 passed in 1.44s
```

## Notes for reviewer
The builders are intentionally vendor-neutral. Tiingo and Alpaca adapters should map their API-specific fields into these core builders instead of adding vendor logic inside `core/data/`.

