### PR TITLE
Document hedge-ready architecture

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -53,8 +53,78 @@ The design principle is:
 - shared state in R2 (accessible by both Pi and Modal)
 - Pi SSD used as a local cache for raw fetched data and intermediate state
 - explicit contracts between every layer
+- long-only execution first, with contracts and risk policy kept compatible with later
+  hedge overlays and long-short expansion
 
 ---
+
+## Portfolio posture and expansion roadmap
+
+The initial production system is a long-only daily equity strategy. That is the safest
+baseline for paper trading and early live operation: no margin dependency, no locate/borrow
+dependency, no short-squeeze mechanics, and simpler execution reconciliation.
+
+The architecture must still avoid hardcoding long-only assumptions into contracts or model
+targets. Future hedge and long-short support should be introduced by policy/config changes
+where possible, and by explicit schema migrations only where the current contracts cannot
+represent the needed execution semantics.
+
+Design constraints that apply from the start:
+- `PortfolioRecord.weight`, `target_dollars`, `current_dollars`, and `change_dollars` are
+  signed quantities by contract. Current long-only policy may reject or clamp negative
+  single-stock targets, but the schema must not imply weights are always positive.
+- Layer 2 should train on sector-neutralized forward returns or cross-sectional ranks, not
+  raw market-beta returns. That keeps the score aligned with stock-specific alpha even
+  before hedging is enabled.
+- Layer 4 risk limits must be parameterized through policy/config. Position caps, ADV caps,
+  beta caps, gross/net exposure caps, and future short-side limits must not be hardcoded
+  constants inside rule implementations.
+- Layer 5 remains simple long-only equity execution until a dedicated execution-contract
+  migration introduces short opening/covering, options, margin, and borrow semantics.
+
+### Expansion phases
+
+**Phase 1 — defensive index hedging**
+
+When regime detection flags bear or high-volatility conditions, the system may add a hedge
+overlay instead of only scaling down long exposure. The first hedge instruments should be
+index-level and simple to reason about:
+- inverse ETFs such as SH for small systematic-risk hedges
+- protective SPY puts only after options approval, options-specific risk rules, and execution
+  contract support exist
+
+This phase does not require single-name shorting. The hedge decision belongs in Layer 3 as
+an overlay decision informed by regime state, VIX, drawdown, and beta exposure. Layer 4 must
+cap hedge notional, gross exposure, and instrument eligibility. Layer 5 must not route
+options unless an explicit options execution contract exists.
+
+**Phase 2 — sector-level hedging**
+
+The next extension is sector pair exposure. If the stock selector is intentionally overweight
+one sector because individual names score well, Layer 3 can short or inverse-hedge the
+sector ETF to isolate stock-specific alpha:
+- long selected names inside a sector
+- short or inverse-hedge the sector ETF, for example XLK for technology exposure
+- constrain net sector exposure, gross exposure, and hedge ratio through Layer 4 policy
+
+This aligns portfolio construction with the Layer 2 sector-neutral target. It requires margin
+or approved inverse instruments, and it requires explicit risk rules for sector hedge sizing.
+
+**Phase 3 — true long-short equity**
+
+The final expansion is a full long-short book. Layer 2 already ranks stocks from strongest
+to weakest; Layer 3 can eventually allocate positive weights to the top of the ranking and
+negative weights to the bottom.
+
+This is not just a switch in the optimizer. It requires:
+- optimizer support for signed weights, gross exposure, net exposure, beta neutrality, and
+  borrow-aware constraints
+- Layer 4 short-specific rules for short squeezes, borrow costs, hard-to-borrow names,
+  concentration, recall risk, and unlimited-downside scenarios
+- Layer 5 support for locate/borrow mechanics, margin checks, short-sale order semantics,
+  buy-to-cover behavior, and broker rejection handling
+- backtests that model borrow fees, short rebates, margin interest, and asymmetric execution
+  risk
 
 ## Data sources
 
@@ -394,6 +464,11 @@ Best — cross-sectional rank, removes good-day vs. bad-day effects entirely:
 target = cross_sectional_rank(stock_return_next_5d, date)
 ```
 
+The primary training target should be sector-neutralized even while execution is long-only.
+Long-only deployment can still buy only the highest-scoring names, but the model should learn
+stock-specific alpha rather than broad sector or market direction. Raw forward returns may be
+kept as diagnostics, not as the canonical model target.
+
 Use 5-day forward return as the prediction horizon. Test 1, 5, and 10 days and compare IC.
 
 **Regime-specific model architecture:**
@@ -462,11 +537,22 @@ Key design choices:
 
 Output: target weight per ticker (fraction of total portfolio).
 
+**Signed weight semantics:**
+Layer 3 should emit signed target weights even if the active policy is long-only. In
+long-only mode, candidate single-stock weights must be non-negative after policy constraints.
+In later hedge modes, approved hedge instruments or short books may carry negative weights.
+This keeps the optimizer interface stable as the system moves from long-only to hedged and
+eventually long-short behavior.
+
 ### Layer 4 — Risk Engine
 
 Layer 4 is a completely separate, model-free hard-rule layer. It does not care what XGBoost
 predicted, what the optimizer decided, or what the bandit selected. It applies after
 optimization and cannot be gamed by the optimizer.
+
+All Layer 4 thresholds must come from explicit policy/config, not hardcoded constants. The
+baseline policy is long-only, but the rule interface should accept signed proposed exposure
+so future hedge and short-side rules can be added without rewriting the layer boundary.
 
 **Position-level rules:**
 
@@ -485,6 +571,17 @@ optimization and cannot be gamed by the optimizer.
 | Correlation cap | 0.70–0.80 (30-day rolling pair) | Keep higher-scored ticker, reduce the other |
 | Daily loss limit | -2% intraday | Reduce gross exposure to 50% (circuit breaker) |
 | Max leverage | 1.0x (long-only cash account) | Scale all weights proportionally |
+
+**Hedge-ready policy gates (disabled in the baseline long-only mode):**
+
+| Rule family | Purpose |
+|---|---|
+| Short enable flag | Reject negative single-name targets unless short mode is explicitly enabled |
+| Approved hedge instruments | Allow only configured ETFs/options as defensive hedges |
+| Gross exposure cap | Limit total absolute exposure when long and hedge legs coexist |
+| Net exposure band | Keep portfolio net exposure within configured long-only, hedged, or long-short bands |
+| Short concentration cap | Cap negative exposure per ticker, sector, and hard-to-borrow group |
+| Borrow/margin checks | Block short orders when locate, borrow, or margin requirements are not satisfied |
 
 **Drawdown-based exposure scaling (most impactful rule):**
 
@@ -512,6 +609,12 @@ It does not make decisions — it follows instructions from Layer 4.
 Before placing any new orders, fetch Alpaca's actual account state and reconcile against
 internal state. Alpaca's state is always the authority. Only after reconciliation does Layer 5
 calculate delta orders needed to reach Layer 4 targets.
+
+Baseline Layer 5 execution is long-only equities. Opening shorts, covering shorts, inverse
+ETF hedge overlays, and options hedges must be introduced by dedicated execution issues and,
+where needed, schema migrations. The current `BUY` and `SELL` actions are sufficient for
+long-only target rebalancing, but they are not enough to distinguish open-short, cover,
+option buy-to-open, or option sell-to-close behavior.
 
 **Weight → shares conversion:**
 Layer 4 outputs dollar amounts. Layer 5 converts to whole share counts (round down).

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -32,6 +32,9 @@ General conventions:
 - all tickers are uppercase strings
 - numerical fields use Python numeric types and must not silently contain strings
 - any optional field must be explicitly marked optional in the schema
+- portfolio and order-intent dollar fields are signed unless a field explicitly says
+  otherwise; long-only behavior is enforced by policy/risk rules, not by pretending every
+  contract value must be positive
 
 Schema version metadata:
 
@@ -224,7 +227,8 @@ Fields:
 - `model_version`
 
 Interpretation:
-- `return_score`: expected relative return score or model score
+- `return_score`: expected sector-neutral or cross-sectional alpha score, not a raw market
+  beta return forecast
 - `pos_prob`: calibrated probability of positive or relative outperformance
 - `rank_score`: normalized rank or cross-sectional ordering metric
 - `regime`: regime label used by the model
@@ -232,6 +236,12 @@ Interpretation:
 - `model_version`: artifact/version that produced this score
 
 This record must not contain order instructions.
+
+Training note:
+- The canonical target should be sector-neutralized forward return or a date-level
+  cross-sectional rank. Raw forward returns may be tracked as diagnostics, but they should
+  not become the primary target because they cause the model to learn market/sector beta
+  instead of stock-specific alpha.
 
 ---
 
@@ -251,13 +261,18 @@ Fields:
 - `selection_reason`
 
 Interpretation:
-- `weight`: proposed portfolio weight
-- `target_dollars`: desired notional exposure
-- `current_dollars`: current notional exposure
-- `change_dollars`: target minus current
+- `weight`: signed proposed portfolio weight; positive means long exposure and negative is
+  reserved for future hedge/short exposure
+- `target_dollars`: signed desired notional exposure after portfolio construction
+- `current_dollars`: signed current notional exposure from broker/internal reconciliation
+- `change_dollars`: signed target minus current
 - `selection_reason`: optional human/debug description
 
-This record is still pre-risk and pre-execution.
+This record is still pre-risk and pre-execution. In the baseline long-only system, Layer 4
+must reject or clamp negative single-stock targets unless an explicitly approved hedge
+instrument policy is enabled. The schema itself intentionally does not enforce positive-only
+weights so defensive hedging, sector hedging, and later long-short books do not require a
+trivial numeric-sign migration.
 
 ---
 
@@ -278,11 +293,19 @@ Fields:
 
 Interpretation:
 - `action`: BUY / SELL / HOLD / REJECT
+- `target_dollars`: signed post-risk target notional; baseline long-only rules should keep
+  ordinary equity targets non-negative
 - `approved`: whether execution may proceed
 - `rules_triggered`: list of hard-rule names that altered or rejected the proposal
 - `reason`: optional explanation for human/debug use
 
 This is the only order-intent contract that execution should consume.
+
+Future expansion note:
+- `BUY` and `SELL` are sufficient for current long-only target rebalancing. Opening shorts,
+  covering shorts, options hedges, and margin-specific order behavior require explicit
+  execution-contract review and likely a schema migration to represent position effect,
+  instrument type, borrow/locate status, and margin requirements.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,9 +45,20 @@ Expected execution chain:
 6. Dry-run risk and execution path
 7. Enable paper execution
 
+Baseline paper execution is long-only equities. Hedge and long-short capabilities must stay
+disabled by policy until the relevant risk and execution gates are implemented:
+- defensive index hedges: explicit approved instrument list, hedge notional caps, and
+  broker/account permission checks
+- sector hedges: margin or inverse-instrument approval, sector ETF mapping, and net/gross
+  exposure controls
+- true long-short: borrow/locate checks, margin checks, short-specific order semantics, and
+  updated execution contracts
+
 ## Operational notes
 
 - Keep secrets outside git
 - Log every stage deterministically
 - Fail closed on missing risk checks
+- Keep risk thresholds in policy/config so long-only, hedged, and long-short modes can use
+  the same Layer 4 rule framework
 - Keep runtime assumptions synchronized across AGENTS, docs, and issue acceptance criteria

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -75,19 +75,24 @@ before enabling the live daily loop.
 4. **Layer 2 inference** (Modal)
    - Read today's feature row from R2
    - Select active XGBoost model for current regime
-   - Produce `ScoreRecord` per ticker (return_score, pos_prob, rank_score)
+   - Produce `ScoreRecord` per ticker using sector-neutral or cross-sectional alpha scores
+     (`return_score`, `pos_prob`, `rank_score`)
    - Write scores to `processed/scores/YYYY-MM-DD.parquet` in R2
    - Write `PipelineManifestRecord` (stage=layer2)
 
 5. **Layer 3 portfolio construction** (Pi)
    - Pi reads scores from R2
    - Contextual bandit filters ~800 universe stocks → 30–50 candidates
-   - Mean-variance optimizer produces target weights with turnover penalty
+   - Mean-variance optimizer produces signed target weights with turnover penalty
+   - Baseline long-only policy keeps ordinary single-stock targets non-negative
+   - Future hedge modes may add approved index or sector hedge overlay targets
    - Write `PortfolioRecord` list to R2
 
 6. **Layer 4 risk engine** (Pi)
    - Apply hard rules: position cap, ADV cap, sector cap, beta cap,
      correlation cap, drawdown scaling, fat-finger checks
+   - Load all thresholds from policy/config; do not rely on hardcoded risk constants
+   - Reject negative single-stock targets unless an explicit hedge/short policy is enabled
    - Write `ApprovedOrderRecord` list to R2 and local SSD
    - Write `PipelineManifestRecord` (stage=layer4)
 
@@ -100,7 +105,7 @@ before enabling the live daily loop.
 
 8. **Layer 5 execution** (Pi)
    - Convert target dollars to whole share counts (round down)
-   - Place limit orders via Alpaca
+   - Place long-only equity limit orders via Alpaca in the baseline deployment
    - Monitor fills every N minutes; cancel and reprice stale orders after 30 min
    - Log fills to local SQLite ledger and `ExecutionFillRecord` in R2
 


### PR DESCRIPTION
## What this PR does
Documents the architecture-level path from the current long-only daily equity system to future defensive hedging, sector hedging, and true long-short equity support. This is docs-only and intentionally does not change `core/contracts/schemas.py` because the current portfolio fields already allow signed numeric values.

## Closes
N/A — architecture direction update from the user, no existing issue.

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [x] Layer 2 — Model
- [x] Layer 3 — Portfolio
- [x] Layer 4 — Risk
- [x] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist

### Correctness
- [x] No schema changes made
- [x] No logic added to forbidden files
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `pytest tests/unit/test_contracts_schemas.py -v --tb=short` passes
- [x] `git diff --check` passes
- [x] Docs-only change; no new public functions or fixture/API tests required

### Project hygiene
- [x] Branch named `codex/hedge-ready-architecture`
- [x] No unrelated files modified
- [x] No new dependencies

---

## New dependencies
None

## Screenshots or sample output
- `pytest tests/unit/test_contracts_schemas.py -v --tb=short` — 11 passed
- `git diff --check` — passed

## Notes for reviewer
- No schema migration is needed now: `PortfolioRecord.weight`, `target_dollars`, `current_dollars`, and `change_dollars` are already unconstrained signed floats.
- The docs now make long-only behavior a policy/risk setting, not a schema assumption.
- Future short, options, margin, and borrow-specific execution behavior is explicitly gated behind future execution-contract work.