### PR TITLE
[codex] Stabilize SimFin retrieval timestamps

### DIFF
--- a/app/lab/data_pipelines/backfill_simfin.py
+++ b/app/lab/data_pipelines/backfill_simfin.py
@@ -7,7 +7,7 @@ import json
 import sys
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
-from datetime import date
+from datetime import UTC, date, datetime
 from io import BytesIO
 from pathlib import Path
 from typing import Protocol
@@ -50,6 +50,7 @@ class FundamentalsFetcher(Protocol):
         end_date: str,
         statements: Sequence[str],
         periods: Sequence[str],
+        retrieved_at: datetime | None,
         limit: int,
     ) -> list[dict[str, object]]:
         """Fetch all raw SimFin rows for a ticker/date range."""
@@ -81,6 +82,7 @@ def backfill_simfin_archive(
     periods: Sequence[str] = DEFAULT_SIMFIN_PERIODS,
     overwrite: bool = False,
     limit: int = DEFAULT_SIMFIN_PAGE_LIMIT,
+    retrieved_at: datetime | None = None,
     serializer: FundamentalsSerializer | None = None,
 ) -> BackfillResult:
     """Backfill SimFin as-reported fundamentals into R2."""
@@ -97,6 +99,7 @@ def backfill_simfin_archive(
     if not ticker_source:
         raise ValueError("tickers must contain at least one ticker")
 
+    archive_retrieved_at = retrieved_at or datetime.now(UTC)
     output_key = raw_fundamentals_path(from_date, to_date)
     if writer.exists(output_key) and not overwrite:
         logger.info("Skipping existing SimFin fundamentals archive {}", output_key)
@@ -115,6 +118,7 @@ def backfill_simfin_archive(
         end_date=to_date.isoformat(),
         statements=statements,
         periods=periods,
+        retrieved_at=archive_retrieved_at,
         limit=limit,
     )
     payload_serializer = serializer or _fundamentals_to_parquet_bytes

--- a/services/simfin/fundamentals_fetcher.py
+++ b/services/simfin/fundamentals_fetcher.py
@@ -75,6 +75,7 @@ class SimFinFundamentalsFetcher:
         end_date: str,
         statements: Sequence[str] = DEFAULT_SIMFIN_STATEMENTS,
         periods: Sequence[str] = DEFAULT_SIMFIN_PERIODS,
+        retrieved_at: datetime | None = None,
         limit: int = DEFAULT_SIMFIN_PAGE_LIMIT,
         offset: int = 0,
     ) -> SimFinPage:
@@ -105,7 +106,7 @@ class SimFinFundamentalsFetcher:
             }
         )
         raw_rows = _extract_payload_rows(payload)
-        rows = normalize_simfin_fundamental_rows(raw_rows)
+        rows = normalize_simfin_fundamental_rows(raw_rows, retrieved_at=retrieved_at)
         return SimFinPage(rows=rows, offset=offset, limit=limit)
 
     def fetch_all_fundamentals(
@@ -116,6 +117,7 @@ class SimFinFundamentalsFetcher:
         end_date: str,
         statements: Sequence[str] = DEFAULT_SIMFIN_STATEMENTS,
         periods: Sequence[str] = DEFAULT_SIMFIN_PERIODS,
+        retrieved_at: datetime | None = None,
         limit: int = DEFAULT_SIMFIN_PAGE_LIMIT,
         max_pages: int | None = None,
     ) -> list[dict[str, Any]]:
@@ -124,6 +126,7 @@ class SimFinFundamentalsFetcher:
         pages = 0
         seen: set[str] = set()
         rows: list[dict[str, Any]] = []
+        archive_retrieved_at = retrieved_at or datetime.now(UTC)
 
         while True:
             page = self.fetch_statement_rows(
@@ -132,6 +135,7 @@ class SimFinFundamentalsFetcher:
                 end_date=end_date,
                 statements=statements,
                 periods=periods,
+                retrieved_at=archive_retrieved_at,
                 limit=limit,
                 offset=offset,
             )

--- a/tests/unit/test_simfin_fundamentals_fetcher.py
+++ b/tests/unit/test_simfin_fundamentals_fetcher.py
@@ -151,6 +151,7 @@ def test_fetch_statement_rows_calls_compact_endpoint_and_normalizes_rows() -> No
 def test_fetch_all_fundamentals_paginates_and_deduplicates() -> None:
     """Pagination continues until exhaustion and deduplicates repeated raw rows."""
     fixture = _fixture_payload()
+    retrieved_at = datetime(2024, 8, 5, tzinfo=UTC)
     session = _FakeSession([
         _FakeResponse(fixture["page1"]),
         _FakeResponse(fixture["page2"]),
@@ -165,6 +166,7 @@ def test_fetch_all_fundamentals_paginates_and_deduplicates() -> None:
         tickers=["AAPL", "MSFT"],
         start_date="2024-01-01",
         end_date="2024-12-31",
+        retrieved_at=retrieved_at,
         limit=2,
     )
 
@@ -174,6 +176,7 @@ def test_fetch_all_fundamentals_paginates_and_deduplicates() -> None:
         ("AAPL", "cf"),
     ]
     assert [call["params"]["offset"] for call in session.calls] == [0, 2, 4]
+    assert {row["retrieved_at"] for row in rows} == {"2024-08-05T00:00:00+00:00"}
 
 
 def test_fetch_statement_rows_rejects_malformed_payload_item() -> None:
@@ -257,9 +260,10 @@ def test_normalize_rejects_missing_required_availability_date() -> None:
 
 def test_backfill_writes_raw_fundamentals_archive() -> None:
     """Backfill writes one deterministic raw fundamentals archive for the range."""
+    retrieved_at = datetime(2024, 8, 3, tzinfo=UTC)
     rows = normalize_simfin_fundamental_rows(
         _fixture_payload()["page2"],
-        retrieved_at=datetime(2024, 8, 3, tzinfo=UTC),
+        retrieved_at=retrieved_at,
     )
     writer = _FakeWriter()
     fetcher = _FakeFetcher(rows)
@@ -272,6 +276,7 @@ def test_backfill_writes_raw_fundamentals_archive() -> None:
         tickers=["AAPL"],
         statements=DEFAULT_SIMFIN_STATEMENTS,
         periods=DEFAULT_SIMFIN_PERIODS,
+        retrieved_at=retrieved_at,
         serializer=_json_serializer,
     )
 
@@ -285,6 +290,7 @@ def test_backfill_writes_raw_fundamentals_archive() -> None:
     assert [row["ticker"] for row in stored_rows] == ["AAPL", "AAPL"]
     assert "raw" in stored_rows[0]
     assert fetcher.calls[0]["tickers"] == ["AAPL"]
+    assert fetcher.calls[0]["retrieved_at"] == retrieved_at
 
 
 def test_backfill_is_idempotent_for_existing_archive() -> None:


### PR DESCRIPTION
## What this PR does
Addresses follow-up review feedback from #72. SimFin archive builds now use one stable `retrieved_at` timestamp across all pages and rows in a fetch/backfill run, instead of letting each normalization call choose its own clock value.

## Closes
Follow-up to #72

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
N/A

## Notes for reviewer
- `fetch_all_fundamentals` now creates one archive-level timestamp and passes it through each paginated request.
- `backfill_simfin_archive` accepts an optional `retrieved_at` for deterministic tests and otherwise creates one timestamp per archive build.
- Existing `normalize_simfin_fundamental_rows` behavior remains compatible for direct callers.