### PR TITLE
Sync docs with approved Layer 0 data stack

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -20,5 +20,3 @@
 - [ ] Universe validation still reports a few historical symbol-identity mismatches
   (e.g., UAA, AGN, IQV transition events); evaluate date-bounded symbol mapping
   policy to reduce residual event-boundary violations.
-- [ ] `services/r2/paths.py` source is missing even though Milestone 1 issues reference it as the
-  canonical R2 path builder

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,6 +4,13 @@
 
 This repository implements a production-oriented quantitative trading system for U.S. equities.
 
+The approved data stack is:
+- historical universe membership from Wikipedia revision history
+- canonical historical OHLCV and raw news archives from Tiingo
+- point-in-time fundamentals and earnings dates from SimFin
+- macro and rate context from FRED
+- live market data, broker state, and execution from Alpaca
+
 The system is designed around four deployment surfaces:
 
 1. **Laptop (development)**
@@ -51,18 +58,27 @@ The design principle is:
 
 | Data type | Source | Notes |
 |---|---|---|
-| OHLCV (adjusted) | Polygon.io (student plan) | Adjusted close, splits, dividends |
-| News archive | Polygon.io (student plan) | Point-in-time news for backtests |
-| S&P 500 universe membership | Wikipedia edit history | Free; scrape revision history for point-in-time membership |
-| Broker / account state | Alpaca | Paper and live trading |
-| Macro / rates | FRED or public sources | Fed funds, yield curve, credit spreads |
+| Historical OHLCV (adjusted) | Tiingo EOD API | Canonical long-history store; stable security identity supports delisted/acquired names |
+| Historical and live raw news | Tiingo News API | Raw article text with ticker tags for NLP backtests and daily inference |
+| S&P 500 universe membership | Wikipedia revision history | Point-in-time constituent list; never use today's snapshot for history |
+| Fundamentals / earnings dates | SimFin | As-reported filing data for point-in-time context features |
+| Macro / rates | FRED | Fed funds, Treasury yields, CPI, and other regime/context inputs |
+| Live daily prices / broker state / execution | Alpaca Market Data + Trading API | Current-day bar snapshot, reconciliation source of truth, and order routing |
 
 ### Universe construction note
 Wikipedia's S&P 500 page revision history provides historical constituent changes at no cost.
 The revision history — not the current page — must be scraped to obtain point-in-time membership.
 This approach is accurate enough for personal-system backtesting but may have gaps around
-spinoffs and rapid constituent changes. The Polygon.io student plan does not include
-point-in-time index membership, so Wikipedia is the designated source for this data.
+spinoffs and rapid constituent changes. Tiingo's stable security identity is then used to
+link historical constituents to surviving, delisted, acquired, and symbol-changed names
+without relying on today's ticker symbols as permanent identifiers.
+
+### Historical vs. live market data note
+Historical price and news storage should be treated as a Tiingo-backed canonical archive.
+Alpaca market data is used only for the live daily bar snapshot that the Pi needs near the
+close or before the next open. Any Alpaca-sourced live bar written into the raw store must be
+normalized into the same `OHLCVRecord` shape and stable-security path convention used by
+Tiingo-backed history.
 
 ---
 
@@ -76,9 +92,10 @@ Both the Pi and Modal jobs read and write to R2.
 ```
 r2/
   raw/
-    prices/           # OHLCV Parquet, one file per ticker: AAPL.parquet
-    news/             # Raw news as JSON Lines (one article per line)
+    prices/           # OHLCV Parquet, one file per stable security identifier
+    news/             # Tiingo raw news as JSON Lines (one article per line)
     universe/         # Daily eligibility masks as CSV
+    reference/        # Symbol/permaTicker/security master snapshots
   processed/
     features/         # Feature tables as Parquet (dates × tickers × features)
     scores/           # Layer 2 score outputs as Parquet
@@ -107,7 +124,7 @@ Any artifact that must survive a Pi restart or be accessed by Modal must be writ
 
 | Data type | Format | Reason |
 |---|---|---|
-| OHLCV history | Parquet (per ticker) | 10–50x faster than CSV; columnar reads; `pd.read_parquet()` |
+| OHLCV history | Parquet (per stable security identifier) | 10–50x faster than CSV; columnar reads; `pd.read_parquet()` |
 | Feature tables | Parquet (partitioned by date) | Frequently read by model pipeline |
 | Model scores | Parquet | Small, fast to read |
 | News raw archive | JSON Lines | One article per line; easy to stream |
@@ -131,11 +148,11 @@ The system follows a strict layered architecture.
 Layer 0 guarantees that all downstream layers operate on clean, honest, point-in-time data.
 
 Responsibilities:
-- construct a point-in-time eligible universe (Wikipedia revision history + Polygon OHLCV)
+- construct a point-in-time eligible universe (Wikipedia revision history + Tiingo security history)
 - avoid survivorship bias — use historical constituent lists, never today's index
 - apply daily liquidity and tradeability filters
-- use adjusted OHLCV from Polygon (adjusted for splits and dividends)
-- ingest raw news from Polygon with point-in-time timestamps
+- use Tiingo adjusted OHLCV as the canonical historical market data store
+- ingest raw Tiingo news with point-in-time timestamps and raw text
 - detect stale, missing, or corrupted market data
 - generate daily eligibility masks and quality flags
 
@@ -145,16 +162,16 @@ Responsibilities:
 Builds the complete R2 database that Layer 1 reads for model training and backtesting.
 Runs on laptop or Modal — not the Pi. The Pi has no role in the backfill.
 - Entrypoint: `app/lab/data_pipelines/backfill_layer0.py`
-- Fetches full OHLCV history (e.g. 2014–present) for all S&P 500 tickers → `r2://raw/prices/{ticker}.parquet`
-- Fetches historical news archive → `r2://raw/news/YYYY-MM-DD.jsonl` per date
+- Fetches full OHLCV history (e.g. 2014–present) for all historical constituents keyed by stable Tiingo security identity → `r2://raw/prices/{security_id}.parquet`
+- Fetches historical Tiingo raw news archive → `r2://raw/news/YYYY-MM-DD.jsonl` per date
 - Computes eligibility masks for all historical dates → `r2://raw/universe/YYYY-MM-DD.csv`
 - Idempotent: safe to re-run; skips dates already stored in R2
 
 **Daily incremental (runs on Pi after every market close):**
 Appends today's data to the existing R2 database. Assumes the backfill has already been run.
 - Entrypoint: `app/pi/fetchers/layer0.py`
-- Fetches today's OHLCV bars → appends to existing `r2://raw/prices/{ticker}.parquet`
-- Fetches today's news → writes `r2://raw/news/YYYY-MM-DD.jsonl`
+- Fetches today's live market bar snapshot from Alpaca Market Data → appends normalized rows to the canonical raw price store
+- Fetches today's raw Tiingo news → writes `r2://raw/news/YYYY-MM-DD.jsonl`
 - Recomputes today's eligibility mask → writes `r2://raw/universe/YYYY-MM-DD.csv`
 - Writes `PipelineManifestRecord` to R2 on completion or failure
 
@@ -171,7 +188,7 @@ Appends today's data to the existing R2 database. Assumes the backfill has alrea
 
 **Outputs:**
 - point-in-time universe membership per date (CSV eligibility mask)
-- adjusted OHLCV Parquet files per ticker
+- adjusted OHLCV Parquet files per stable security identifier
 - quality flags per ticker per day: tradeable / halted / data-error / illiquid
 - raw news archive (JSON Lines) for Layer 1 processing
 
@@ -192,7 +209,7 @@ Final feature table shape: `(N_dates × N_tickers)` rows × `M_features` columns
 **Pipeline order (must be executed in this sequence):**
 
 ```
-RAW ARTICLES (Polygon news)
+RAW ARTICLES (Tiingo news)
   → Step 1: Preprocessing
       Clean text, remove boilerplate, split into sentences, tag ticker mentions
   → Step 2a: Sentence Transformers (per article)
@@ -602,8 +619,8 @@ R2 is the source of truth for:
 The following must be completed before the daily loop can run:
 
 1. Run historical backfill: `python app/lab/data_pipelines/backfill_layer0.py --from-date 2014-01-01 --to-date <today>`
-   - Builds complete OHLCV Parquet database in R2 — one file per ticker, all historical bars
-   - Builds historical news archive in R2 — one JSON Lines file per date
+   - Builds complete Tiingo OHLCV Parquet database in R2 — one file per stable security identifier, all historical bars
+   - Builds Tiingo raw news archive in R2 — one JSON Lines file per date
    - Builds historical eligibility masks in R2 — one CSV per date
 2. Train and validate the XGBoost models (Milestones 2, 2.5, 3, 4)
 3. Deploy validated model bundle to R2 / cloud Oracle
@@ -611,7 +628,7 @@ The following must be completed before the daily loop can run:
 Without the historical backfill, Layer 1 feature generation and model training cannot run.
 
 ### After market close (daily, Pi)
-1. Pi runs Layer 0 incremental: fetches today's EOD bars and news from Polygon, appends to R2
+1. Pi runs Layer 0 incremental: fetches today's Alpaca live bar snapshot and Tiingo raw news, appends normalized artifacts to R2
 2. Pi triggers Modal: build/refresh aligned feature table for today → R2
 3. Modal runs FinBERT + XGBoost inference → scores to R2
 4. Pi reads scores from R2
@@ -672,13 +689,13 @@ A candidate becomes promotable only if it survives:
 - `app/cloud/` — cloud inference surface (Modal)
 - `app/pi/` — edge runtime surface (Pi, daily incremental only)
 - `core/contracts/` — shared inter-layer schemas
-- `core/data/` — point-in-time universe/data logic (Polygon + Wikipedia)
+- `core/data/` — point-in-time universe/data logic (Wikipedia + Tiingo-backed records)
 - `core/features/` — market, NLP, context feature logic
 - `core/models/` — XGBoost, HMM, calibration
 - `core/portfolio/` — contextual bandit, optimizer
 - `core/risk/` — hard risk rules
 - `core/execution/` — deterministic execution helpers
-- `services/` — external system adapters (Alpaca, R2, Modal, observability)
+- `services/` — external system adapters (Alpaca, Tiingo, Wikipedia, SimFin, FRED, R2, Modal, observability)
 
 Ownership boundary summary:
 - `app/` coordinates runtime surfaces.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,9 +4,18 @@ This document describes deployment surfaces and responsibilities.
 
 ## Surfaces
 
-- app/lab: cloud training and packaging jobs
-- app/cloud: hosted inference service
-- app/pi: edge runtime and execution process (containerized on Pi)
+- `app/lab`: cloud training, validation, historical backfill, and packaging jobs
+- `app/cloud`: hosted inference service surface
+- `app/pi`: edge runtime and execution process, containerized on the Pi
+
+## External dependency roles
+
+- Wikipedia revision history: point-in-time S&P 500 membership source
+- Tiingo: canonical historical OHLCV and raw news archives
+- SimFin: as-reported fundamentals and earnings dates for the context branch
+- FRED: macro and rates context for features and regime detection
+- Alpaca Market Data + Trading API: live daily prices, broker reconciliation, and execution
+- Cloudflare R2: shared object store for cross-surface data handoff and artifacts
 
 ## Pi runtime container model
 
@@ -23,10 +32,12 @@ Expected execution chain:
 
 ## Baseline rollout order
 
-1. Deploy cloud oracle with fixed contracts
-2. Validate edge-to-cloud handshake
-3. Dry-run risk and execution path
-4. Enable paper execution
+1. Build and validate the historical Tiingo/Wikipedia Layer 0 backfill in R2
+2. Validate SimFin and FRED context ingestion against point-in-time rules
+3. Deploy cloud oracle with fixed contracts
+4. Validate edge-to-cloud handshake plus Alpaca live-market-data normalization
+5. Dry-run risk and execution path
+6. Enable paper execution
 
 ## Operational notes
 

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -16,22 +16,28 @@ Execution context:
 This phase builds the historical database in R2 that all downstream layers depend on.
 It runs on a laptop or Modal — not the Pi.
 
-```
+```bash
 python app/lab/data_pipelines/backfill_layer0.py \
     --from-date 2014-01-01 \
     --to-date <today>
 ```
 
 What it produces in R2:
-- `raw/prices/{ticker}.parquet` — full OHLCV history per ticker (adjusted)
-- `raw/news/YYYY-MM-DD.jsonl` — news archive per date
+- `raw/prices/{security_id}.parquet` — full Tiingo-backed OHLCV history per stable security identity
+- `raw/news/YYYY-MM-DD.jsonl` — Tiingo raw news archive per date
 - `raw/universe/YYYY-MM-DD.csv` — eligibility masks for all historical dates
+- `raw/reference/security_master/YYYY-MM-DD.json` — reference snapshots for resolving symbol changes
+
+Historical backfill uses:
+- Wikipedia revision history for point-in-time index membership
+- Tiingo for canonical historical OHLCV and raw news archives
+- SimFin for as-reported fundamentals and earnings dates
+- FRED for macro context series
 
 Without this, Layer 1 feature generation and model training cannot run.
-The backfill is idempotent — safe to re-run; skips dates already stored.
+The backfill is idempotent — safe to re-run; skips artifacts already stored.
 
-After backfill: run model training and walk-forward validation (Milestones 2–4)
-before enabling the live daily loop.
+After backfill: run model training and walk-forward validation before enabling the live daily loop.
 
 ---
 
@@ -40,21 +46,24 @@ before enabling the live daily loop.
 ### After market close
 
 1. **Layer 0 incremental** (`app/pi/fetchers/layer0.py`)
-   - Fetch today's adjusted OHLCV bars from Polygon for all eligible tickers
-   - Append to existing `raw/prices/{ticker}.parquet` in R2
-   - Fetch today's news from Polygon → write `raw/news/YYYY-MM-DD.jsonl` to R2
+   - Fetch today's live bar snapshot from Alpaca Market Data for eligible tickers
+   - Normalize Alpaca bars into the same `OHLCVRecord` shape as the Tiingo historical archive
+   - Append normalized bars to the canonical raw price store in R2
+   - Fetch today's raw Tiingo news → write `raw/news/YYYY-MM-DD.jsonl` to R2
    - Recompute today's eligibility mask (quality + liquidity filters)
    - Write `raw/universe/YYYY-MM-DD.csv` to R2
    - Write `PipelineManifestRecord` (stage=layer0)
 
 2. **Layer 1 feature generation** (Modal)
    - Read today's OHLCV Parquet and news JSON Lines from R2
+   - Join point-in-time SimFin fundamentals and earnings dates
+   - Join FRED macro context series persisted for the run date
    - Compute market, NLP, and context features for today
    - Write aligned feature row to `processed/features/YYYY-MM-DD.parquet` in R2
    - Write `PipelineManifestRecord` (stage=layer1)
 
 3. **Layer 1.5 regime detection** (Modal)
-   - Read recent SPY returns, VIX, yield curve from R2
+   - Read recent SPY returns, VIX, and FRED macro regime inputs from R2
    - Run HMM to classify current regime (bull / bear / sideways)
    - Append regime label and confidence to today's feature row
    - Write updated feature row to R2
@@ -68,7 +77,7 @@ before enabling the live daily loop.
 
 5. **Layer 3 portfolio construction** (Pi)
    - Pi reads scores from R2
-   - Contextual bandit filters ~800 universe stocks → 30–50 candidates
+   - Contextual bandit filters the eligible universe down to 30–50 candidates
    - Mean-variance optimizer produces target weights with turnover penalty
    - Write `PortfolioRecord` list to R2
 
@@ -110,5 +119,11 @@ before enabling the live daily loop.
 Every stage writes a `PipelineManifestRecord` to R2 on completion or failure.
 The next stage reads the manifest to verify the upstream stage completed before proceeding.
 If a manifest is missing or `status=failed`, the stage halts and alerts.
+
+Source-of-truth rules for the daily loop:
+- Tiingo is the canonical historical archive for raw prices and news.
+- SimFin is the canonical source for point-in-time fundamentals and earnings dates.
+- FRED is the canonical source for macro context inputs.
+- Alpaca is the live source for current-day market data, broker reconciliation, and execution.
 
 This ensures no stage silently runs on stale or missing inputs.

--- a/services/README.md
+++ b/services/README.md
@@ -7,13 +7,18 @@ Owner: External integration boundary.
 Responsibilities:
 - Encapsulate third-party APIs and storage adapters
 - Normalize retries, errors, and request/response handling
+- Keep vendor-specific response parsing outside `core/`
 
 Out of scope:
 - Trading decision logic and portfolio/risk rules
 - Cross-layer schema ownership
 
 Subfolders:
-- `alpaca/` — market data and broker integrations
-- `r2/` — object storage interfaces and manifests
+- `alpaca/` — live market data, broker state, and execution integrations
+- `r2/` — Cloudflare R2 object storage interfaces, canonical paths, and manifests
 - `modal/` — cloud job and deployment integrations
 - `observability/` — logging, metrics, and alert glue
+- `wikipedia/` — point-in-time S&P 500 universe construction
+- `tiingo/` — canonical historical OHLCV and raw news adapters
+- `simfin/` — point-in-time fundamentals and earnings-date adapters
+- `fred/` — macro and rates context adapters


### PR DESCRIPTION
## What this PR does
Syncs the canonical docs with the approved data stack so Milestone 1 implementation issues no longer conflict with `main`: Tiingo is documented as the canonical historical OHLCV/news archive, Wikipedia as point-in-time universe source, SimFin/FRED as context sources, Alpaca as live market-data/execution source, and R2 price paths now use stable security identifiers rather than assuming ticker symbols are permanent.

## Closes
Closes #64

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [x] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — pending human review

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each (not applicable; docs-only)
- [x] Tests cover: happy path, empty input, missing columns, NaN input (not applicable; docs-only)
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints (not applicable; docs-only)
- [x] All new public functions have a docstring (not applicable; docs-only)
- [x] Imports ordered: stdlib → third-party → internal (not applicable; docs-only)
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
```text
/home/juyoungoh/Projects/AI-Stock-Trader/.venv/bin/python -m ruff check .
All checks passed!

/home/juyoungoh/Projects/AI-Stock-Trader/.venv/bin/python -m pytest tests/unit/ -v --tb=short
150 passed in 1.49s
```

## Notes for reviewer
This PR intentionally does not change schemas or implementation code. It only repairs the canonical docs so #46 and the rest of Milestone 1 can proceed without docs/issue conflicts.

