### PR TITLE
[codex] Add Tiingo OHLCV historical backfill

### DIFF
--- a/app/lab/data_pipelines/backfill_ohlcv.py
+++ b/app/lab/data_pipelines/backfill_ohlcv.py
@@ -1,0 +1,241 @@
+"""Historical Tiingo OHLCV backfill into the canonical R2 raw price archive."""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from io import BytesIO
+from pathlib import Path
+from typing import Protocol
+
+from loguru import logger
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from core.contracts.schemas import OHLCVRecord  # noqa: E402
+from services.r2.paths import raw_price_path, raw_security_master_path  # noqa: E402
+from services.r2.writer import R2Writer  # noqa: E402
+from services.tiingo.ohlcv_fetcher import TiingoClientConfig, TiingoOHLCVFetcher  # noqa: E402
+from services.tiingo.security_master import TiingoSecurity, TiingoSecurityMaster  # noqa: E402
+from services.wikipedia.sp500_universe import get_all_historical_tickers  # noqa: E402
+
+
+class ObjectWriter(Protocol):
+    """Subset of R2Writer used by the OHLCV backfill."""
+
+    def put_object(self, key: str, data: bytes | str) -> None:
+        """Write an object to storage."""
+
+    def exists(self, key: str) -> bool:
+        """Return True when an object already exists."""
+
+
+class OHLCVFetcher(Protocol):
+    """Subset of TiingoOHLCVFetcher used by the OHLCV backfill."""
+
+    def fetch_security_records(
+        self,
+        security: TiingoSecurity,
+        from_date: str,
+        to_date: str,
+    ) -> list[OHLCVRecord]:
+        """Fetch validated OHLCV records for one resolved Tiingo security."""
+
+
+RecordSerializer = Callable[[list[OHLCVRecord]], bytes]
+
+
+@dataclass(frozen=True)
+class BackfillResult:
+    """Summary of a Tiingo OHLCV backfill run."""
+
+    requested: int
+    written: int
+    skipped: int
+    empty: int
+    reference_key: str
+
+
+def backfill_ohlcv_archive(
+    from_date: date,
+    to_date: date,
+    *,
+    fetcher: OHLCVFetcher,
+    security_master: TiingoSecurityMaster,
+    writer: ObjectWriter,
+    tickers: list[str] | None = None,
+    overwrite: bool = False,
+    record_serializer: RecordSerializer | None = None,
+) -> BackfillResult:
+    """Backfill Tiingo OHLCV history into R2 keyed by stable security identity."""
+    if from_date > to_date:
+        raise ValueError("from_date must be <= to_date")
+
+    ticker_source = (
+        get_all_historical_tickers(from_date.isoformat(), to_date.isoformat())
+        if tickers is None
+        else tickers
+    )
+    requested_tickers = sorted(set(ticker_source))
+    securities = [
+        security
+        for security in security_master.resolve_many(requested_tickers)
+        if _security_overlaps_range(security, from_date, to_date)
+    ]
+    reference_key = raw_security_master_path(to_date)
+    _write_reference_mapping(
+        writer=writer,
+        key=reference_key,
+        from_date=from_date,
+        to_date=to_date,
+        securities=securities,
+        overwrite=overwrite,
+    )
+
+    written = 0
+    skipped = 0
+    empty = 0
+    serializer = record_serializer or _records_to_parquet_bytes
+
+    for security in securities:
+        price_key = raw_price_path(security.security_id)
+        if writer.exists(price_key) and not overwrite:
+            skipped += 1
+            logger.info("Skipping existing Tiingo OHLCV archive {}", price_key)
+            continue
+
+        fetch_from_date, fetch_to_date = _security_fetch_range(security, from_date, to_date)
+        records = fetcher.fetch_security_records(
+            security=security,
+            from_date=fetch_from_date.isoformat(),
+            to_date=fetch_to_date.isoformat(),
+        )
+        if not records:
+            empty += 1
+            logger.warning("No Tiingo OHLCV rows returned for {}", security.ticker)
+            continue
+
+        writer.put_object(price_key, serializer(records))
+        written += 1
+        logger.info("Wrote {} Tiingo OHLCV rows to {}", len(records), price_key)
+
+    return BackfillResult(
+        requested=len(securities),
+        written=written,
+        skipped=skipped,
+        empty=empty,
+        reference_key=reference_key,
+    )
+
+
+def _records_to_parquet_bytes(records: list[OHLCVRecord]) -> bytes:
+    """Serialize OHLCV records to Parquet bytes."""
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to serialize Tiingo OHLCV records to Parquet. "
+            "Install the Pi, Modal, or dev requirements before running the live backfill."
+        ) from exc
+
+    frame = pd.DataFrame([record.model_dump() for record in records])
+    buffer = BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def _security_overlaps_range(security: TiingoSecurity, from_date: date, to_date: date) -> bool:
+    """Return True when a security's Tiingo date range overlaps the requested range."""
+    if security.end_date is not None and date.fromisoformat(security.end_date) < from_date:
+        return False
+    if security.start_date is not None and date.fromisoformat(security.start_date) > to_date:
+        return False
+    return True
+
+
+def _security_fetch_range(security: TiingoSecurity, from_date: date, to_date: date) -> tuple[date, date]:
+    """Clamp the requested backfill window to one security's active Tiingo date range."""
+    fetch_from = from_date
+    fetch_to = to_date
+    if security.start_date is not None:
+        fetch_from = max(fetch_from, date.fromisoformat(security.start_date))
+    if security.end_date is not None:
+        fetch_to = min(fetch_to, date.fromisoformat(security.end_date))
+    return fetch_from, fetch_to
+
+
+def _write_reference_mapping(
+    *,
+    writer: ObjectWriter,
+    key: str,
+    from_date: date,
+    to_date: date,
+    securities: list[TiingoSecurity],
+    overwrite: bool,
+) -> None:
+    """Write the ticker-to-security reference mapping needed for archive resolution."""
+    if writer.exists(key) and not overwrite:
+        logger.info("Skipping existing Tiingo security reference {}", key)
+        return
+
+    payload = {
+        "source": "tiingo",
+        "from_date": from_date.isoformat(),
+        "to_date": to_date.isoformat(),
+        "generated_at": datetime.now(UTC).isoformat(),
+        "securities": [security.to_reference_row() for security in securities],
+    }
+    writer.put_object(key, json.dumps(payload, sort_keys=True, separators=(",", ":")))
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the historical OHLCV backfill."""
+    parser = argparse.ArgumentParser(description="Backfill Tiingo historical OHLCV into R2.")
+    parser.add_argument("--from-date", required=True, metavar="YYYY-MM-DD")
+    parser.add_argument("--to-date", required=True, metavar="YYYY-MM-DD")
+    parser.add_argument(
+        "--tickers",
+        nargs="*",
+        default=None,
+        help="Optional ticker list. Defaults to all historical S&P 500 constituents.",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Rewrite existing R2 objects.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the Tiingo OHLCV backfill from the command line."""
+    args = _parse_args()
+    try:
+        from_date = date.fromisoformat(args.from_date)
+        to_date = date.fromisoformat(args.to_date)
+    except ValueError as exc:
+        logger.error("Invalid date argument: {}", exc)
+        return 1
+
+    if from_date > to_date:
+        logger.error("--from-date must be <= --to-date")
+        return 1
+
+    writer = R2Writer()
+    fetcher = TiingoOHLCVFetcher(TiingoClientConfig.from_env())
+    security_master = TiingoSecurityMaster.fetch_supported_tickers()
+    result = backfill_ohlcv_archive(
+        from_date=from_date,
+        to_date=to_date,
+        fetcher=fetcher,
+        security_master=security_master,
+        writer=writer,
+        tickers=args.tickers,
+        overwrite=args.overwrite,
+    )
+    logger.info("Tiingo OHLCV backfill complete: {}", result)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/lab/data_pipelines/backfill_ohlcv.py
+++ b/app/lab/data_pipelines/backfill_ohlcv.py
@@ -2,9 +2,10 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from datetime import UTC, date, datetime
 from io import BytesIO
@@ -58,6 +59,7 @@ class BackfillResult:
     skipped: int
     empty: int
     reference_key: str
+    missing_tickers: tuple[str, ...] = ()
 
 
 def backfill_ohlcv_archive(
@@ -81,11 +83,16 @@ def backfill_ohlcv_archive(
         else tickers
     )
     requested_tickers = sorted(set(ticker_source))
+    resolved_securities, missing_tickers = _resolve_requested_securities(
+        security_master=security_master,
+        tickers=requested_tickers,
+    )
     securities = [
         security
-        for security in security_master.resolve_many(requested_tickers)
+        for security in resolved_securities
         if _security_overlaps_range(security, from_date, to_date)
     ]
+    security_groups = _group_securities_by_id(securities)
     reference_key = raw_security_master_path(to_date)
     _write_reference_mapping(
         writer=writer,
@@ -93,6 +100,7 @@ def backfill_ohlcv_archive(
         from_date=from_date,
         to_date=to_date,
         securities=securities,
+        missing_tickers=missing_tickers,
         overwrite=overwrite,
     )
 
@@ -101,34 +109,40 @@ def backfill_ohlcv_archive(
     empty = 0
     serializer = record_serializer or _records_to_parquet_bytes
 
-    for security in securities:
-        price_key = raw_price_path(security.security_id)
+    for security_id, security_rows in security_groups.items():
+        price_key = raw_price_path(security_id)
         if writer.exists(price_key) and not overwrite:
             skipped += 1
             logger.info("Skipping existing Tiingo OHLCV archive {}", price_key)
             continue
 
-        fetch_from_date, fetch_to_date = _security_fetch_range(security, from_date, to_date)
-        records = fetcher.fetch_security_records(
-            security=security,
-            from_date=fetch_from_date.isoformat(),
-            to_date=fetch_to_date.isoformat(),
-        )
+        records: list[OHLCVRecord] = []
+        for security in security_rows:
+            fetch_from_date, fetch_to_date = _security_fetch_range(security, from_date, to_date)
+            records.extend(
+                fetcher.fetch_security_records(
+                    security=security,
+                    from_date=fetch_from_date.isoformat(),
+                    to_date=fetch_to_date.isoformat(),
+                )
+            )
+
         if not records:
             empty += 1
-            logger.warning("No Tiingo OHLCV rows returned for {}", security.ticker)
+            logger.warning("No Tiingo OHLCV rows returned for security_id={}", security_id)
             continue
 
-        writer.put_object(price_key, serializer(records))
+        writer.put_object(price_key, serializer(_sort_records(records)))
         written += 1
         logger.info("Wrote {} Tiingo OHLCV rows to {}", len(records), price_key)
 
     return BackfillResult(
-        requested=len(securities),
+        requested=len(security_groups),
         written=written,
         skipped=skipped,
         empty=empty,
         reference_key=reference_key,
+        missing_tickers=missing_tickers,
     )
 
 
@@ -136,6 +150,7 @@ def _records_to_parquet_bytes(records: list[OHLCVRecord]) -> bytes:
     """Serialize OHLCV records to Parquet bytes."""
     try:
         import pandas as pd
+        importlib.import_module("pyarrow")
     except ModuleNotFoundError as exc:
         raise ModuleNotFoundError(
             "pandas and pyarrow are required to serialize Tiingo OHLCV records to Parquet. "
@@ -146,6 +161,51 @@ def _records_to_parquet_bytes(records: list[OHLCVRecord]) -> bytes:
     buffer = BytesIO()
     frame.to_parquet(buffer, index=False)
     return buffer.getvalue()
+
+
+def _resolve_requested_securities(
+    *,
+    security_master: TiingoSecurityMaster,
+    tickers: Iterable[str],
+) -> tuple[list[TiingoSecurity], tuple[str, ...]]:
+    """Resolve requested tickers while logging and returning master misses."""
+    resolved: set[TiingoSecurity] = set()
+    missing_tickers: list[str] = []
+    for ticker in tickers:
+        try:
+            resolved.update(security_master.resolve_all(ticker))
+        except KeyError:
+            missing_tickers.append(ticker)
+            logger.warning("Skipping ticker missing from Tiingo security master: {}", ticker)
+    return sorted(resolved, key=_security_reference_sort_key), tuple(sorted(missing_tickers))
+
+
+def _group_securities_by_id(
+    securities: Iterable[TiingoSecurity],
+) -> dict[str, list[TiingoSecurity]]:
+    """Group security rows by stable archive key while preserving ticker aliases."""
+    groups: dict[str, list[TiingoSecurity]] = {}
+    for security in securities:
+        groups.setdefault(security.security_id, []).append(security)
+    return {
+        security_id: sorted(rows, key=_security_reference_sort_key)
+        for security_id, rows in sorted(groups.items())
+    }
+
+
+def _security_reference_sort_key(security: TiingoSecurity) -> tuple[str, str, str, str]:
+    """Sort security-reference rows without collapsing shared stable identities."""
+    return (
+        security.security_id,
+        security.start_date or "0000-00-00",
+        security.end_date or "9999-99-99",
+        security.ticker,
+    )
+
+
+def _sort_records(records: list[OHLCVRecord]) -> list[OHLCVRecord]:
+    """Sort OHLCV records deterministically before archive serialization."""
+    return sorted(records, key=lambda record: (record.date, record.ticker))
 
 
 def _security_overlaps_range(security: TiingoSecurity, from_date: date, to_date: date) -> bool:
@@ -175,6 +235,7 @@ def _write_reference_mapping(
     from_date: date,
     to_date: date,
     securities: list[TiingoSecurity],
+    missing_tickers: tuple[str, ...],
     overwrite: bool,
 ) -> None:
     """Write the ticker-to-security reference mapping needed for archive resolution."""
@@ -187,6 +248,7 @@ def _write_reference_mapping(
         "from_date": from_date.isoformat(),
         "to_date": to_date.isoformat(),
         "generated_at": datetime.now(UTC).isoformat(),
+        "missing_tickers": list(missing_tickers),
         "securities": [security.to_reference_row() for security in securities],
     }
     writer.put_object(key, json.dumps(payload, sort_keys=True, separators=(",", ":")))

--- a/data/sample/tiingo_ohlcv_response.json
+++ b/data/sample/tiingo_ohlcv_response.json
@@ -1,0 +1,52 @@
+{
+  "security_master": [
+    {
+      "ticker": "AAPL",
+      "permaTicker": "PT_AAPL_001",
+      "startDate": "1980-12-12",
+      "endDate": null,
+      "exchange": "NASDAQ",
+      "assetType": "Stock",
+      "name": "Apple Inc."
+    },
+    {
+      "ticker": "ABC",
+      "permaTicker": "PT_ABC_OLD",
+      "startDate": "2010-01-01",
+      "endDate": "2015-12-31",
+      "exchange": "NYSE",
+      "assetType": "Stock",
+      "name": "Example Acquired Co."
+    }
+  ],
+  "prices": [
+    {
+      "date": "2024-01-02T00:00:00.000Z",
+      "open": 185.64,
+      "high": 188.44,
+      "low": 183.89,
+      "close": 185.64,
+      "volume": 82488700,
+      "adjOpen": 184.734,
+      "adjHigh": 187.52,
+      "adjLow": 182.992,
+      "adjClose": 184.734,
+      "splitFactor": 1.0,
+      "divCash": 0.0
+    },
+    {
+      "date": "2024-01-03T00:00:00.000Z",
+      "open": 184.22,
+      "high": 185.88,
+      "low": 183.43,
+      "close": 184.25,
+      "volume": 58414500,
+      "adjOpen": 183.321,
+      "adjHigh": 184.973,
+      "adjLow": 182.535,
+      "adjClose": 183.351,
+      "splitFactor": 1.0,
+      "divCash": 0.0
+    }
+  ]
+}

--- a/services/tiingo/__init__.py
+++ b/services/tiingo/__init__.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from services.tiingo.ohlcv_fetcher import TiingoClientConfig, TiingoOHLCVFetcher
+from services.tiingo.security_master import TiingoSecurity, TiingoSecurityMaster
+
+__all__ = [
+    "TiingoClientConfig",
+    "TiingoOHLCVFetcher",
+    "TiingoSecurity",
+    "TiingoSecurityMaster",
+]

--- a/services/tiingo/ohlcv_fetcher.py
+++ b/services/tiingo/ohlcv_fetcher.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date as Date
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+from core.contracts.schemas import OHLCVRecord
+from core.data.ohlcv import build_ohlcv_record
+from services.tiingo.security_master import TiingoSecurity
+
+TIINGO_API_TOKEN_ENV = "TIINGO_API_TOKEN"
+DEFAULT_TIINGO_BASE_URL = "https://api.tiingo.com"
+
+
+@dataclass(frozen=True)
+class TiingoClientConfig:
+    """Configuration for Tiingo HTTP clients."""
+
+    api_token: str
+    base_url: str = DEFAULT_TIINGO_BASE_URL
+    timeout_seconds: int = 30
+
+    @classmethod
+    def from_env(cls) -> TiingoClientConfig:
+        """Build Tiingo config from environment variables."""
+        token = os.getenv(TIINGO_API_TOKEN_ENV)
+        if not token:
+            raise ValueError(f"Missing required Tiingo environment variable: {TIINGO_API_TOKEN_ENV}")
+        return cls(api_token=token)
+
+
+class TiingoOHLCVFetcher:
+    """Fetch and normalize Tiingo historical EOD OHLCV rows."""
+
+    def __init__(
+        self,
+        config: TiingoClientConfig,
+        session: requests.Session | None = None,
+    ) -> None:
+        """Store client configuration and HTTP session."""
+        self.config = config
+        self.session = session or requests.Session()
+
+    def fetch_price_rows(self, ticker: str, from_date: str, to_date: str) -> list[dict[str, Any]]:
+        """Fetch raw Tiingo EOD price rows for one ticker and date range."""
+        normalized_ticker = _normalize_ticker(ticker)
+        _validate_date(from_date, "from_date")
+        _validate_date(to_date, "to_date")
+        if from_date > to_date:
+            raise ValueError("from_date must be <= to_date")
+
+        encoded_ticker = quote(normalized_ticker, safe="")
+        url = f"{self.config.base_url.rstrip('/')}/tiingo/daily/{encoded_ticker}/prices"
+        response = self.session.get(
+            url,
+            params={
+                "startDate": from_date,
+                "endDate": to_date,
+                "token": self.config.api_token,
+            },
+            timeout=self.config.timeout_seconds,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise ValueError("Tiingo OHLCV response must be a JSON list")
+        return [dict(item) for item in payload]
+
+    def fetch_records(self, ticker: str, from_date: str, to_date: str) -> list[OHLCVRecord]:
+        """Fetch Tiingo EOD rows and normalize them to OHLCVRecord objects."""
+        normalized_ticker = _normalize_ticker(ticker)
+        rows = self.fetch_price_rows(
+            ticker=normalized_ticker,
+            from_date=from_date,
+            to_date=to_date,
+        )
+        return normalize_tiingo_price_rows(ticker=normalized_ticker, rows=rows)
+
+    def fetch_security_records(
+        self,
+        security: TiingoSecurity,
+        from_date: str,
+        to_date: str,
+    ) -> list[OHLCVRecord]:
+        """Fetch records for a resolved security using its Tiingo ticker symbol."""
+        return self.fetch_records(ticker=security.ticker, from_date=from_date, to_date=to_date)
+
+
+def normalize_tiingo_price_rows(ticker: str, rows: Sequence[Mapping[str, Any]]) -> list[OHLCVRecord]:
+    """Normalize raw Tiingo price rows into schema-valid OHLCV records."""
+    normalized_ticker = _normalize_ticker(ticker)
+    records: list[OHLCVRecord] = []
+    for row in rows:
+        adj_close = _required_numeric(row, "adjClose")
+        volume = _required_numeric(row, "volume")
+        record = build_ohlcv_record(
+            {
+                "date": _normalize_tiingo_date(row.get("date")),
+                "ticker": normalized_ticker,
+                "open": _preferred_numeric(row, "adjOpen", "open"),
+                "high": _preferred_numeric(row, "adjHigh", "high"),
+                "low": _preferred_numeric(row, "adjLow", "low"),
+                "close": adj_close,
+                "volume": volume,
+                "adj_close": adj_close,
+                "dollar_volume": adj_close * volume,
+            }
+        )
+        records.append(record)
+    return records
+
+
+def _normalize_tiingo_date(value: Any) -> str:
+    """Normalize Tiingo timestamp strings to YYYY-MM-DD."""
+    if not isinstance(value, str):
+        raise TypeError("Tiingo price row date must be a string")
+    date_part = value.strip().split("T", maxsplit=1)[0]
+    return _validate_date(date_part, "date")
+
+
+def _preferred_numeric(row: Mapping[str, Any], preferred: str, fallback: str) -> int | float:
+    """Return a preferred numeric value, falling back to another field."""
+    if preferred in row and row[preferred] is not None:
+        return _required_numeric(row, preferred)
+    return _required_numeric(row, fallback)
+
+
+def _required_numeric(row: Mapping[str, Any], field_name: str) -> int | float:
+    """Return a required numeric field without string coercion."""
+    if field_name not in row or row[field_name] is None:
+        raise ValueError(f"Missing required Tiingo price field: {field_name}")
+    value = row[field_name]
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise TypeError(f"Tiingo price field {field_name} must be numeric")
+    return value
+
+
+def _validate_date(value: str, field_name: str) -> str:
+    """Validate and normalize a YYYY-MM-DD date string."""
+    try:
+        return Date.fromisoformat(value).isoformat()
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be YYYY-MM-DD: {value}") from exc
+
+
+def _normalize_ticker(ticker: str) -> str:
+    """Normalize ticker text for Tiingo requests and records."""
+    normalized = ticker.strip().upper().replace(".", "-")
+    if not normalized:
+        raise ValueError("ticker cannot be empty")
+    return normalized

--- a/services/tiingo/security_master.py
+++ b/services/tiingo/security_master.py
@@ -114,16 +114,16 @@ class TiingoSecurityMaster:
 
     def resolve_many(self, tickers: Iterable[str]) -> list[TiingoSecurity]:
         """Resolve many tickers while preserving sorted deterministic output."""
-        resolved: dict[str, TiingoSecurity] = {}
+        resolved: set[TiingoSecurity] = set()
         for ticker in tickers:
             for security in self.resolve_all(ticker):
-                resolved[security.security_id] = security
-        return [resolved[key] for key in sorted(resolved)]
+                resolved.add(security)
+        return sorted(resolved, key=_security_reference_sort_key)
 
     def to_reference_rows(self, securities: Iterable[TiingoSecurity] | None = None) -> list[dict[str, str | None]]:
         """Serialize selected security rows for R2 reference storage."""
         source = self._securities if securities is None else tuple(securities)
-        return [security.to_reference_row() for security in sorted(source, key=lambda row: row.security_id)]
+        return [security.to_reference_row() for security in sorted(source, key=_security_reference_sort_key)]
 
 
 def security_from_mapping(row: Mapping[str, Any]) -> TiingoSecurity:
@@ -223,4 +223,14 @@ def _security_sort_key(security: TiingoSecurity) -> tuple[str, str, str]:
         security.start_date or "0000-00-00",
         security.end_date or "9999-99-99",
         security.security_id,
+    )
+
+
+def _security_reference_sort_key(security: TiingoSecurity) -> tuple[str, str, str, str]:
+    """Sort security-reference rows without collapsing shared stable identities."""
+    return (
+        security.security_id,
+        security.start_date or "0000-00-00",
+        security.end_date or "9999-99-99",
+        security.ticker,
     )

--- a/services/tiingo/security_master.py
+++ b/services/tiingo/security_master.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import csv
+import io
+import re
+import zipfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import date as Date
+from typing import Any
+
+import requests
+
+SUPPORTED_TICKERS_ZIP_URL = "https://apimedia.tiingo.com/docs/tiingo/daily/supported_tickers.zip"
+_ACTIVE_END_DATE_VALUES = {"", "null", "none", "nan", "active", "present"}
+_SECURITY_ID_PART_PATTERN = re.compile(r"[^A-Z0-9_-]+")
+
+
+@dataclass(frozen=True)
+class TiingoSecurity:
+    """One Tiingo security identity row used to key historical price archives."""
+
+    ticker: str
+    perma_ticker: str | None
+    start_date: str | None = None
+    end_date: str | None = None
+    exchange: str | None = None
+    asset_type: str | None = None
+    name: str | None = None
+
+    @property
+    def security_id(self) -> str:
+        """Return the stable archive key for this security."""
+        if self.perma_ticker:
+            return _normalize_security_id_part(self.perma_ticker)
+
+        start = _normalize_security_id_part(self.start_date or "unknown-start")
+        end = _normalize_security_id_part(self.end_date or "active")
+        ticker = _normalize_security_id_part(self.ticker)
+        return f"{ticker}_{start}_{end}"
+
+    def to_reference_row(self) -> dict[str, str | None]:
+        """Serialize this security for the raw reference mapping artifact."""
+        return {
+            "ticker": self.ticker,
+            "perma_ticker": self.perma_ticker,
+            "security_id": self.security_id,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+            "exchange": self.exchange,
+            "asset_type": self.asset_type,
+            "name": self.name,
+        }
+
+
+class TiingoSecurityMaster:
+    """Resolve historical tickers to stable Tiingo security identities."""
+
+    def __init__(self, securities: Sequence[TiingoSecurity]) -> None:
+        """Index security rows by normalized ticker."""
+        if not securities:
+            raise ValueError("TiingoSecurityMaster requires at least one security")
+        self._securities = tuple(securities)
+        self._by_ticker: dict[str, list[TiingoSecurity]] = {}
+        for security in self._securities:
+            self._by_ticker.setdefault(security.ticker, []).append(security)
+
+        for ticker, rows in self._by_ticker.items():
+            self._by_ticker[ticker] = sorted(rows, key=_security_sort_key)
+
+    @classmethod
+    def from_rows(cls, rows: Iterable[Mapping[str, Any]]) -> TiingoSecurityMaster:
+        """Build a security master from vendor-neutral mapping rows."""
+        securities = [security_from_mapping(row) for row in rows]
+        return cls(securities)
+
+    @classmethod
+    def from_supported_tickers_zip(cls, payload: bytes) -> TiingoSecurityMaster:
+        """Build a security master from Tiingo's supported-tickers ZIP payload."""
+        return cls.from_rows(_read_supported_tickers_zip(payload))
+
+    @classmethod
+    def fetch_supported_tickers(
+        cls,
+        session: requests.Session | None = None,
+        url: str = SUPPORTED_TICKERS_ZIP_URL,
+        timeout_seconds: int = 30,
+    ) -> TiingoSecurityMaster:
+        """Fetch and parse Tiingo's supported-tickers ZIP into a security master."""
+        active_session = session or requests.Session()
+        response = active_session.get(url, timeout=timeout_seconds)
+        response.raise_for_status()
+        return cls.from_supported_tickers_zip(response.content)
+
+    def resolve(self, ticker: str, as_of_date: str | None = None) -> TiingoSecurity:
+        """Resolve one ticker to the best matching Tiingo security row."""
+        candidates = self.resolve_all(ticker)
+
+        if as_of_date is not None:
+            _validate_date(as_of_date, "as_of_date")
+            dated = [security for security in candidates if _security_active_on(security, as_of_date)]
+            if dated:
+                return dated[-1]
+
+        return candidates[-1]
+
+    def resolve_all(self, ticker: str) -> list[TiingoSecurity]:
+        """Resolve a ticker to every matching historical Tiingo security row."""
+        normalized = _normalize_ticker(ticker)
+        candidates = self._by_ticker.get(normalized)
+        if not candidates:
+            raise KeyError(f"Ticker {normalized} is not present in Tiingo security master")
+        return list(candidates)
+
+    def resolve_many(self, tickers: Iterable[str]) -> list[TiingoSecurity]:
+        """Resolve many tickers while preserving sorted deterministic output."""
+        resolved: dict[str, TiingoSecurity] = {}
+        for ticker in tickers:
+            for security in self.resolve_all(ticker):
+                resolved[security.security_id] = security
+        return [resolved[key] for key in sorted(resolved)]
+
+    def to_reference_rows(self, securities: Iterable[TiingoSecurity] | None = None) -> list[dict[str, str | None]]:
+        """Serialize selected security rows for R2 reference storage."""
+        source = self._securities if securities is None else tuple(securities)
+        return [security.to_reference_row() for security in sorted(source, key=lambda row: row.security_id)]
+
+
+def security_from_mapping(row: Mapping[str, Any]) -> TiingoSecurity:
+    """Parse one Tiingo security mapping row into a normalized security object."""
+    ticker = _coerce_required_text(_first_present(row, ("ticker", "symbol")), "ticker")
+    return TiingoSecurity(
+        ticker=_normalize_ticker(ticker),
+        perma_ticker=_coerce_optional_text(
+            _first_present(row, ("permaTicker", "perma_ticker", "permaticker", "permaTickerId"))
+        ),
+        start_date=_coerce_optional_date(_first_present(row, ("startDate", "start_date")), "startDate"),
+        end_date=_coerce_optional_date(_first_present(row, ("endDate", "end_date")), "endDate"),
+        exchange=_coerce_optional_text(_first_present(row, ("exchange", "exchangeCode"))),
+        asset_type=_coerce_optional_text(_first_present(row, ("assetType", "asset_type"))),
+        name=_coerce_optional_text(_first_present(row, ("name", "companyName", "description"))),
+    )
+
+
+def _read_supported_tickers_zip(payload: bytes) -> list[dict[str, str]]:
+    """Read the first CSV file from Tiingo's supported-tickers ZIP payload."""
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        csv_names = sorted(name for name in archive.namelist() if name.lower().endswith(".csv"))
+        if not csv_names:
+            raise ValueError("Tiingo supported-tickers ZIP did not contain a CSV file")
+        with archive.open(csv_names[0]) as csv_file:
+            text = io.TextIOWrapper(csv_file, encoding="utf-8", newline="")
+            return list(csv.DictReader(text))
+
+
+def _first_present(row: Mapping[str, Any], fields: tuple[str, ...]) -> Any | None:
+    """Return the first present non-empty value from a row."""
+    for field in fields:
+        value = row.get(field)
+        if value is not None and str(value).strip():
+            return value
+    return None
+
+
+def _coerce_required_text(value: Any | None, field_name: str) -> str:
+    """Coerce a required text field."""
+    text = _coerce_optional_text(value)
+    if text is None:
+        raise ValueError(f"Missing required Tiingo security field: {field_name}")
+    return text
+
+
+def _coerce_optional_text(value: Any | None) -> str | None:
+    """Coerce optional text while treating blank values as missing."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _coerce_optional_date(value: Any | None, field_name: str) -> str | None:
+    """Coerce optional YYYY-MM-DD dates while treating active end dates as missing."""
+    text = _coerce_optional_text(value)
+    if text is None or text.lower() in _ACTIVE_END_DATE_VALUES:
+        return None
+    return _validate_date(text, field_name)
+
+
+def _validate_date(value: str, field_name: str) -> str:
+    """Validate and normalize a YYYY-MM-DD date string."""
+    try:
+        return Date.fromisoformat(value).isoformat()
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be YYYY-MM-DD: {value}") from exc
+
+
+def _normalize_ticker(ticker: str) -> str:
+    """Normalize ticker text for lookups."""
+    normalized = ticker.strip().upper().replace(".", "-")
+    if not normalized:
+        raise ValueError("ticker cannot be empty")
+    return normalized
+
+
+def _normalize_security_id_part(value: str) -> str:
+    """Normalize text for safe R2 key parts."""
+    normalized = _SECURITY_ID_PART_PATTERN.sub("-", value.strip().upper()).strip("-")
+    if not normalized:
+        raise ValueError(f"security identifier part cannot be empty: {value!r}")
+    return normalized
+
+
+def _security_active_on(security: TiingoSecurity, as_of_date: str) -> bool:
+    """Return True when a security row covers the given date."""
+    starts_before = security.start_date is None or security.start_date <= as_of_date
+    ends_after = security.end_date is None or as_of_date <= security.end_date
+    return starts_before and ends_after
+
+
+def _security_sort_key(security: TiingoSecurity) -> tuple[str, str, str]:
+    """Sort older inactive rows before current rows for deterministic resolution."""
+    return (
+        security.start_date or "0000-00-00",
+        security.end_date or "9999-99-99",
+        security.security_id,
+    )

--- a/tests/unit/test_tiingo_ohlcv_fetcher.py
+++ b/tests/unit/test_tiingo_ohlcv_fetcher.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+from app.lab.data_pipelines import backfill_ohlcv as backfill_module
 from app.lab.data_pipelines.backfill_ohlcv import backfill_ohlcv_archive
 from core.contracts.schemas import OHLCVRecord
 from services.r2.paths import raw_price_path, raw_security_master_path
@@ -277,6 +278,35 @@ def test_security_master_resolve_many_preserves_reused_ticker_rows() -> None:
     ]
 
 
+def test_security_master_resolve_many_keeps_rows_with_shared_perma_ticker() -> None:
+    """Ticker aliases sharing one permaTicker remain separate reference rows."""
+    master = TiingoSecurityMaster.from_rows(
+        [
+            {
+                "ticker": "OLD",
+                "permaTicker": "PT_SHARED",
+                "startDate": "2010-01-01",
+                "endDate": "2012-12-31",
+            },
+            {
+                "ticker": "NEW",
+                "permaTicker": "PT_SHARED",
+                "startDate": "2013-01-01",
+                "endDate": None,
+            },
+        ]
+    )
+
+    assert [security.ticker for security in master.resolve_many(["OLD", "NEW"])] == [
+        "OLD",
+        "NEW",
+    ]
+    assert [security.security_id for security in master.resolve_many(["OLD", "NEW"])] == [
+        "PT_SHARED",
+        "PT_SHARED",
+    ]
+
+
 def test_security_master_parses_supported_tickers_zip() -> None:
     """Supported-ticker ZIP parsing preserves delisted/end-date metadata."""
     payload = _supported_tickers_zip(
@@ -358,7 +388,85 @@ def test_backfill_writes_price_archive_and_reference_mapping() -> None:
 
     reference = json.loads(writer.objects[reference_key])
     assert reference["source"] == "tiingo"
+    assert reference["missing_tickers"] == []
     assert reference["securities"][0]["security_id"] == "PT_AAPL_001"
+
+
+def test_backfill_combines_alias_rows_that_share_one_perma_ticker() -> None:
+    """Backfill fetches every alias row before writing one stable-identity archive."""
+    price_rows = _fixture_payload()["prices"]
+    master = TiingoSecurityMaster.from_rows(
+        [
+            {
+                "ticker": "OLD",
+                "permaTicker": "PT_SHARED",
+                "startDate": "2024-01-02",
+                "endDate": "2024-01-02",
+            },
+            {
+                "ticker": "NEW",
+                "permaTicker": "PT_SHARED",
+                "startDate": "2024-01-03",
+                "endDate": None,
+            },
+        ]
+    )
+    writer = _FakeWriter()
+    fetcher = _FakeFetcher(
+        {
+            "OLD": normalize_tiingo_price_rows("OLD", [price_rows[0]]),
+            "NEW": normalize_tiingo_price_rows("NEW", [price_rows[1]]),
+        }
+    )
+
+    result = backfill_ohlcv_archive(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 3),
+        fetcher=fetcher,
+        security_master=master,
+        writer=writer,
+        tickers=["OLD", "NEW"],
+        record_serializer=_serialize_records_for_test,
+    )
+
+    price_key = raw_price_path("PT_SHARED")
+    reference_key = raw_security_master_path("2024-01-03")
+    archive_rows = json.loads(writer.objects[price_key])  # type: ignore[arg-type]
+    reference_rows = json.loads(writer.objects[reference_key])["securities"]
+
+    assert result.requested == 1
+    assert result.written == 1
+    assert fetcher.calls == [
+        ("OLD", "2024-01-02", "2024-01-02"),
+        ("NEW", "2024-01-03", "2024-01-03"),
+    ]
+    assert [row["ticker"] for row in archive_rows] == ["OLD", "NEW"]
+    assert [row["ticker"] for row in reference_rows] == ["OLD", "NEW"]
+    assert [row["security_id"] for row in reference_rows] == ["PT_SHARED", "PT_SHARED"]
+
+
+def test_backfill_skips_missing_security_master_tickers() -> None:
+    """Universe/security-master mismatches are reported without aborting the backfill."""
+    records = normalize_tiingo_price_rows("AAPL", _fixture_payload()["prices"])
+    master = TiingoSecurityMaster.from_rows(_fixture_payload()["security_master"])
+    writer = _FakeWriter()
+    fetcher = _FakeFetcher({"AAPL": records})
+
+    result = backfill_ohlcv_archive(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 3),
+        fetcher=fetcher,
+        security_master=master,
+        writer=writer,
+        tickers=["AAPL", "MISSING"],
+        record_serializer=_serialize_records_for_test,
+    )
+
+    reference = json.loads(writer.objects[result.reference_key])
+    assert result.requested == 1
+    assert result.written == 1
+    assert result.missing_tickers == ("MISSING",)
+    assert reference["missing_tickers"] == ["MISSING"]
 
 
 def test_backfill_allows_empty_ticker_list_without_fetching_universe() -> None:
@@ -458,6 +566,22 @@ def test_backfill_is_idempotent_for_existing_price_archive() -> None:
     assert result.skipped == 1
     assert fetcher.calls == []
     assert price_key not in writer.objects
+
+
+def test_parquet_serializer_reports_missing_pyarrow(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Parquet serialization fails with a clear dependency message when pyarrow is absent."""
+    records = normalize_tiingo_price_rows("AAPL", _fixture_payload()["prices"])
+    real_import_module = backfill_module.importlib.import_module
+
+    def fake_import_module(name: str, package: str | None = None) -> object:
+        if name == "pyarrow":
+            raise ModuleNotFoundError("No module named 'pyarrow'")
+        return real_import_module(name, package)
+
+    monkeypatch.setattr(backfill_module.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ModuleNotFoundError, match="pandas and pyarrow are required"):
+        backfill_module._records_to_parquet_bytes(records)
 
 
 def _serialize_records_for_test(records: list[OHLCVRecord]) -> bytes:

--- a/tests/unit/test_tiingo_ohlcv_fetcher.py
+++ b/tests/unit/test_tiingo_ohlcv_fetcher.py
@@ -1,0 +1,465 @@
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from app.lab.data_pipelines.backfill_ohlcv import backfill_ohlcv_archive
+from core.contracts.schemas import OHLCVRecord
+from services.r2.paths import raw_price_path, raw_security_master_path
+from services.tiingo.ohlcv_fetcher import (
+    TiingoClientConfig,
+    TiingoOHLCVFetcher,
+    normalize_tiingo_price_rows,
+)
+from services.tiingo.security_master import (
+    TiingoSecurity,
+    TiingoSecurityMaster,
+    security_from_mapping,
+)
+
+FIXTURE_PATH = Path("data/sample/tiingo_ohlcv_response.json")
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any, content: bytes = b"") -> None:
+        self._payload = payload
+        self.content = content
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        return None
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse) -> None:
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append({"url": url, **kwargs})
+        return self.response
+
+
+class _FakeWriter:
+    def __init__(self, existing: set[str] | None = None) -> None:
+        self.existing = set(existing or set())
+        self.objects: dict[str, bytes | str] = {}
+
+    def put_object(self, key: str, data: bytes | str) -> None:
+        self.objects[key] = data
+        self.existing.add(key)
+
+    def exists(self, key: str) -> bool:
+        return key in self.existing
+
+
+class _FakeFetcher:
+    def __init__(self, records_by_ticker: dict[str, list[OHLCVRecord]]) -> None:
+        self.records_by_ticker = records_by_ticker
+        self.calls: list[tuple[str, str, str]] = []
+
+    def fetch_security_records(
+        self,
+        security: TiingoSecurity,
+        from_date: str,
+        to_date: str,
+    ) -> list[OHLCVRecord]:
+        self.calls.append((security.ticker, from_date, to_date))
+        return self.records_by_ticker.get(security.ticker, [])
+
+
+def _fixture_payload() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _supported_tickers_zip(csv_text: str) -> bytes:
+    """Build an in-memory supported-tickers ZIP fixture."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, mode="w") as archive:
+        archive.writestr("supported_tickers.csv", csv_text)
+    return buffer.getvalue()
+
+
+def test_client_config_from_env_reads_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tiingo config reads its API token from the documented environment variable."""
+    monkeypatch.setenv("TIINGO_API_TOKEN", "env-token")
+
+    config = TiingoClientConfig.from_env()
+
+    assert config.api_token == "env-token"
+    assert config.base_url == "https://api.tiingo.com"
+    assert config.timeout_seconds == 30
+
+
+def test_client_config_from_env_rejects_missing_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tiingo config fails closed when credentials are absent."""
+    monkeypatch.delenv("TIINGO_API_TOKEN", raising=False)
+
+    with pytest.raises(ValueError, match="TIINGO_API_TOKEN"):
+        TiingoClientConfig.from_env()
+
+
+def test_fetch_price_rows_calls_tiingo_historical_endpoint() -> None:
+    """Fetcher uses Tiingo's historical EOD endpoint and tokenized date params."""
+    session = _FakeSession(_FakeResponse(_fixture_payload()["prices"]))
+    fetcher = TiingoOHLCVFetcher(
+        TiingoClientConfig(api_token="test-token", base_url="https://example.tiingo.test"),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    rows = fetcher.fetch_price_rows("AAPL", "2024-01-02", "2024-01-03")
+
+    assert len(rows) == 2
+    assert session.calls == [
+        {
+            "url": "https://example.tiingo.test/tiingo/daily/AAPL/prices",
+            "params": {
+                "startDate": "2024-01-02",
+                "endDate": "2024-01-03",
+                "token": "test-token",
+            },
+            "timeout": 30,
+        }
+    ]
+
+
+def test_fetch_records_normalizes_symbol_for_endpoint_and_contract() -> None:
+    """Fetcher normalizes ticker aliases before calling Tiingo and building records."""
+    session = _FakeSession(_FakeResponse(_fixture_payload()["prices"]))
+    fetcher = TiingoOHLCVFetcher(
+        TiingoClientConfig(api_token="test-token", base_url="https://example.tiingo.test"),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    records = fetcher.fetch_records("brk.b", "2024-01-02", "2024-01-03")
+
+    assert session.calls[0]["url"] == "https://example.tiingo.test/tiingo/daily/BRK-B/prices"
+    assert {record.ticker for record in records} == {"BRK-B"}
+
+
+def test_fetch_security_records_uses_resolved_tiingo_ticker() -> None:
+    """Security-level fetching preserves the resolved Tiingo identity boundary."""
+    session = _FakeSession(_FakeResponse(_fixture_payload()["prices"]))
+    fetcher = TiingoOHLCVFetcher(
+        TiingoClientConfig(api_token="test-token", base_url="https://example.tiingo.test"),
+        session=session,  # type: ignore[arg-type]
+    )
+    security = TiingoSecurity(ticker="ABC", perma_ticker="PT_ABC_OLD")
+
+    records = fetcher.fetch_security_records(security, "2024-01-02", "2024-01-03")
+
+    assert session.calls[0]["url"] == "https://example.tiingo.test/tiingo/daily/ABC/prices"
+    assert [record.ticker for record in records] == ["ABC", "ABC"]
+
+
+def test_fetch_price_rows_rejects_non_list_payload() -> None:
+    """Malformed Tiingo payloads fail fast instead of silently normalizing."""
+    session = _FakeSession(_FakeResponse({"unexpected": "shape"}))
+    fetcher = TiingoOHLCVFetcher(TiingoClientConfig(api_token="test-token"), session=session)  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="JSON list"):
+        fetcher.fetch_price_rows("AAPL", "2024-01-02", "2024-01-03")
+
+
+def test_normalize_tiingo_price_rows_uses_adjusted_prices_and_contract_validation() -> None:
+    """Tiingo rows normalize into schema-valid adjusted OHLCV records."""
+    records = normalize_tiingo_price_rows("aapl", _fixture_payload()["prices"])
+
+    assert [record.date for record in records] == ["2024-01-02", "2024-01-03"]
+    assert records[0].ticker == "AAPL"
+    assert records[0].open == 184.734
+    assert records[0].high == 187.52
+    assert records[0].low == 182.992
+    assert records[0].close == 184.734
+    assert records[0].adj_close == 184.734
+    assert records[0].volume == 82488700
+    assert records[0].dollar_volume == pytest.approx(184.734 * 82488700)
+
+
+def test_normalize_tiingo_price_rows_returns_empty_for_empty_day() -> None:
+    """An empty Tiingo response remains an empty record list."""
+    assert normalize_tiingo_price_rows("AAPL", []) == []
+
+
+def test_normalize_tiingo_price_rows_rejects_string_numeric_values() -> None:
+    """Numeric strings must be parsed explicitly before contract construction."""
+    row = dict(_fixture_payload()["prices"][0])
+    row["adjClose"] = "184.734"
+
+    with pytest.raises(TypeError, match="adjClose"):
+        normalize_tiingo_price_rows("AAPL", [row])
+
+
+def test_normalize_tiingo_price_rows_rejects_missing_required_price_fields() -> None:
+    """Missing adjusted close fields fail before downstream feature code can use them."""
+    row = dict(_fixture_payload()["prices"][0])
+    del row["adjClose"]
+
+    with pytest.raises(ValueError, match="adjClose"):
+        normalize_tiingo_price_rows("AAPL", [row])
+
+
+def test_normalize_tiingo_price_rows_rejects_nan_values() -> None:
+    """NaN vendor values fail contract validation instead of entering storage."""
+    row = dict(_fixture_payload()["prices"][0])
+    row["adjClose"] = float("nan")
+
+    with pytest.raises(ValueError, match="must be finite"):
+        normalize_tiingo_price_rows("AAPL", [row])
+
+
+def test_security_master_resolves_perma_ticker_security_id() -> None:
+    """Security master uses permaTicker as the preferred stable archive key."""
+    master = TiingoSecurityMaster.from_rows(_fixture_payload()["security_master"])
+
+    security = master.resolve("aapl")
+
+    assert security.ticker == "AAPL"
+    assert security.perma_ticker == "PT_AAPL_001"
+    assert security.security_id == "PT_AAPL_001"
+
+
+def test_security_master_constructs_stable_id_when_perma_ticker_is_absent() -> None:
+    """Ticker plus Tiingo date range prevents assuming ticker symbols are permanent."""
+    master = TiingoSecurityMaster.from_rows(
+        [
+            {
+                "ticker": "XYZ",
+                "startDate": "2010-01-01",
+                "endDate": "2012-12-31",
+            }
+        ]
+    )
+
+    assert master.resolve("XYZ").security_id == "XYZ_2010-01-01_2012-12-31"
+
+
+def test_security_from_mapping_accepts_alternate_tiingo_fields() -> None:
+    """Security parsing handles alternate Tiingo field names seen across exports."""
+    security = security_from_mapping(
+        {
+            "symbol": "brk.b",
+            "permaTickerId": 12345,
+            "start_date": "1996-05-09",
+            "end_date": "present",
+            "exchangeCode": "NYSE",
+            "asset_type": "Stock",
+            "companyName": "Berkshire Hathaway Inc.",
+        }
+    )
+
+    assert security.ticker == "BRK-B"
+    assert security.perma_ticker == "12345"
+    assert security.security_id == "12345"
+    assert security.end_date is None
+
+
+def test_security_master_resolve_many_preserves_reused_ticker_rows() -> None:
+    """A reused ticker resolves to every historical security row, not just the latest one."""
+    master = TiingoSecurityMaster.from_rows(
+        [
+            {"ticker": "XYZ", "permaTicker": "PT_XYZ_OLD", "startDate": "2010-01-01", "endDate": "2012-12-31"},
+            {"ticker": "XYZ", "permaTicker": "PT_XYZ_NEW", "startDate": "2020-01-01", "endDate": None},
+        ]
+    )
+
+    assert [security.security_id for security in master.resolve_many(["XYZ"])] == [
+        "PT_XYZ_NEW",
+        "PT_XYZ_OLD",
+    ]
+
+
+def test_security_master_parses_supported_tickers_zip() -> None:
+    """Supported-ticker ZIP parsing preserves delisted/end-date metadata."""
+    payload = _supported_tickers_zip(
+        "ticker,permaTicker,startDate,endDate,exchange,assetType,name\n"
+        "OLD,PT_OLD,2001-01-01,2010-12-31,NYSE,Stock,Old Co\n"
+    )
+
+    master = TiingoSecurityMaster.from_supported_tickers_zip(payload)
+    security = master.resolve("OLD", as_of_date="2005-01-01")
+
+    assert security.security_id == "PT_OLD"
+    assert security.end_date == "2010-12-31"
+
+
+def test_security_master_fetch_supported_tickers_uses_supplied_session() -> None:
+    """Supported-ticker downloads are isolated behind an injectable HTTP session."""
+    payload = _supported_tickers_zip(
+        "ticker,permaTicker,startDate,endDate,exchange,assetType,name\n"
+        "OLD,PT_OLD,2001-01-01,2010-12-31,NYSE,Stock,Old Co\n"
+    )
+    session = _FakeSession(_FakeResponse(payload={}, content=payload))
+
+    master = TiingoSecurityMaster.fetch_supported_tickers(
+        session=session,  # type: ignore[arg-type]
+        url="https://example.tiingo.test/supported_tickers.zip",
+        timeout_seconds=7,
+    )
+
+    assert session.calls == [
+        {
+            "url": "https://example.tiingo.test/supported_tickers.zip",
+            "timeout": 7,
+        }
+    ]
+    assert master.resolve("OLD").security_id == "PT_OLD"
+
+
+def test_security_master_reference_rows_are_stable_and_serializable() -> None:
+    """Reference-row output captures the symbol mapping needed to resolve archives."""
+    master = TiingoSecurityMaster.from_rows(_fixture_payload()["security_master"])
+
+    rows = master.to_reference_rows([master.resolve("ABC"), master.resolve("AAPL")])
+
+    assert [row["security_id"] for row in rows] == ["PT_AAPL_001", "PT_ABC_OLD"]
+    assert rows[0]["ticker"] == "AAPL"
+    assert rows[1]["end_date"] == "2015-12-31"
+
+
+def test_backfill_writes_price_archive_and_reference_mapping() -> None:
+    """Backfill writes canonical R2 objects keyed by stable security identity."""
+    records = normalize_tiingo_price_rows("AAPL", _fixture_payload()["prices"])
+    master = TiingoSecurityMaster.from_rows(_fixture_payload()["security_master"])
+    writer = _FakeWriter()
+    fetcher = _FakeFetcher({"AAPL": records})
+
+    result = backfill_ohlcv_archive(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 3),
+        fetcher=fetcher,
+        security_master=master,
+        writer=writer,
+        tickers=["AAPL"],
+        record_serializer=_serialize_records_for_test,
+    )
+
+    price_key = raw_price_path("PT_AAPL_001")
+    reference_key = raw_security_master_path("2024-01-03")
+    assert result.requested == 1
+    assert result.written == 1
+    assert result.skipped == 0
+    assert result.empty == 0
+    assert result.reference_key == reference_key
+    assert price_key in writer.objects
+    assert reference_key in writer.objects
+
+    archive_rows = json.loads(writer.objects[price_key])  # type: ignore[arg-type]
+    assert [row["ticker"] for row in archive_rows] == ["AAPL", "AAPL"]
+    assert [row["date"] for row in archive_rows] == ["2024-01-02", "2024-01-03"]
+
+    reference = json.loads(writer.objects[reference_key])
+    assert reference["source"] == "tiingo"
+    assert reference["securities"][0]["security_id"] == "PT_AAPL_001"
+
+
+def test_backfill_allows_empty_ticker_list_without_fetching_universe() -> None:
+    """An explicit empty ticker scope writes an empty reference and makes no API calls."""
+    master = TiingoSecurityMaster.from_rows(_fixture_payload()["security_master"])
+    writer = _FakeWriter()
+    fetcher = _FakeFetcher({})
+
+    result = backfill_ohlcv_archive(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 3),
+        fetcher=fetcher,
+        security_master=master,
+        writer=writer,
+        tickers=[],
+        record_serializer=_serialize_records_for_test,
+    )
+
+    reference_key = raw_security_master_path("2024-01-03")
+    assert result.requested == 0
+    assert result.written == 0
+    assert result.skipped == 0
+    assert result.empty == 0
+    assert fetcher.calls == []
+    assert json.loads(writer.objects[reference_key])["securities"] == []
+
+
+def test_backfill_counts_empty_price_responses_without_writing_archive() -> None:
+    """Empty Tiingo responses are counted and do not create empty price archives."""
+    master = TiingoSecurityMaster.from_rows(_fixture_payload()["security_master"])
+    writer = _FakeWriter()
+    fetcher = _FakeFetcher({"AAPL": []})
+
+    result = backfill_ohlcv_archive(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 3),
+        fetcher=fetcher,
+        security_master=master,
+        writer=writer,
+        tickers=["AAPL"],
+        record_serializer=_serialize_records_for_test,
+    )
+
+    assert result.requested == 1
+    assert result.written == 0
+    assert result.empty == 1
+    assert raw_price_path("PT_AAPL_001") not in writer.objects
+
+
+def test_backfill_clamps_fetch_window_to_security_active_dates() -> None:
+    """Backfill does not request dates outside a resolved security's Tiingo lifetime."""
+    master = TiingoSecurityMaster.from_rows(
+        [
+            {
+                "ticker": "ABC",
+                "permaTicker": "PT_ABC_OLD",
+                "startDate": "2010-01-01",
+                "endDate": "2015-12-31",
+            }
+        ]
+    )
+    writer = _FakeWriter()
+    fetcher = _FakeFetcher({"ABC": normalize_tiingo_price_rows("ABC", _fixture_payload()["prices"])})
+
+    backfill_ohlcv_archive(
+        from_date=date(2014, 1, 1),
+        to_date=date(2020, 1, 1),
+        fetcher=fetcher,
+        security_master=master,
+        writer=writer,
+        tickers=["ABC"],
+        record_serializer=_serialize_records_for_test,
+    )
+
+    assert fetcher.calls == [("ABC", "2014-01-01", "2015-12-31")]
+
+
+def test_backfill_is_idempotent_for_existing_price_archive() -> None:
+    """Existing R2 price archives are skipped unless overwrite is requested."""
+    master = TiingoSecurityMaster.from_rows(_fixture_payload()["security_master"])
+    price_key = raw_price_path("PT_AAPL_001")
+    writer = _FakeWriter(existing={price_key})
+    fetcher = _FakeFetcher({"AAPL": normalize_tiingo_price_rows("AAPL", _fixture_payload()["prices"])})
+
+    result = backfill_ohlcv_archive(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 3),
+        fetcher=fetcher,
+        security_master=master,
+        writer=writer,
+        tickers=["AAPL"],
+        record_serializer=_serialize_records_for_test,
+    )
+
+    assert result.requested == 1
+    assert result.written == 0
+    assert result.skipped == 1
+    assert fetcher.calls == []
+    assert price_key not in writer.objects
+
+
+def _serialize_records_for_test(records: list[OHLCVRecord]) -> bytes:
+    """Serialize records as JSON bytes so unit tests do not require Parquet dependencies."""
+    return json.dumps([record.model_dump() for record in records]).encode("utf-8")


### PR DESCRIPTION
## What this PR does
Adds the Layer 0 historical Tiingo OHLCV backfill path. The new Tiingo adapter resolves historical symbols through a security master, keys raw price archives by stable Tiingo security identity, normalizes adjusted EOD bars into `OHLCVRecord`, and writes both price archives and the reference mapping through canonical R2 path builders.

## Closes
Closes #46

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — ready for human review

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None. The default Parquet serializer uses `pandas`/`pyarrow`, which are already present in the existing runtime/dev requirements; unit tests inject a JSON serializer to keep tests fixture-only and avoid live API calls.

## Screenshots or sample output
Local validation:
- `.venv/bin/ruff check .` → passed
- `.venv/bin/python -m pytest tests/unit/ -v --tb=short` → 177 passed

## Notes for reviewer
- Historical fetches use Tiingo EOD endpoint `/tiingo/daily/{ticker}/prices`, not Polygon.
- Price objects are written to `raw/prices/{security_id}.parquet`, preferring `permaTicker` and falling back to ticker plus Tiingo date range when needed.
- Reference mapping is written to `raw/reference/security_master/{to_date}.json` so downstream jobs can resolve symbol changes and reused tickers.

