### PR TITLE
[codex] Add FRED raw macro archive

### DIFF
--- a/app/lab/data_pipelines/backfill_fred.py
+++ b/app/lab/data_pipelines/backfill_fred.py
@@ -47,6 +47,8 @@ class MacroFetcher(Protocol):
         series_ids: Sequence[str],
         start_date: str,
         end_date: str,
+        realtime_start: str | None,
+        realtime_end: str | None,
         limit: int,
     ) -> list[dict[str, object]]:
         """Fetch all raw FRED rows for configured series/date range."""
@@ -102,6 +104,8 @@ def backfill_fred_archive(
         series_ids=normalized_series_ids,
         start_date=from_date.isoformat(),
         end_date=to_date.isoformat(),
+        realtime_start=from_date.isoformat(),
+        realtime_end=to_date.isoformat(),
         limit=limit,
     )
     payload_serializer = serializer or _macro_to_parquet_bytes

--- a/app/lab/data_pipelines/backfill_fred.py
+++ b/app/lab/data_pipelines/backfill_fred.py
@@ -1,0 +1,243 @@
+"""Historical FRED macro/rates backfill into the canonical R2 raw archive."""
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from datetime import date
+from io import BytesIO
+from pathlib import Path
+from typing import Protocol
+
+from loguru import logger
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from services.fred.macro_fetcher import (  # noqa: E402
+    DEFAULT_FRED_CONFIG_PATH,
+    DEFAULT_FRED_PAGE_LIMIT,
+    FredClientConfig,
+    FredMacroFetcher,
+    load_fred_archive_config,
+)
+from services.r2.paths import raw_macro_path  # noqa: E402
+from services.r2.writer import R2Writer  # noqa: E402
+
+
+class ObjectWriter(Protocol):
+    """Subset of R2Writer used by the FRED backfill."""
+
+    def put_object(self, key: str, data: bytes | str) -> None:
+        """Write an object to storage."""
+
+    def exists(self, key: str) -> bool:
+        """Return True when an object already exists."""
+
+
+class MacroFetcher(Protocol):
+    """Subset of FredMacroFetcher used by the backfill."""
+
+    def fetch_all_macro_observations(
+        self,
+        *,
+        series_ids: Sequence[str],
+        start_date: str,
+        end_date: str,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        """Fetch all raw FRED rows for configured series/date range."""
+
+
+MacroSerializer = Callable[[list[dict[str, object]]], bytes]
+
+
+@dataclass(frozen=True)
+class BackfillResult:
+    """Summary of a FRED macro/rates backfill run."""
+
+    requested_series: int
+    written: int
+    skipped: int
+    empty: int
+    total_rows: int
+    output_key: str
+
+
+def backfill_fred_archive(
+    from_date: date,
+    to_date: date,
+    *,
+    fetcher: MacroFetcher,
+    writer: ObjectWriter,
+    series_ids: Sequence[str],
+    overwrite: bool = False,
+    limit: int = DEFAULT_FRED_PAGE_LIMIT,
+    serializer: MacroSerializer | None = None,
+) -> BackfillResult:
+    """Backfill FRED macro/rate observations into R2."""
+    if from_date > to_date:
+        raise ValueError("from_date must be <= to_date")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+
+    normalized_series_ids = _normalize_series_ids(series_ids)
+
+    output_key = raw_macro_path(from_date, to_date)
+    if writer.exists(output_key) and not overwrite:
+        logger.info("Skipping existing FRED macro archive {}", output_key)
+        return BackfillResult(
+            requested_series=len(normalized_series_ids),
+            written=0,
+            skipped=1,
+            empty=0,
+            total_rows=0,
+            output_key=output_key,
+        )
+
+    rows = fetcher.fetch_all_macro_observations(
+        series_ids=normalized_series_ids,
+        start_date=from_date.isoformat(),
+        end_date=to_date.isoformat(),
+        limit=limit,
+    )
+    payload_serializer = serializer or _macro_to_parquet_bytes
+    writer.put_object(output_key, payload_serializer(_sort_macro_observations(rows)))
+    logger.info("Wrote {} FRED macro/rate rows to {}", len(rows), output_key)
+    return BackfillResult(
+        requested_series=len(normalized_series_ids),
+        written=1,
+        skipped=0,
+        empty=0 if rows else 1,
+        total_rows=len(rows),
+        output_key=output_key,
+    )
+
+
+def _macro_to_parquet_bytes(rows: list[dict[str, object]]) -> bytes:
+    """Serialize normalized FRED macro observations to Parquet bytes."""
+    try:
+        import pandas as pd
+        importlib.import_module("pyarrow")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to serialize FRED macro observations to Parquet. "
+            "Install the Pi, Modal, or dev requirements before running the live backfill."
+        ) from exc
+
+    frame = pd.DataFrame([_parquet_ready_row(row) for row in rows])
+    buffer = BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def _parquet_ready_row(row: dict[str, object]) -> dict[str, object]:
+    """Convert nested raw payloads to deterministic JSON strings for Parquet."""
+    output = dict(row)
+    raw = output.pop("raw", None)
+    if raw is not None:
+        output["raw_json"] = json.dumps(raw, sort_keys=True, separators=(",", ":"))
+    return output
+
+
+def _sort_macro_observations(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Sort normalized FRED observations deterministically before serialization."""
+    return sorted(
+        rows,
+        key=lambda row: (
+            str(row.get("series_id") or ""),
+            str(row.get("observation_date") or ""),
+            str(row.get("realtime_start") or ""),
+            str(row.get("realtime_end") or ""),
+        ),
+    )
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse CLI arguments for the historical FRED backfill."""
+    parser = argparse.ArgumentParser(description="Backfill FRED macro/rates into R2.")
+    parser.add_argument(
+        "--config",
+        default=str(DEFAULT_FRED_CONFIG_PATH),
+        help="Path to the FRED archive config JSON.",
+    )
+    parser.add_argument("--from-date", metavar="YYYY-MM-DD")
+    parser.add_argument("--to-date", metavar="YYYY-MM-DD")
+    parser.add_argument(
+        "--series-ids",
+        nargs="*",
+        default=None,
+        help="Optional FRED series IDs. Defaults to config/fred_series.json.",
+    )
+    parser.add_argument("--overwrite", action="store_true", help="Rewrite existing R2 objects.")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=DEFAULT_FRED_PAGE_LIMIT,
+        help=f"Page size for FRED pagination (default: {DEFAULT_FRED_PAGE_LIMIT}).",
+    )
+    args = parser.parse_args()
+    if args.series_ids == []:
+        parser.error("--series-ids requires at least one series when provided")
+    return args
+
+
+def main() -> int:
+    """Run the FRED macro/rates backfill from the command line."""
+    args = _parse_args()
+    archive_config = load_fred_archive_config(Path(args.config))
+
+    try:
+        from_date = date.fromisoformat(args.from_date or archive_config.default_start_date)
+        to_date = _resolve_to_date(args.to_date or archive_config.default_end_date)
+    except ValueError as exc:
+        logger.error("Invalid date argument: {}", exc)
+        return 1
+
+    if from_date > to_date:
+        logger.error("--from-date must be <= --to-date")
+        return 1
+
+    series_ids = args.series_ids or archive_config.series_ids
+    writer = R2Writer()
+    fetcher = FredMacroFetcher(FredClientConfig.from_env())
+    result = backfill_fred_archive(
+        from_date=from_date,
+        to_date=to_date,
+        fetcher=fetcher,
+        writer=writer,
+        series_ids=series_ids,
+        overwrite=args.overwrite,
+        limit=args.limit,
+    )
+    logger.info("FRED macro/rates backfill complete: {}", result)
+    return 0
+
+
+def _resolve_to_date(value: str) -> date:
+    """Resolve an explicit YYYY-MM-DD date or the config-level latest sentinel."""
+    if value.strip().lower() == "latest":
+        return date.today()
+    return date.fromisoformat(value)
+
+
+def _normalize_series_ids(series_ids: Sequence[str]) -> tuple[str, ...]:
+    """Validate and normalize configured FRED series IDs."""
+    if not series_ids:
+        raise ValueError("series_ids must contain at least one series")
+    normalized: set[str] = set()
+    for series_id in series_ids:
+        if not isinstance(series_id, str):
+            raise TypeError("series_ids values must be strings")
+        cleaned = series_id.strip().upper()
+        if not cleaned:
+            raise ValueError("series_ids cannot contain empty values")
+        normalized.add(cleaned)
+    return tuple(sorted(normalized))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/config/README.md
+++ b/config/README.md
@@ -18,3 +18,7 @@ Use `config/r2.env` for local-only Cloudflare R2 credentials; the R2 client load
 automatically when present.
 Use `config/examples/simfin.env.example` as the template and keep the real
 `config/simfin.env` local only.
+Use `config/examples/fred.env.example` as the template and keep the real
+`config/fred.env` local only.
+Use `config/fred_series.json` for the default FRED macro/rate series and backfill
+date range.

--- a/config/examples/fred.env.example
+++ b/config/examples/fred.env.example
@@ -1,0 +1,2 @@
+FRED_API_KEY=replace_me
+FRED_BASE_URL=https://api.stlouisfed.org/fred

--- a/config/fred_series.json
+++ b/config/fred_series.json
@@ -1,0 +1,26 @@
+{
+  "default_start_date": "2014-01-01",
+  "default_end_date": "latest",
+  "series": [
+    {
+      "id": "FEDFUNDS",
+      "description": "Effective federal funds rate"
+    },
+    {
+      "id": "DGS10",
+      "description": "10-year Treasury constant maturity rate"
+    },
+    {
+      "id": "DGS2",
+      "description": "2-year Treasury constant maturity rate"
+    },
+    {
+      "id": "CPIAUCSL",
+      "description": "Consumer Price Index for All Urban Consumers"
+    },
+    {
+      "id": "BAMLH0A0HYM2",
+      "description": "ICE BofA high yield option-adjusted spread"
+    }
+  ]
+}

--- a/data/sample/fred_series_response.json
+++ b/data/sample/fred_series_response.json
@@ -1,0 +1,82 @@
+{
+  "page1": {
+    "realtime_start": "2024-01-01",
+    "realtime_end": "2024-12-31",
+    "observation_start": "2024-01-01",
+    "observation_end": "2024-12-31",
+    "units": "lin",
+    "output_type": 1,
+    "file_type": "json",
+    "order_by": "observation_date",
+    "sort_order": "asc",
+    "count": 3,
+    "offset": 0,
+    "limit": 2,
+    "observations": [
+      {
+        "realtime_start": "2024-01-01",
+        "realtime_end": "2024-12-31",
+        "date": "2024-01-01",
+        "value": "5.33"
+      },
+      {
+        "realtime_start": "2024-01-01",
+        "realtime_end": "2024-12-31",
+        "date": "2024-01-02",
+        "value": "."
+      }
+    ]
+  },
+  "page2": {
+    "realtime_start": "2024-01-01",
+    "realtime_end": "2024-12-31",
+    "observation_start": "2024-01-01",
+    "observation_end": "2024-12-31",
+    "units": "lin",
+    "output_type": 1,
+    "file_type": "json",
+    "order_by": "observation_date",
+    "sort_order": "asc",
+    "count": 3,
+    "offset": 2,
+    "limit": 2,
+    "observations": [
+      {
+        "realtime_start": "2024-01-01",
+        "realtime_end": "2024-12-31",
+        "date": "2024-01-02",
+        "value": "."
+      },
+      {
+        "realtime_start": "2024-01-01",
+        "realtime_end": "2024-12-31",
+        "date": "2024-01-03",
+        "value": "5.35"
+      }
+    ]
+  },
+  "empty": {
+    "realtime_start": "2024-01-01",
+    "realtime_end": "2024-12-31",
+    "observation_start": "2024-01-01",
+    "observation_end": "2024-12-31",
+    "units": "lin",
+    "output_type": 1,
+    "file_type": "json",
+    "order_by": "observation_date",
+    "sort_order": "asc",
+    "count": 0,
+    "offset": 0,
+    "limit": 2,
+    "observations": []
+  },
+  "malformed_missing_date": {
+    "observations": [
+      {
+        "realtime_start": "2024-01-01",
+        "realtime_end": "2024-12-31",
+        "value": "5.33"
+      }
+    ]
+  }
+}

--- a/services/fred/__init__.py
+++ b/services/fred/__init__.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from services.fred.macro_fetcher import (
+    DEFAULT_FRED_BASE_URL,
+    DEFAULT_FRED_CONFIG_PATH,
+    DEFAULT_FRED_PAGE_LIMIT,
+    FRED_API_KEY_ENV,
+    FRED_BASE_URL_ENV,
+    FredArchiveConfig,
+    FredClientConfig,
+    FredMacroFetcher,
+    FredPage,
+    FredSeriesSpec,
+    load_fred_archive_config,
+    normalize_fred_observations,
+)
+
+__all__ = [
+    "DEFAULT_FRED_BASE_URL",
+    "DEFAULT_FRED_CONFIG_PATH",
+    "DEFAULT_FRED_PAGE_LIMIT",
+    "FRED_API_KEY_ENV",
+    "FRED_BASE_URL_ENV",
+    "FredArchiveConfig",
+    "FredClientConfig",
+    "FredMacroFetcher",
+    "FredPage",
+    "FredSeriesSpec",
+    "load_fred_archive_config",
+    "normalize_fred_observations",
+]

--- a/services/fred/macro_fetcher.py
+++ b/services/fred/macro_fetcher.py
@@ -93,15 +93,21 @@ class FredMacroFetcher:
         series_id: str,
         start_date: str,
         end_date: str,
+        realtime_start: str | None = None,
+        realtime_end: str | None = None,
         limit: int = DEFAULT_FRED_PAGE_LIMIT,
         offset: int = 0,
     ) -> FredPage:
-        """Fetch one page of FRED observations for one series/date range."""
+        """Fetch one page of FRED observations for one series/date/realtime range."""
         normalized_series_id = _normalize_series_id(series_id)
         start = _validate_date(start_date, "start_date")
         end = _validate_date(end_date, "end_date")
+        realtime_start_value = _validate_date(realtime_start or start, "realtime_start")
+        realtime_end_value = _validate_date(realtime_end or end, "realtime_end")
         if start > end:
             raise ValueError("start_date must be <= end_date")
+        if realtime_start_value > realtime_end_value:
+            raise ValueError("realtime_start must be <= realtime_end")
         if limit <= 0:
             raise ValueError("limit must be positive")
         if offset < 0:
@@ -112,8 +118,11 @@ class FredMacroFetcher:
                 "series_id": normalized_series_id,
                 "observation_start": start,
                 "observation_end": end,
+                "realtime_start": realtime_start_value,
+                "realtime_end": realtime_end_value,
                 "sort_order": "asc",
                 "file_type": "json",
+                "output_type": 1,
                 "limit": limit,
                 "offset": offset,
                 "api_key": self.config.api_key,
@@ -129,10 +138,12 @@ class FredMacroFetcher:
         series_id: str,
         start_date: str,
         end_date: str,
+        realtime_start: str | None = None,
+        realtime_end: str | None = None,
         limit: int = DEFAULT_FRED_PAGE_LIMIT,
         max_pages: int | None = None,
     ) -> list[dict[str, Any]]:
-        """Fetch all observations for one FRED series/date range."""
+        """Fetch all observations for one FRED series/date/realtime range."""
         offset = 0
         pages = 0
         rows: list[dict[str, Any]] = []
@@ -143,6 +154,8 @@ class FredMacroFetcher:
                 series_id=series_id,
                 start_date=start_date,
                 end_date=end_date,
+                realtime_start=realtime_start,
+                realtime_end=realtime_end,
                 limit=limit,
                 offset=offset,
             )
@@ -172,9 +185,11 @@ class FredMacroFetcher:
         series_ids: Sequence[str],
         start_date: str,
         end_date: str,
+        realtime_start: str | None = None,
+        realtime_end: str | None = None,
         limit: int = DEFAULT_FRED_PAGE_LIMIT,
     ) -> list[dict[str, Any]]:
-        """Fetch all configured FRED series observations for a date range."""
+        """Fetch all configured FRED series observations for a date/realtime range."""
         normalized_series_ids = _normalize_series_ids(series_ids)
         rows: list[dict[str, Any]] = []
         for series_id in normalized_series_ids:
@@ -183,6 +198,8 @@ class FredMacroFetcher:
                     series_id=series_id,
                     start_date=start_date,
                     end_date=end_date,
+                    realtime_start=realtime_start,
+                    realtime_end=realtime_end,
                     limit=limit,
                 )
             )

--- a/services/fred/macro_fetcher.py
+++ b/services/fred/macro_fetcher.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import json
+import os
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import requests
+from dotenv import load_dotenv
+
+FRED_API_KEY_ENV = "FRED_API_KEY"
+FRED_BASE_URL_ENV = "FRED_BASE_URL"
+DEFAULT_FRED_BASE_URL = "https://api.stlouisfed.org/fred"
+FRED_OBSERVATIONS_ENDPOINT = "/series/observations"
+DEFAULT_FRED_PAGE_LIMIT = 1000
+FRED_ENV_FILE = Path(__file__).resolve().parents[2] / "config" / "fred.env"
+DEFAULT_FRED_CONFIG_PATH = Path(__file__).resolve().parents[2] / "config" / "fred_series.json"
+
+
+@dataclass(frozen=True)
+class FredClientConfig:
+    """Configuration for FRED HTTP clients."""
+
+    api_key: str
+    base_url: str = DEFAULT_FRED_BASE_URL
+    timeout_seconds: int = 30
+    max_retries: int = 2
+    retry_sleep_seconds: float = 1.0
+
+    @classmethod
+    def from_env(cls) -> FredClientConfig:
+        """Build FRED config from environment variables or config/fred.env."""
+        _load_local_fred_env_file()
+        api_key = os.getenv(FRED_API_KEY_ENV)
+        if not api_key:
+            raise ValueError(f"Missing required FRED environment variable: {FRED_API_KEY_ENV}")
+        return cls(
+            api_key=api_key,
+            base_url=os.getenv(FRED_BASE_URL_ENV) or DEFAULT_FRED_BASE_URL,
+        )
+
+
+@dataclass(frozen=True)
+class FredSeriesSpec:
+    """Configured FRED series metadata."""
+
+    series_id: str
+    description: str | None = None
+
+
+@dataclass(frozen=True)
+class FredArchiveConfig:
+    """Configured FRED macro archive series and date range."""
+
+    default_start_date: str
+    default_end_date: str
+    series: tuple[FredSeriesSpec, ...]
+
+    @property
+    def series_ids(self) -> tuple[str, ...]:
+        """Return configured series IDs in deterministic order."""
+        return tuple(series.series_id for series in self.series)
+
+
+@dataclass(frozen=True)
+class FredPage:
+    """One page of normalized FRED observations."""
+
+    rows: list[dict[str, Any]]
+    offset: int
+    limit: int
+
+
+class FredMacroFetcher:
+    """Fetch and normalize FRED macro/rate observations."""
+
+    def __init__(
+        self,
+        config: FredClientConfig,
+        session: requests.Session | None = None,
+    ) -> None:
+        """Store client configuration and HTTP session."""
+        self.config = config
+        self.session = session or requests.Session()
+
+    def fetch_series_page(
+        self,
+        *,
+        series_id: str,
+        start_date: str,
+        end_date: str,
+        limit: int = DEFAULT_FRED_PAGE_LIMIT,
+        offset: int = 0,
+    ) -> FredPage:
+        """Fetch one page of FRED observations for one series/date range."""
+        normalized_series_id = _normalize_series_id(series_id)
+        start = _validate_date(start_date, "start_date")
+        end = _validate_date(end_date, "end_date")
+        if start > end:
+            raise ValueError("start_date must be <= end_date")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        if offset < 0:
+            raise ValueError("offset must be non-negative")
+
+        payload = self._request_json(
+            params={
+                "series_id": normalized_series_id,
+                "observation_start": start,
+                "observation_end": end,
+                "sort_order": "asc",
+                "file_type": "json",
+                "limit": limit,
+                "offset": offset,
+                "api_key": self.config.api_key,
+            }
+        )
+        observations = _extract_observations(payload)
+        rows = normalize_fred_observations(observations, series_id=normalized_series_id)
+        return FredPage(rows=rows, offset=offset, limit=limit)
+
+    def fetch_series_observations(
+        self,
+        *,
+        series_id: str,
+        start_date: str,
+        end_date: str,
+        limit: int = DEFAULT_FRED_PAGE_LIMIT,
+        max_pages: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch all observations for one FRED series/date range."""
+        offset = 0
+        pages = 0
+        rows: list[dict[str, Any]] = []
+        seen: set[str] = set()
+
+        while True:
+            page = self.fetch_series_page(
+                series_id=series_id,
+                start_date=start_date,
+                end_date=end_date,
+                limit=limit,
+                offset=offset,
+            )
+            if not page.rows:
+                break
+
+            for row in page.rows:
+                key = _observation_key(row)
+                if key in seen:
+                    continue
+                seen.add(key)
+                rows.append(row)
+
+            if len(page.rows) < page.limit:
+                break
+
+            offset += page.limit
+            pages += 1
+            if max_pages is not None and pages >= max_pages:
+                break
+
+        return rows
+
+    def fetch_all_macro_observations(
+        self,
+        *,
+        series_ids: Sequence[str],
+        start_date: str,
+        end_date: str,
+        limit: int = DEFAULT_FRED_PAGE_LIMIT,
+    ) -> list[dict[str, Any]]:
+        """Fetch all configured FRED series observations for a date range."""
+        normalized_series_ids = _normalize_series_ids(series_ids)
+        rows: list[dict[str, Any]] = []
+        for series_id in normalized_series_ids:
+            rows.extend(
+                self.fetch_series_observations(
+                    series_id=series_id,
+                    start_date=start_date,
+                    end_date=end_date,
+                    limit=limit,
+                )
+            )
+        return rows
+
+    def _request_json(self, params: Mapping[str, Any]) -> Any:
+        """Request one FRED payload with bounded retries for transient failures."""
+        url = f"{self.config.base_url.rstrip('/')}{FRED_OBSERVATIONS_ENDPOINT}"
+        last_error: requests.RequestException | None = None
+        for attempt in range(self.config.max_retries + 1):
+            try:
+                response = self.session.get(
+                    url,
+                    params=dict(params),
+                    timeout=self.config.timeout_seconds,
+                )
+                response.raise_for_status()
+                return response.json()
+            except requests.RequestException as exc:
+                last_error = exc
+                if attempt >= self.config.max_retries or not _is_retryable_error(exc):
+                    raise
+                time.sleep(self.config.retry_sleep_seconds)
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("FRED request failed without an exception")
+
+
+def load_fred_archive_config(path: Path = DEFAULT_FRED_CONFIG_PATH) -> FredArchiveConfig:
+    """Load configured FRED series IDs and default date range from JSON config."""
+    payload = json.loads(path.read_text())
+    if not isinstance(payload, Mapping):
+        raise ValueError("FRED config must be a JSON object")
+
+    start_date = _required_config_date(payload, "default_start_date")
+    end_date = _required_config_end_date(payload)
+    series_payload = payload.get("series")
+    if not isinstance(series_payload, list) or not series_payload:
+        raise ValueError("FRED config series must be a non-empty list")
+
+    seen: set[str] = set()
+    series: list[FredSeriesSpec] = []
+    for index, item in enumerate(series_payload):
+        if not isinstance(item, Mapping):
+            raise ValueError(f"FRED config series item {index} must be an object")
+        series_id_value = item.get("id")
+        if not isinstance(series_id_value, str):
+            raise TypeError(f"FRED config series item {index} id must be a string")
+        series_id = _normalize_series_id(series_id_value)
+        if series_id in seen:
+            raise ValueError(f"Duplicate FRED series configured: {series_id}")
+        seen.add(series_id)
+        description = item.get("description")
+        if description is not None and not isinstance(description, str):
+            raise TypeError(f"FRED config series {series_id} description must be a string")
+        series.append(FredSeriesSpec(series_id=series_id, description=description))
+
+    return FredArchiveConfig(
+        default_start_date=start_date,
+        default_end_date=end_date,
+        series=tuple(series),
+    )
+
+
+def normalize_fred_observations(
+    observations: Sequence[Mapping[str, Any]],
+    *,
+    series_id: str,
+    retrieved_at: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Normalize raw FRED observations while preserving the original payload."""
+    normalized_series_id = _normalize_series_id(series_id)
+    retrieval_time = (retrieved_at or datetime.now(UTC)).isoformat()
+    normalized_rows: list[dict[str, Any]] = []
+
+    for index, observation in enumerate(observations):
+        if not isinstance(observation, Mapping):
+            raise ValueError(
+                f"FRED observation {index} must be an object, "
+                f"got {type(observation).__name__}"
+            )
+        raw = dict(observation)
+        observation_date = _required_date(raw, "date", "observation_date")
+        realtime_start = _required_date(raw, "realtime_start", "realtime_start")
+        realtime_end = _required_date(raw, "realtime_end", "realtime_end")
+        value = _required_value(raw, "value", index)
+
+        normalized_rows.append(
+            {
+                "source": "fred",
+                "series_id": normalized_series_id,
+                "observation_date": observation_date,
+                "realtime_start": realtime_start,
+                "realtime_end": realtime_end,
+                "retrieved_at": retrieval_time,
+                "value": value,
+                "is_missing": value is None,
+                "raw": raw,
+            }
+        )
+
+    return normalized_rows
+
+
+def _extract_observations(payload: Any) -> list[Mapping[str, Any]]:
+    """Extract observation objects from a FRED JSON payload."""
+    if not isinstance(payload, Mapping):
+        raise ValueError("FRED response must be a JSON object")
+    observations = payload.get("observations")
+    if observations is None:
+        raise ValueError("FRED response must contain observations")
+    if not isinstance(observations, list):
+        raise ValueError("FRED response observations must be a list")
+
+    rows: list[Mapping[str, Any]] = []
+    for index, observation in enumerate(observations):
+        if not isinstance(observation, Mapping):
+            raise ValueError(
+                f"FRED observation {index} must be an object, "
+                f"got {type(observation).__name__}"
+            )
+        rows.append(observation)
+    return rows
+
+
+def _required_config_date(payload: Mapping[str, Any], field_name: str) -> str:
+    """Return a required config date in YYYY-MM-DD format."""
+    value = payload.get(field_name)
+    if not isinstance(value, str):
+        raise TypeError(f"FRED config {field_name} must be a string")
+    return _validate_date(value, field_name)
+
+
+def _required_config_end_date(payload: Mapping[str, Any]) -> str:
+    """Return a required config end date or the latest sentinel."""
+    value = payload.get("default_end_date")
+    if not isinstance(value, str):
+        raise TypeError("FRED config default_end_date must be a string")
+    stripped = value.strip().lower()
+    if stripped == "latest":
+        return stripped
+    return _validate_date(stripped, "default_end_date")
+
+
+def _normalize_series_ids(series_ids: Sequence[str]) -> tuple[str, ...]:
+    """Validate and normalize a non-empty sequence of FRED series IDs."""
+    if not series_ids:
+        raise ValueError("series_ids must contain at least one series")
+    return tuple(_normalize_series_id(series_id) for series_id in series_ids)
+
+
+def _normalize_series_id(series_id: str) -> str:
+    """Normalize one FRED series ID."""
+    if not isinstance(series_id, str):
+        raise TypeError("series_id must be a string")
+    cleaned = series_id.strip().upper()
+    if not cleaned:
+        raise ValueError("series_id cannot be empty")
+    return cleaned
+
+
+def _required_date(row: Mapping[str, Any], field_name: str, output_name: str) -> str:
+    """Return a required YYYY-MM-DD date from a FRED row."""
+    value = row.get(field_name)
+    if value is None:
+        raise ValueError(f"Missing required FRED field: {output_name}")
+    if not isinstance(value, str):
+        raise TypeError(f"FRED field {output_name} must be a string date")
+    return _validate_date(value, output_name)
+
+
+def _required_value(row: Mapping[str, Any], field_name: str, index: int) -> float | None:
+    """Return a required FRED value, preserving '.' as missing data."""
+    value = row.get(field_name)
+    if value is None:
+        raise ValueError("Missing required FRED field: value")
+    if not isinstance(value, str):
+        raise TypeError("FRED field value must be a string")
+    stripped = value.strip()
+    if stripped in {"", "."}:
+        return None
+    try:
+        return float(stripped)
+    except ValueError as exc:
+        raise ValueError(f"FRED observation {index} value must be numeric or '.': {value}") from exc
+
+
+def _validate_date(value: str, field_name: str) -> str:
+    """Validate and normalize a YYYY-MM-DD date string."""
+    try:
+        return date.fromisoformat(value.strip().split("T", maxsplit=1)[0]).isoformat()
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be YYYY-MM-DD: {value}") from exc
+
+
+def _observation_key(row: Mapping[str, Any]) -> str:
+    """Return a deterministic key for deduplicating normalized FRED observations."""
+    return "|".join(
+        [
+            str(row.get("series_id") or ""),
+            str(row.get("observation_date") or ""),
+            str(row.get("realtime_start") or ""),
+            str(row.get("realtime_end") or ""),
+            json.dumps(row.get("raw") or {}, sort_keys=True, separators=(",", ":")),
+        ]
+    )
+
+
+def _is_retryable_error(error: requests.RequestException) -> bool:
+    """Return True when a request error is likely transient."""
+    response = getattr(error, "response", None)
+    status_code = getattr(response, "status_code", None)
+    return status_code in {429, 500, 502, 503, 504} or isinstance(
+        error,
+        (requests.ConnectionError, requests.Timeout),
+    )
+
+
+def _load_local_fred_env_file() -> None:
+    """Load local FRED settings from config/fred.env when the file exists."""
+    load_dotenv(dotenv_path=FRED_ENV_FILE, override=False)

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -46,6 +46,18 @@ def raw_fundamentals_path(
     )
 
 
+def raw_macro_path(
+    from_date: str | Date | datetime,
+    to_date: str | Date | datetime,
+) -> str:
+    """Return the canonical raw macro/rates Parquet path for one date range."""
+    return build_r2_key(
+        "raw",
+        "macro",
+        f"{_format_date(from_date)}_to_{_format_date(to_date)}.parquet",
+    )
+
+
 def raw_reference_path(name: str, extension: str = "json") -> str:
     """Return the canonical raw reference snapshot path."""
     safe_name = _validate_key_part(name)

--- a/tests/unit/test_fred_macro_fetcher.py
+++ b/tests/unit/test_fred_macro_fetcher.py
@@ -1,0 +1,395 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+import requests
+
+from app.lab.data_pipelines import backfill_fred
+from app.lab.data_pipelines.backfill_fred import backfill_fred_archive
+from services.fred.macro_fetcher import (
+    DEFAULT_FRED_PAGE_LIMIT,
+    FredClientConfig,
+    FredMacroFetcher,
+    load_fred_archive_config,
+    normalize_fred_observations,
+)
+from services.r2.paths import raw_macro_path
+
+FIXTURE_PATH = Path("data/sample/fred_series_response.json")
+
+
+class _FakeResponse:
+    def __init__(self, payload: Any, error: requests.RequestException | None = None) -> None:
+        self._payload = payload
+        self._error = error
+
+    def json(self) -> Any:
+        return self._payload
+
+    def raise_for_status(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+
+class _FakeSession:
+    def __init__(self, responses: list[_FakeResponse]) -> None:
+        self._responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    def get(self, url: str, **kwargs: Any) -> _FakeResponse:
+        self.calls.append({"url": url, **kwargs})
+        return self._responses.pop(0) if self._responses else _FakeResponse({"observations": []})
+
+
+class _FakeWriter:
+    def __init__(self, existing: set[str] | None = None) -> None:
+        self.existing = set(existing or set())
+        self.objects: dict[str, bytes | str] = {}
+
+    def put_object(self, key: str, data: bytes | str) -> None:
+        self.objects[key] = data
+        self.existing.add(key)
+
+    def exists(self, key: str) -> bool:
+        return key in self.existing
+
+
+class _FakeFetcher:
+    def __init__(self, rows: list[dict[str, Any]]) -> None:
+        self.rows = rows
+        self.calls: list[dict[str, Any]] = []
+
+    def fetch_all_macro_observations(self, **kwargs: Any) -> list[dict[str, Any]]:
+        self.calls.append(kwargs)
+        return self.rows
+
+
+def _fixture_payload() -> dict[str, Any]:
+    return json.loads(FIXTURE_PATH.read_text())
+
+
+def _json_serializer(rows: list[dict[str, object]]) -> bytes:
+    return json.dumps(rows, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def _read_json(payload: bytes | str) -> list[dict[str, Any]]:
+    text = payload.decode("utf-8") if isinstance(payload, bytes) else payload
+    return json.loads(text)
+
+
+def test_client_config_from_env_reads_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """FRED config reads API settings from environment variables."""
+    monkeypatch.setenv("FRED_API_KEY", "test-key")
+    monkeypatch.setenv("FRED_BASE_URL", "https://example.fred.test/fred")
+
+    config = FredClientConfig.from_env()
+
+    assert config.api_key == "test-key"
+    assert config.base_url == "https://example.fred.test/fred"
+    assert config.timeout_seconds == 30
+
+
+def test_client_config_from_env_rejects_missing_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """FRED config fails closed when credentials are absent."""
+    monkeypatch.delenv("FRED_API_KEY", raising=False)
+
+    with pytest.raises(ValueError, match="FRED_API_KEY"):
+        FredClientConfig.from_env()
+
+
+def test_load_fred_archive_config_reads_baseline_series() -> None:
+    """Default FRED config provides the baseline regime/context series."""
+    config = load_fred_archive_config()
+
+    assert config.default_start_date == "2014-01-01"
+    assert config.default_end_date == "latest"
+    assert {"FEDFUNDS", "DGS10", "DGS2", "CPIAUCSL"}.issubset(config.series_ids)
+
+
+def test_load_fred_archive_config_rejects_duplicate_series(tmp_path: Path) -> None:
+    """Series selection is explicit and duplicate IDs fail fast."""
+    config_path = tmp_path / "fred_series.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "default_start_date": "2024-01-01",
+                "default_end_date": "2024-12-31",
+                "series": [{"id": "FEDFUNDS"}, {"id": "fedfunds"}],
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="Duplicate FRED series"):
+        load_fred_archive_config(config_path)
+
+
+def test_load_fred_archive_config_rejects_non_string_series_id(tmp_path: Path) -> None:
+    """Configured FRED series IDs must be explicit strings."""
+    config_path = tmp_path / "fred_series.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "default_start_date": "2024-01-01",
+                "default_end_date": "2024-12-31",
+                "series": [{"id": 123}],
+            }
+        )
+    )
+
+    with pytest.raises(TypeError, match="id must be a string"):
+        load_fred_archive_config(config_path)
+
+
+def test_fetch_series_page_calls_fred_endpoint_and_normalizes_rows() -> None:
+    """Fetcher calls FRED's observations endpoint with scoped params."""
+    fixture = _fixture_payload()
+    session = _FakeSession([_FakeResponse(fixture["page1"])])
+    fetcher = FredMacroFetcher(
+        FredClientConfig(
+            api_key="test-key",
+            base_url="https://example.fred.test/fred",
+            retry_sleep_seconds=0,
+        ),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    page = fetcher.fetch_series_page(
+        series_id="fedfunds",
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        limit=2,
+        offset=0,
+    )
+
+    assert [(row["series_id"], row["observation_date"], row["value"]) for row in page.rows] == [
+        ("FEDFUNDS", "2024-01-01", 5.33),
+        ("FEDFUNDS", "2024-01-02", None),
+    ]
+    assert page.rows[1]["is_missing"] is True
+    assert session.calls == [
+        {
+            "url": "https://example.fred.test/fred/series/observations",
+            "params": {
+                "series_id": "FEDFUNDS",
+                "observation_start": "2024-01-01",
+                "observation_end": "2024-12-31",
+                "sort_order": "asc",
+                "file_type": "json",
+                "limit": 2,
+                "offset": 0,
+                "api_key": "test-key",
+            },
+            "timeout": 30,
+        }
+    ]
+
+
+def test_fetch_series_observations_paginates_and_deduplicates() -> None:
+    """Pagination continues until exhaustion and deduplicates repeated rows."""
+    fixture = _fixture_payload()
+    session = _FakeSession([
+        _FakeResponse(fixture["page1"]),
+        _FakeResponse(fixture["page2"]),
+        _FakeResponse(fixture["empty"]),
+    ])
+    fetcher = FredMacroFetcher(
+        FredClientConfig(api_key="test-key", retry_sleep_seconds=0),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    rows = fetcher.fetch_series_observations(
+        series_id="FEDFUNDS",
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        limit=2,
+    )
+
+    assert [(row["observation_date"], row["value"]) for row in rows] == [
+        ("2024-01-01", 5.33),
+        ("2024-01-02", None),
+        ("2024-01-03", 5.35),
+    ]
+    assert [call["params"]["offset"] for call in session.calls] == [0, 2, 4]
+
+
+def test_fetch_series_page_accepts_empty_response() -> None:
+    """Empty FRED responses normalize to an empty page."""
+    fixture = _fixture_payload()
+    session = _FakeSession([_FakeResponse(fixture["empty"])])
+    fetcher = FredMacroFetcher(
+        FredClientConfig(api_key="test-key"),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    page = fetcher.fetch_series_page(
+        series_id="DGS10",
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+    )
+
+    assert page.rows == []
+
+
+def test_fetch_series_page_rejects_malformed_required_fields() -> None:
+    """Malformed FRED observations fail with actionable diagnostics."""
+    fixture = _fixture_payload()
+    session = _FakeSession([_FakeResponse(fixture["malformed_missing_date"])])
+    fetcher = FredMacroFetcher(
+        FredClientConfig(api_key="test-key"),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match="observation_date"):
+        fetcher.fetch_series_page(
+            series_id="FEDFUNDS",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+
+
+def test_normalize_rejects_malformed_numeric_value() -> None:
+    """FRED values must be numeric strings or the '.' missing-value sentinel."""
+    with pytest.raises(ValueError, match="numeric"):
+        normalize_fred_observations(
+            [
+                {
+                    "realtime_start": "2024-01-01",
+                    "realtime_end": "2024-12-31",
+                    "date": "2024-01-01",
+                    "value": "not-a-number",
+                }
+            ],
+            series_id="FEDFUNDS",
+            retrieved_at=datetime(2024, 1, 4, tzinfo=UTC),
+        )
+
+
+def test_fetch_series_page_retries_transient_errors() -> None:
+    """Retryable provider errors are retried before succeeding."""
+    response = requests.Response()
+    response.status_code = 503
+    error = requests.HTTPError("temporarily unavailable", response=response)
+    fixture = _fixture_payload()
+    session = _FakeSession([_FakeResponse({}, error), _FakeResponse(fixture["page1"])])
+    fetcher = FredMacroFetcher(
+        FredClientConfig(api_key="test-key", retry_sleep_seconds=0),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    page = fetcher.fetch_series_page(
+        series_id="FEDFUNDS",
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+    )
+
+    assert len(page.rows) == 2
+    assert len(session.calls) == 2
+
+
+def test_normalize_preserves_retrieval_and_realtime_dates() -> None:
+    """Point-in-time macro archives preserve observation and as-of metadata."""
+    rows = normalize_fred_observations(
+        [
+            {
+                "realtime_start": "2024-01-01",
+                "realtime_end": "2024-12-31",
+                "date": "2024-01-02",
+                "value": ".",
+            }
+        ],
+        series_id="DGS10",
+        retrieved_at=datetime(2024, 1, 4, tzinfo=UTC),
+    )
+
+    assert rows == [
+        {
+            "source": "fred",
+            "series_id": "DGS10",
+            "observation_date": "2024-01-02",
+            "realtime_start": "2024-01-01",
+            "realtime_end": "2024-12-31",
+            "retrieved_at": "2024-01-04T00:00:00+00:00",
+            "value": None,
+            "is_missing": True,
+            "raw": {
+                "realtime_start": "2024-01-01",
+                "realtime_end": "2024-12-31",
+                "date": "2024-01-02",
+                "value": ".",
+            },
+        }
+    ]
+
+
+def test_backfill_writes_raw_macro_archive() -> None:
+    """Backfill writes one deterministic raw macro archive for the range."""
+    rows = normalize_fred_observations(
+        _fixture_payload()["page1"]["observations"],
+        series_id="FEDFUNDS",
+        retrieved_at=datetime(2024, 1, 4, tzinfo=UTC),
+    )
+    writer = _FakeWriter()
+    fetcher = _FakeFetcher(rows)
+
+    result = backfill_fred_archive(
+        from_date=date(2024, 1, 1),
+        to_date=date(2024, 12, 31),
+        fetcher=fetcher,
+        writer=writer,
+        series_ids=["FEDFUNDS", "DGS10"],
+        serializer=_json_serializer,
+        limit=DEFAULT_FRED_PAGE_LIMIT,
+    )
+
+    key = raw_macro_path(date(2024, 1, 1), date(2024, 12, 31))
+    assert result.output_key == key
+    assert result.requested_series == 2
+    assert result.written == 1
+    assert result.total_rows == 2
+    assert key in writer.objects
+    stored_rows = _read_json(writer.objects[key])
+    assert [row["observation_date"] for row in stored_rows] == ["2024-01-01", "2024-01-02"]
+    assert "raw" in stored_rows[0]
+    assert fetcher.calls[0]["series_ids"] == ("DGS10", "FEDFUNDS")
+
+
+def test_backfill_is_idempotent_for_existing_archive() -> None:
+    """Existing FRED archives are skipped unless overwrite is requested."""
+    key = raw_macro_path(date(2024, 1, 1), date(2024, 12, 31))
+    writer = _FakeWriter(existing={key})
+    fetcher = _FakeFetcher([])
+
+    result = backfill_fred_archive(
+        from_date=date(2024, 1, 1),
+        to_date=date(2024, 12, 31),
+        fetcher=fetcher,
+        writer=writer,
+        series_ids=["FEDFUNDS"],
+        serializer=_json_serializer,
+    )
+
+    assert result.written == 0
+    assert result.skipped == 1
+    assert fetcher.calls == []
+
+
+def test_parse_args_rejects_empty_series_ids_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """CLI rejects '--series-ids' without symbols instead of running an unscoped pull."""
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "backfill_fred.py",
+            "--from-date",
+            "2024-01-01",
+            "--to-date",
+            "2024-12-31",
+            "--series-ids",
+        ],
+    )
+
+    with pytest.raises(SystemExit):
+        backfill_fred._parse_args()

--- a/tests/unit/test_fred_macro_fetcher.py
+++ b/tests/unit/test_fred_macro_fetcher.py
@@ -177,8 +177,11 @@ def test_fetch_series_page_calls_fred_endpoint_and_normalizes_rows() -> None:
                 "series_id": "FEDFUNDS",
                 "observation_start": "2024-01-01",
                 "observation_end": "2024-12-31",
+                "realtime_start": "2024-01-01",
+                "realtime_end": "2024-12-31",
                 "sort_order": "asc",
                 "file_type": "json",
+                "output_type": 1,
                 "limit": 2,
                 "offset": 0,
                 "api_key": "test-key",
@@ -214,6 +217,41 @@ def test_fetch_series_observations_paginates_and_deduplicates() -> None:
         ("2024-01-03", 5.35),
     ]
     assert [call["params"]["offset"] for call in session.calls] == [0, 2, 4]
+
+
+def test_fetch_series_page_accepts_explicit_realtime_window() -> None:
+    """Historical pulls can request a bounded FRED realtime vintage window."""
+    fixture = _fixture_payload()
+    session = _FakeSession([_FakeResponse(fixture["page1"])])
+    fetcher = FredMacroFetcher(
+        FredClientConfig(api_key="test-key", retry_sleep_seconds=0),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    fetcher.fetch_series_page(
+        series_id="CPIAUCSL",
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        realtime_start="2024-02-01",
+        realtime_end="2024-03-01",
+    )
+
+    assert session.calls[0]["params"]["realtime_start"] == "2024-02-01"
+    assert session.calls[0]["params"]["realtime_end"] == "2024-03-01"
+
+
+def test_fetch_series_page_rejects_invalid_realtime_window() -> None:
+    """Realtime vintage windows must be ordered."""
+    fetcher = FredMacroFetcher(FredClientConfig(api_key="test-key"))
+
+    with pytest.raises(ValueError, match="realtime_start"):
+        fetcher.fetch_series_page(
+            series_id="CPIAUCSL",
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+            realtime_start="2024-03-01",
+            realtime_end="2024-02-01",
+        )
 
 
 def test_fetch_series_page_accepts_empty_response() -> None:
@@ -355,6 +393,8 @@ def test_backfill_writes_raw_macro_archive() -> None:
     assert [row["observation_date"] for row in stored_rows] == ["2024-01-01", "2024-01-02"]
     assert "raw" in stored_rows[0]
     assert fetcher.calls[0]["series_ids"] == ("DGS10", "FEDFUNDS")
+    assert fetcher.calls[0]["realtime_start"] == "2024-01-01"
+    assert fetcher.calls[0]["realtime_end"] == "2024-12-31"
 
 
 def test_backfill_is_idempotent_for_existing_archive() -> None:

--- a/tests/unit/test_r2_paths.py
+++ b/tests/unit/test_r2_paths.py
@@ -8,6 +8,7 @@ from services.r2.paths import (
     build_r2_key,
     pipeline_manifest_path,
     raw_fundamentals_path,
+    raw_macro_path,
     raw_news_path,
     raw_price_path,
     raw_reference_path,
@@ -30,6 +31,9 @@ def test_layer0_raw_path_builders_return_canonical_keys() -> None:
     assert (
         raw_fundamentals_path(date(2025, 1, 1), "2025-12-31")
         == "raw/fundamentals/2025-01-01_to_2025-12-31.parquet"
+    )
+    assert raw_macro_path("2025-01-01", date(2025, 12, 31)) == (
+        "raw/macro/2025-01-01_to_2025-12-31.parquet"
     )
     assert raw_reference_path("tiingo_security_master") == "raw/reference/tiingo_security_master.json"
     assert (


### PR DESCRIPTION
## What this PR does
Adds the Layer 0 FRED macro/rates ingestion adapter, configured baseline series, canonical R2 macro archive path, and historical backfill entrypoint. The raw archive preserves observation date, FRED realtime metadata, retrieval timestamp, missing-value state, and raw vendor payloads so Layer 1/1.5 can build context and regime features without calling FRED.

## Closes
Closes #70

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
N/A

## Notes for reviewer
- Unit tests use fixture payloads and fake sessions only; no live FRED API calls were made.
- `config/fred_series.json` owns the default series IDs and date range. `default_end_date: latest` resolves at runtime for operational backfills.
- FRED credentials are loaded from `FRED_API_KEY` or local-only `config/fred.env`, with `config/examples/fred.env.example` as the committed template.