### PR TITLE
[codex] Add Layer 0 ingestion orchestration

### DIFF
--- a/app/lab/data_pipelines/backfill_layer0.py
+++ b/app/lab/data_pipelines/backfill_layer0.py
@@ -1,0 +1,121 @@
+"""Complete historical Layer 0 raw-data backfill orchestration."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date
+from pathlib import Path
+
+from loguru import logger
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from core.data.layer0_pipeline import (  # noqa: E402
+    HistoricalLayer0Config,
+    run_historical_layer0_backfill,
+)
+from services.fred.macro_fetcher import (  # noqa: E402
+    DEFAULT_FRED_CONFIG_PATH,
+    FredClientConfig,
+    FredMacroFetcher,
+    load_fred_archive_config,
+)
+from services.r2.writer import R2Writer  # noqa: E402
+from services.simfin.fundamentals_fetcher import (  # noqa: E402
+    SimFinClientConfig,
+    SimFinFundamentalsFetcher,
+)
+from services.tiingo.news_fetcher import DEFAULT_NEWS_PAGE_LIMIT, TiingoNewsFetcher  # noqa: E402
+from services.tiingo.ohlcv_fetcher import TiingoClientConfig, TiingoOHLCVFetcher  # noqa: E402
+from services.tiingo.security_master import TiingoSecurityMaster  # noqa: E402
+from services.wikipedia.sp500_universe import (  # noqa: E402
+    get_all_historical_tickers,
+    get_constituents,
+)
+
+
+class WikipediaUniverseProvider:
+    """Adapter exposing Wikipedia S&P 500 membership to the Layer 0 pipeline."""
+
+    def get_constituents(self, as_of_date: str) -> list[str]:
+        """Return point-in-time S&P 500 constituents for one date."""
+        return get_constituents(as_of_date)
+
+    def get_historical_tickers(self, from_date: str, to_date: str) -> set[str]:
+        """Return all S&P 500 tickers present at any point in the date range."""
+        return get_all_historical_tickers(from_date, to_date)
+
+
+def main() -> int:
+    """Run the historical Layer 0 ingest from the command line."""
+    args = _parse_args()
+    archive_config = load_fred_archive_config(Path(args.config))
+    try:
+        from_date = date.fromisoformat(args.from_date)
+        to_date = _resolve_to_date(args.to_date or archive_config.default_end_date)
+    except ValueError as exc:
+        logger.error("Invalid date argument: {}", exc)
+        return 1
+
+    if from_date > to_date:
+        logger.error("--from-date must be <= --to-date")
+        return 1
+
+    tiingo_config = TiingoClientConfig.from_env()
+    config = HistoricalLayer0Config(
+        from_date=from_date,
+        to_date=to_date,
+        tickers=args.tickers,
+        fred_series_ids=args.series_ids or archive_config.series_ids,
+        overwrite=args.overwrite,
+        news_limit=args.news_limit,
+        simfin_limit=args.simfin_limit,
+        fred_limit=args.fred_limit,
+        run_id=args.run_id,
+    )
+    result = run_historical_layer0_backfill(
+        config=config,
+        universe_provider=WikipediaUniverseProvider(),
+        price_fetcher=TiingoOHLCVFetcher(tiingo_config),
+        security_master=TiingoSecurityMaster.fetch_supported_tickers(),
+        news_fetcher=TiingoNewsFetcher(tiingo_config),
+        fundamentals_fetcher=SimFinFundamentalsFetcher(SimFinClientConfig.from_env()),
+        macro_fetcher=FredMacroFetcher(FredClientConfig.from_env()),
+        writer=R2Writer(),
+    )
+    logger.info("Historical Layer 0 backfill complete: {}", result)
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse historical Layer 0 CLI arguments."""
+    parser = argparse.ArgumentParser(description="Backfill all Layer 0 raw archives into R2.")
+    parser.add_argument("--config", default=str(DEFAULT_FRED_CONFIG_PATH))
+    parser.add_argument("--from-date", required=True, metavar="YYYY-MM-DD")
+    parser.add_argument("--to-date", metavar="YYYY-MM-DD")
+    parser.add_argument("--tickers", nargs="*", default=None)
+    parser.add_argument("--series-ids", nargs="*", default=None)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument("--news-limit", type=int, default=DEFAULT_NEWS_PAGE_LIMIT)
+    parser.add_argument("--simfin-limit", type=int, default=1000)
+    parser.add_argument("--fred-limit", type=int, default=1000)
+    args = parser.parse_args()
+    if args.tickers == []:
+        parser.error("--tickers requires at least one ticker when provided")
+    if args.series_ids == []:
+        parser.error("--series-ids requires at least one series when provided")
+    return args
+
+
+def _resolve_to_date(value: str) -> date:
+    """Resolve an explicit YYYY-MM-DD date or the latest sentinel."""
+    if value.strip().lower() == "latest":
+        return date.today()
+    return date.fromisoformat(value)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/app/pi/fetchers/layer0.py
+++ b/app/pi/fetchers/layer0.py
@@ -1,0 +1,84 @@
+"""Daily Layer 0 incremental ingest for the Pi runtime."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import date
+from pathlib import Path
+
+from loguru import logger
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from core.data.layer0_pipeline import DailyLayer0Config, run_daily_layer0_incremental  # noqa: E402
+from services.alpaca.market_data import AlpacaMarketDataClient, AlpacaMarketDataConfig  # noqa: E402
+from services.fred.macro_fetcher import (  # noqa: E402
+    DEFAULT_FRED_CONFIG_PATH,
+    FredClientConfig,
+    FredMacroFetcher,
+    load_fred_archive_config,
+)
+from services.r2.writer import R2Writer  # noqa: E402
+from services.simfin.fundamentals_fetcher import (  # noqa: E402
+    SimFinClientConfig,
+    SimFinFundamentalsFetcher,
+)
+from services.tiingo.news_fetcher import DEFAULT_NEWS_PAGE_LIMIT, TiingoNewsFetcher  # noqa: E402
+from services.tiingo.ohlcv_fetcher import TiingoClientConfig  # noqa: E402
+
+
+def main() -> int:
+    """Run one daily Layer 0 incremental ingest from the command line."""
+    args = _parse_args()
+    archive_config = load_fred_archive_config(Path(args.config))
+    try:
+        as_of_date = date.fromisoformat(args.as_of_date)
+    except ValueError as exc:
+        logger.error("Invalid --as-of-date: {}", exc)
+        return 1
+
+    tiingo_config = TiingoClientConfig.from_env()
+    config = DailyLayer0Config(
+        as_of_date=as_of_date,
+        tickers=args.tickers,
+        fred_series_ids=args.series_ids or archive_config.series_ids,
+        overwrite=args.overwrite,
+        news_limit=args.news_limit,
+        simfin_limit=args.simfin_limit,
+        fred_limit=args.fred_limit,
+        run_id=args.run_id,
+    )
+    result = run_daily_layer0_incremental(
+        config=config,
+        live_price_fetcher=AlpacaMarketDataClient(AlpacaMarketDataConfig.from_env()),
+        news_fetcher=TiingoNewsFetcher(tiingo_config),
+        fundamentals_fetcher=SimFinFundamentalsFetcher(SimFinClientConfig.from_env()),
+        macro_fetcher=FredMacroFetcher(FredClientConfig.from_env()),
+        writer=R2Writer(),
+    )
+    logger.info("Daily Layer 0 incremental ingest complete: {}", result)
+    return 0
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse daily Layer 0 CLI arguments."""
+    parser = argparse.ArgumentParser(description="Run daily Layer 0 raw ingest into R2.")
+    parser.add_argument("--config", default=str(DEFAULT_FRED_CONFIG_PATH))
+    parser.add_argument("--as-of-date", required=True, metavar="YYYY-MM-DD")
+    parser.add_argument("--tickers", nargs="+", required=True)
+    parser.add_argument("--series-ids", nargs="*", default=None)
+    parser.add_argument("--overwrite", action="store_true")
+    parser.add_argument("--run-id", default=None)
+    parser.add_argument("--news-limit", type=int, default=DEFAULT_NEWS_PAGE_LIMIT)
+    parser.add_argument("--simfin-limit", type=int, default=1000)
+    parser.add_argument("--fred-limit", type=int, default=1000)
+    args = parser.parse_args()
+    if args.series_ids == []:
+        parser.error("--series-ids requires at least one series when provided")
+    return args
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -366,9 +366,11 @@ def run_daily_layer0_incremental(
     )
 
     try:
-        daily_records = live_price_fetcher.fetch_live_daily_bars(
-            tickers=tickers,
-            as_of_date=as_of_date.isoformat(),
+        daily_records = _canonicalize_ohlcv_records(
+            live_price_fetcher.fetch_live_daily_bars(
+                tickers=tickers,
+                as_of_date=as_of_date.isoformat(),
+            )
         )
         price_result = _write_daily_prices(
             records=daily_records,
@@ -381,7 +383,7 @@ def run_daily_layer0_incremental(
 
         quality_window = _copy_ohlcv_window(config.quality_ohlcv_window)
         for record in daily_records:
-            quality_window.setdefault(record.ticker.upper(), []).append(record)
+            quality_window.setdefault(_canonicalize_ticker(record.ticker), []).append(record)
         universe_records = build_universe_mask_records(
             as_of_date=as_of_date,
             tickers=tickers,
@@ -551,29 +553,32 @@ def _backfill_historical_prices(
 
     for security_id, security_rows in grouped.items():
         key = raw_price_path(security_id)
-        if writer.exists(key) and not config.overwrite:
+        should_write = config.overwrite or not writer.exists(key)
+        if not should_write:
             skipped += 1
-            continue
 
         records: list[OHLCVRecord] = []
         for security in security_rows:
             fetch_from, fetch_to = _security_fetch_range(security, config.from_date, config.to_date)
-            fetched = price_fetcher.fetch_security_records(
-                security=security,
-                from_date=fetch_from.isoformat(),
-                to_date=fetch_to.isoformat(),
+            fetched = _canonicalize_ohlcv_records(
+                price_fetcher.fetch_security_records(
+                    security=security,
+                    from_date=fetch_from.isoformat(),
+                    to_date=fetch_to.isoformat(),
+                )
             )
             records.extend(fetched)
             for record in fetched:
-                quality_window.setdefault(record.ticker.upper(), []).append(record)
+                quality_window.setdefault(_canonicalize_ticker(record.ticker), []).append(record)
 
         if not records:
             empty += 1
             continue
 
-        writer.put_object(key, serializer(_sort_ohlcv_records(records)))
-        output_keys.append(key)
-        written += 1
+        if should_write:
+            writer.put_object(key, serializer(_sort_ohlcv_records(records)))
+            output_keys.append(key)
+            written += 1
 
     return _WriteResult(
         output_keys=output_keys,
@@ -602,8 +607,9 @@ def _write_historical_universe_masks(
     written = 0
     skipped = 0
     total_records = 0
+    days = _business_days(config.from_date, config.to_date)
 
-    for current_date in _business_days(config.from_date, config.to_date):
+    for current_date in days:
         if writer.exists(raw_universe_path(current_date)) and not config.overwrite:
             skipped += 1
             continue
@@ -629,7 +635,7 @@ def _write_historical_universe_masks(
     return _WriteResult(
         output_keys=output_keys,
         metadata={
-            "requested_days": len(_business_days(config.from_date, config.to_date)),
+            "requested_days": len(days),
             "written": written,
             "skipped": skipped,
             "total_records": total_records,
@@ -707,8 +713,9 @@ def _backfill_news(
     skipped = 0
     empty = 0
     total_articles = 0
+    days = _date_range(from_date, to_date)
 
-    for current_date in _date_range(from_date, to_date):
+    for current_date in days:
         key = raw_news_path(current_date)
         if writer.exists(key) and not overwrite:
             skipped += 1
@@ -728,7 +735,7 @@ def _backfill_news(
     return _WriteResult(
         output_keys=output_keys,
         metadata={
-            "requested_days": len(_date_range(from_date, to_date)),
+            "requested_days": len(days),
             "written": written,
             "skipped": skipped,
             "empty": empty,
@@ -958,7 +965,7 @@ def _copy_ohlcv_window(
 ) -> dict[str, list[OHLCVRecord]]:
     if window is None:
         return {}
-    return {ticker.upper(): list(records) for ticker, records in window.items()}
+    return {_canonicalize_ticker(ticker): list(records) for ticker, records in window.items()}
 
 
 def _resolve_securities(
@@ -1046,11 +1053,22 @@ def _normalize_tickers(tickers: Iterable[str]) -> tuple[str, ...]:
     for ticker in tickers:
         if not isinstance(ticker, str):
             raise TypeError("tickers must be strings")
-        cleaned = ticker.strip().upper()
+        cleaned = _canonicalize_ticker(ticker)
         if not cleaned:
             raise ValueError("tickers cannot contain empty values")
         normalized.add(cleaned)
     return tuple(sorted(normalized))
+
+
+def _canonicalize_ticker(ticker: str) -> str:
+    return ticker.strip().upper().replace(".", "-")
+
+
+def _canonicalize_ohlcv_records(records: Sequence[OHLCVRecord]) -> list[OHLCVRecord]:
+    return [
+        record.model_copy(update={"ticker": _canonicalize_ticker(record.ticker)})
+        for record in records
+    ]
 
 
 def _normalize_tokens(values: Sequence[str]) -> tuple[str, ...]:

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -1,0 +1,1113 @@
+from __future__ import annotations
+
+import csv
+import importlib
+import io
+import json
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime, timedelta
+from typing import Protocol
+
+from core.contracts.schemas import OHLCVRecord, PipelineManifestRecord, RunStatus, UniverseRecord
+from core.data.quality import QualityFilterConfig, apply_quality_filters
+from core.data.universe import build_universe_record
+from services.r2.paths import (
+    pipeline_manifest_path,
+    raw_fundamentals_path,
+    raw_macro_path,
+    raw_news_path,
+    raw_price_path,
+    raw_security_master_path,
+    raw_universe_path,
+)
+
+
+class ObjectWriter(Protocol):
+    """Object-store methods required by the Layer 0 pipeline."""
+
+    def put_object(self, key: str, data: bytes | str) -> None:
+        """Write one object to storage."""
+
+    def exists(self, key: str) -> bool:
+        """Return True when an object key already exists."""
+
+
+class HistoricalUniverseProvider(Protocol):
+    """Point-in-time universe source used by historical Layer 0 backfills."""
+
+    def get_constituents(self, as_of_date: str) -> list[str]:
+        """Return index constituents as of one date."""
+
+    def get_historical_tickers(self, from_date: str, to_date: str) -> set[str]:
+        """Return all tickers that appeared in the index over a date range."""
+
+
+class SecurityIdentity(Protocol):
+    """Stable security identity row resolved from a ticker security master."""
+
+    ticker: str
+    security_id: str
+    start_date: str | None
+    end_date: str | None
+
+    def to_reference_row(self) -> dict[str, str | None]:
+        """Serialize a security identity for the reference archive."""
+
+
+class SecurityMaster(Protocol):
+    """Security-master methods required for historical Tiingo price archives."""
+
+    def resolve_all(self, ticker: str) -> list[SecurityIdentity]:
+        """Resolve one ticker to every historical security identity row."""
+
+
+class HistoricalPriceFetcher(Protocol):
+    """Historical OHLCV fetcher used by the backfill pipeline."""
+
+    def fetch_security_records(
+        self,
+        security: SecurityIdentity,
+        from_date: str,
+        to_date: str,
+    ) -> list[OHLCVRecord]:
+        """Fetch validated OHLCV records for one security identity."""
+
+
+class LivePriceFetcher(Protocol):
+    """Live daily OHLCV fetcher used by the daily incremental pipeline."""
+
+    def fetch_live_daily_bars(
+        self,
+        *,
+        tickers: Sequence[str],
+        as_of_date: str,
+    ) -> list[OHLCVRecord]:
+        """Fetch current daily bars normalized to OHLCVRecord."""
+
+
+class NewsFetcher(Protocol):
+    """Tiingo raw-news fetcher used by Layer 0 orchestration."""
+
+    def fetch_news_day(
+        self,
+        *,
+        tickers: list[str] | None,
+        as_of_date: str,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        """Fetch raw news rows for one date."""
+
+
+class FundamentalsFetcher(Protocol):
+    """SimFin raw fundamentals fetcher used by Layer 0 orchestration."""
+
+    def fetch_all_fundamentals(
+        self,
+        *,
+        tickers: Sequence[str],
+        start_date: str,
+        end_date: str,
+        statements: Sequence[str],
+        periods: Sequence[str],
+        retrieved_at: datetime | None,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        """Fetch raw fundamentals rows for a ticker/date range."""
+
+
+class MacroFetcher(Protocol):
+    """FRED raw macro/rates fetcher used by Layer 0 orchestration."""
+
+    def fetch_all_macro_observations(
+        self,
+        *,
+        series_ids: Sequence[str],
+        start_date: str,
+        end_date: str,
+        realtime_start: str | None,
+        realtime_end: str | None,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        """Fetch raw macro observations for configured series/date ranges."""
+
+
+RecordSerializer = Callable[[list[OHLCVRecord]], bytes]
+NewsSerializer = Callable[[list[dict[str, object]]], bytes]
+RawRowSerializer = Callable[[list[dict[str, object]]], bytes]
+UniverseSerializer = Callable[[list[UniverseRecord]], bytes]
+
+
+@dataclass(frozen=True)
+class HistoricalLayer0Config:
+    """Configuration for a complete historical Layer 0 raw-data backfill."""
+
+    from_date: date
+    to_date: date
+    tickers: Sequence[str] | None = None
+    fred_series_ids: Sequence[str] = ()
+    simfin_statements: Sequence[str] = ("pl", "bs", "cf", "derived")
+    simfin_periods: Sequence[str] = ("q1", "q2", "q3", "q4", "fy")
+    overwrite: bool = False
+    news_limit: int = 100
+    simfin_limit: int = 1000
+    fred_limit: int = 1000
+    quality_config: QualityFilterConfig = field(default_factory=QualityFilterConfig)
+    quality_ohlcv_window: Mapping[str, Sequence[OHLCVRecord]] | None = None
+    run_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate date windows, limits, and configured FRED series."""
+        _validate_date_window(self.from_date, self.to_date)
+        _validate_positive_limit(self.news_limit, "news_limit")
+        _validate_positive_limit(self.simfin_limit, "simfin_limit")
+        _validate_positive_limit(self.fred_limit, "fred_limit")
+        if not self.fred_series_ids:
+            raise ValueError("fred_series_ids must contain at least one series")
+        if not self.simfin_statements:
+            raise ValueError("simfin_statements must contain at least one statement")
+        if not self.simfin_periods:
+            raise ValueError("simfin_periods must contain at least one period")
+
+
+@dataclass(frozen=True)
+class DailyLayer0Config:
+    """Configuration for one daily Layer 0 incremental ingest run."""
+
+    as_of_date: date
+    tickers: Sequence[str]
+    fred_series_ids: Sequence[str]
+    simfin_statements: Sequence[str] = ("pl", "bs", "cf", "derived")
+    simfin_periods: Sequence[str] = ("q1", "q2", "q3", "q4", "fy")
+    overwrite: bool = False
+    news_limit: int = 100
+    simfin_limit: int = 1000
+    fred_limit: int = 1000
+    quality_config: QualityFilterConfig = field(default_factory=QualityFilterConfig)
+    quality_ohlcv_window: Mapping[str, Sequence[OHLCVRecord]] | None = None
+    run_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate daily ticker and vendor-fetch settings."""
+        if not _normalize_tickers(self.tickers):
+            raise ValueError("tickers must contain at least one ticker")
+        if not self.fred_series_ids:
+            raise ValueError("fred_series_ids must contain at least one series")
+        if not self.simfin_statements:
+            raise ValueError("simfin_statements must contain at least one statement")
+        if not self.simfin_periods:
+            raise ValueError("simfin_periods must contain at least one period")
+        _validate_positive_limit(self.news_limit, "news_limit")
+        _validate_positive_limit(self.simfin_limit, "simfin_limit")
+        _validate_positive_limit(self.fred_limit, "fred_limit")
+
+
+@dataclass(frozen=True)
+class Layer0PipelineResult:
+    """Completion summary for one Layer 0 pipeline run."""
+
+    run_id: str
+    manifest_key: str
+    status: RunStatus
+    output_keys: tuple[str, ...]
+    metadata: dict[str, object]
+
+
+def run_historical_layer0_backfill(
+    *,
+    config: HistoricalLayer0Config,
+    universe_provider: HistoricalUniverseProvider,
+    price_fetcher: HistoricalPriceFetcher,
+    security_master: SecurityMaster,
+    news_fetcher: NewsFetcher,
+    fundamentals_fetcher: FundamentalsFetcher,
+    macro_fetcher: MacroFetcher,
+    writer: ObjectWriter,
+    price_serializer: RecordSerializer | None = None,
+    news_serializer: NewsSerializer | None = None,
+    fundamentals_serializer: RawRowSerializer | None = None,
+    macro_serializer: RawRowSerializer | None = None,
+    universe_serializer: UniverseSerializer | None = None,
+) -> Layer0PipelineResult:
+    """Run the complete historical Layer 0 ingest and write a success/failure manifest."""
+    run_id = config.run_id or f"layer0-historical-{config.from_date}_to_{config.to_date}"
+    started_at = datetime.now(UTC)
+    output_keys: list[str] = []
+    metadata: dict[str, object] = _base_metadata(
+        mode="historical_backfill",
+        from_date=config.from_date.isoformat(),
+        to_date=config.to_date.isoformat(),
+        fred_series_ids=_normalize_tokens(config.fred_series_ids),
+    )
+
+    try:
+        tickers = _resolve_backfill_tickers(config=config, universe_provider=universe_provider)
+        quality_window = _copy_ohlcv_window(config.quality_ohlcv_window)
+
+        price_result = _backfill_historical_prices(
+            config=config,
+            tickers=tickers,
+            price_fetcher=price_fetcher,
+            security_master=security_master,
+            writer=writer,
+            serializer=price_serializer or _records_to_parquet_bytes,
+            quality_window=quality_window,
+        )
+        output_keys.extend(price_result.output_keys)
+        metadata["prices"] = price_result.metadata
+
+        universe_result = _write_historical_universe_masks(
+            config=config,
+            universe_provider=universe_provider,
+            writer=writer,
+            ohlcv_window=quality_window,
+            serializer=universe_serializer or _universe_to_csv_bytes,
+        )
+        output_keys.extend(universe_result.output_keys)
+        metadata["universe"] = universe_result.metadata
+
+        news_result = _backfill_news(
+            from_date=config.from_date,
+            to_date=config.to_date,
+            tickers=tickers,
+            limit=config.news_limit,
+            overwrite=config.overwrite,
+            fetcher=news_fetcher,
+            writer=writer,
+            serializer=news_serializer or _articles_to_jsonl_bytes,
+        )
+        output_keys.extend(news_result.output_keys)
+        metadata["news"] = news_result.metadata
+
+        fundamentals_key = raw_fundamentals_path(config.from_date, config.to_date)
+        fundamentals_result = _write_fundamentals_archive(
+            key=fundamentals_key,
+            from_date=config.from_date,
+            to_date=config.to_date,
+            tickers=tickers,
+            statements=config.simfin_statements,
+            periods=config.simfin_periods,
+            limit=config.simfin_limit,
+            overwrite=config.overwrite,
+            fetcher=fundamentals_fetcher,
+            writer=writer,
+            serializer=fundamentals_serializer or _raw_rows_to_parquet_bytes,
+        )
+        output_keys.extend(fundamentals_result.output_keys)
+        metadata["fundamentals"] = fundamentals_result.metadata
+
+        macro_key = raw_macro_path(config.from_date, config.to_date)
+        macro_result = _write_macro_archive(
+            key=macro_key,
+            from_date=config.from_date,
+            to_date=config.to_date,
+            series_ids=config.fred_series_ids,
+            limit=config.fred_limit,
+            overwrite=config.overwrite,
+            fetcher=macro_fetcher,
+            writer=writer,
+            serializer=macro_serializer or _raw_rows_to_parquet_bytes,
+        )
+        output_keys.extend(macro_result.output_keys)
+        metadata["macro"] = macro_result.metadata
+
+        manifest_key = _write_pipeline_manifest(
+            writer=writer,
+            run_id=run_id,
+            status=RunStatus.COMPLETED,
+            started_at=started_at,
+            metadata=metadata | {"output_keys": sorted(set(output_keys))},
+        )
+        return Layer0PipelineResult(
+            run_id=run_id,
+            manifest_key=manifest_key,
+            status=RunStatus.COMPLETED,
+            output_keys=tuple(sorted(set(output_keys + [manifest_key]))),
+            metadata=metadata,
+        )
+    except Exception as exc:
+        manifest_key = _write_failure_manifest(
+            writer=writer,
+            run_id=run_id,
+            started_at=started_at,
+            metadata=metadata,
+            output_keys=output_keys,
+            exc=exc,
+        )
+        output_keys.append(manifest_key)
+        raise
+
+
+def run_daily_layer0_incremental(
+    *,
+    config: DailyLayer0Config,
+    live_price_fetcher: LivePriceFetcher,
+    news_fetcher: NewsFetcher,
+    fundamentals_fetcher: FundamentalsFetcher,
+    macro_fetcher: MacroFetcher,
+    writer: ObjectWriter,
+    price_serializer: RecordSerializer | None = None,
+    news_serializer: NewsSerializer | None = None,
+    fundamentals_serializer: RawRowSerializer | None = None,
+    macro_serializer: RawRowSerializer | None = None,
+    universe_serializer: UniverseSerializer | None = None,
+) -> Layer0PipelineResult:
+    """Run one daily Layer 0 ingest and write a success/failure manifest."""
+    run_id = config.run_id or f"layer0-daily-{config.as_of_date}"
+    started_at = datetime.now(UTC)
+    as_of_date = config.as_of_date
+    tickers = _normalize_tickers(config.tickers)
+    output_keys: list[str] = []
+    metadata: dict[str, object] = _base_metadata(
+        mode="daily_incremental",
+        from_date=as_of_date.isoformat(),
+        to_date=as_of_date.isoformat(),
+        fred_series_ids=_normalize_tokens(config.fred_series_ids),
+    )
+
+    try:
+        daily_records = live_price_fetcher.fetch_live_daily_bars(
+            tickers=tickers,
+            as_of_date=as_of_date.isoformat(),
+        )
+        price_result = _write_daily_prices(
+            records=daily_records,
+            overwrite=config.overwrite,
+            writer=writer,
+            serializer=price_serializer or _records_to_parquet_bytes,
+        )
+        output_keys.extend(price_result.output_keys)
+        metadata["prices"] = price_result.metadata
+
+        quality_window = _copy_ohlcv_window(config.quality_ohlcv_window)
+        for record in daily_records:
+            quality_window.setdefault(record.ticker.upper(), []).append(record)
+        universe_records = build_universe_mask_records(
+            as_of_date=as_of_date,
+            tickers=tickers,
+            ohlcv_window=quality_window,
+            quality_config=config.quality_config,
+        )
+        universe_result = _write_universe_mask(
+            as_of_date=as_of_date,
+            records=universe_records,
+            overwrite=config.overwrite,
+            writer=writer,
+            serializer=universe_serializer or _universe_to_csv_bytes,
+        )
+        output_keys.extend(universe_result.output_keys)
+        metadata["universe"] = universe_result.metadata
+
+        news_result = _backfill_news(
+            from_date=as_of_date,
+            to_date=as_of_date,
+            tickers=list(tickers),
+            limit=config.news_limit,
+            overwrite=config.overwrite,
+            fetcher=news_fetcher,
+            writer=writer,
+            serializer=news_serializer or _articles_to_jsonl_bytes,
+        )
+        output_keys.extend(news_result.output_keys)
+        metadata["news"] = news_result.metadata
+
+        fundamentals_key = raw_fundamentals_path(as_of_date, as_of_date)
+        fundamentals_result = _write_fundamentals_archive(
+            key=fundamentals_key,
+            from_date=as_of_date,
+            to_date=as_of_date,
+            tickers=list(tickers),
+            statements=config.simfin_statements,
+            periods=config.simfin_periods,
+            limit=config.simfin_limit,
+            overwrite=config.overwrite,
+            fetcher=fundamentals_fetcher,
+            writer=writer,
+            serializer=fundamentals_serializer or _raw_rows_to_parquet_bytes,
+        )
+        output_keys.extend(fundamentals_result.output_keys)
+        metadata["fundamentals"] = fundamentals_result.metadata
+
+        macro_key = raw_macro_path(as_of_date, as_of_date)
+        macro_result = _write_macro_archive(
+            key=macro_key,
+            from_date=as_of_date,
+            to_date=as_of_date,
+            series_ids=config.fred_series_ids,
+            limit=config.fred_limit,
+            overwrite=config.overwrite,
+            fetcher=macro_fetcher,
+            writer=writer,
+            serializer=macro_serializer or _raw_rows_to_parquet_bytes,
+        )
+        output_keys.extend(macro_result.output_keys)
+        metadata["macro"] = macro_result.metadata
+
+        manifest_key = _write_pipeline_manifest(
+            writer=writer,
+            run_id=run_id,
+            status=RunStatus.COMPLETED,
+            started_at=started_at,
+            metadata=metadata | {"output_keys": sorted(set(output_keys))},
+        )
+        return Layer0PipelineResult(
+            run_id=run_id,
+            manifest_key=manifest_key,
+            status=RunStatus.COMPLETED,
+            output_keys=tuple(sorted(set(output_keys + [manifest_key]))),
+            metadata=metadata,
+        )
+    except Exception as exc:
+        manifest_key = _write_failure_manifest(
+            writer=writer,
+            run_id=run_id,
+            started_at=started_at,
+            metadata=metadata,
+            output_keys=output_keys,
+            exc=exc,
+        )
+        output_keys.append(manifest_key)
+        raise
+
+
+def build_universe_mask_records(
+    *,
+    as_of_date: date,
+    tickers: Sequence[str],
+    ohlcv_window: Mapping[str, Sequence[OHLCVRecord]],
+    quality_config: QualityFilterConfig,
+) -> list[UniverseRecord]:
+    """Build schema-valid point-in-time universe rows with quality flags applied."""
+    records = [
+        build_universe_record(
+            {"date": as_of_date.isoformat(), "ticker": ticker, "in_universe": True}
+        )
+        for ticker in _normalize_tickers(tickers)
+    ]
+    return apply_quality_filters(records, ohlcv_window, quality_config)
+
+
+@dataclass(frozen=True)
+class _WriteResult:
+    output_keys: list[str]
+    metadata: dict[str, object]
+
+
+def _resolve_backfill_tickers(
+    *,
+    config: HistoricalLayer0Config,
+    universe_provider: HistoricalUniverseProvider,
+) -> list[str]:
+    if config.tickers is not None:
+        tickers = _normalize_tickers(config.tickers)
+    else:
+        tickers = _normalize_tickers(
+            universe_provider.get_historical_tickers(
+                config.from_date.isoformat(),
+                config.to_date.isoformat(),
+            )
+        )
+    if not tickers:
+        raise ValueError("historical backfill ticker universe is empty")
+    return list(tickers)
+
+
+def _backfill_historical_prices(
+    *,
+    config: HistoricalLayer0Config,
+    tickers: Sequence[str],
+    price_fetcher: HistoricalPriceFetcher,
+    security_master: SecurityMaster,
+    writer: ObjectWriter,
+    serializer: RecordSerializer,
+    quality_window: dict[str, list[OHLCVRecord]],
+) -> _WriteResult:
+    securities, missing_tickers = _resolve_securities(
+        security_master=security_master, tickers=tickers
+    )
+    active_securities = [
+        security
+        for security in securities
+        if _security_overlaps_range(security, config.from_date, config.to_date)
+    ]
+    grouped = _group_securities_by_id(active_securities)
+    output_keys: list[str] = []
+    written = 0
+    skipped = 0
+    empty = 0
+
+    reference_key = raw_security_master_path(config.to_date)
+    if not writer.exists(reference_key) or config.overwrite:
+        reference_payload = _security_reference_payload(
+            from_date=config.from_date,
+            to_date=config.to_date,
+            securities=active_securities,
+            missing_tickers=missing_tickers,
+        )
+        writer.put_object(reference_key, json.dumps(reference_payload, sort_keys=True))
+        output_keys.append(reference_key)
+    else:
+        skipped += 1
+
+    for security_id, security_rows in grouped.items():
+        key = raw_price_path(security_id)
+        if writer.exists(key) and not config.overwrite:
+            skipped += 1
+            continue
+
+        records: list[OHLCVRecord] = []
+        for security in security_rows:
+            fetch_from, fetch_to = _security_fetch_range(security, config.from_date, config.to_date)
+            fetched = price_fetcher.fetch_security_records(
+                security=security,
+                from_date=fetch_from.isoformat(),
+                to_date=fetch_to.isoformat(),
+            )
+            records.extend(fetched)
+            for record in fetched:
+                quality_window.setdefault(record.ticker.upper(), []).append(record)
+
+        if not records:
+            empty += 1
+            continue
+
+        writer.put_object(key, serializer(_sort_ohlcv_records(records)))
+        output_keys.append(key)
+        written += 1
+
+    return _WriteResult(
+        output_keys=output_keys,
+        metadata={
+            "requested_tickers": len(tickers),
+            "resolved_securities": len(grouped),
+            "written": written,
+            "skipped": skipped,
+            "empty": empty,
+            "missing_tickers": list(missing_tickers),
+            "reference_key": reference_key,
+            "output_keys": output_keys,
+        },
+    )
+
+
+def _write_historical_universe_masks(
+    *,
+    config: HistoricalLayer0Config,
+    universe_provider: HistoricalUniverseProvider,
+    writer: ObjectWriter,
+    ohlcv_window: Mapping[str, Sequence[OHLCVRecord]],
+    serializer: UniverseSerializer,
+) -> _WriteResult:
+    output_keys: list[str] = []
+    written = 0
+    skipped = 0
+    total_records = 0
+
+    for current_date in _business_days(config.from_date, config.to_date):
+        if writer.exists(raw_universe_path(current_date)) and not config.overwrite:
+            skipped += 1
+            continue
+        tickers = universe_provider.get_constituents(current_date.isoformat())
+        records = build_universe_mask_records(
+            as_of_date=current_date,
+            tickers=tickers,
+            ohlcv_window=ohlcv_window,
+            quality_config=config.quality_config,
+        )
+        result = _write_universe_mask(
+            as_of_date=current_date,
+            records=records,
+            overwrite=config.overwrite,
+            writer=writer,
+            serializer=serializer,
+        )
+        output_keys.extend(result.output_keys)
+        total_records += len(records)
+        written += int(result.metadata["written"])
+        skipped += int(result.metadata["skipped"])
+
+    return _WriteResult(
+        output_keys=output_keys,
+        metadata={
+            "requested_days": len(_business_days(config.from_date, config.to_date)),
+            "written": written,
+            "skipped": skipped,
+            "total_records": total_records,
+            "output_keys": output_keys,
+        },
+    )
+
+
+def _write_daily_prices(
+    *,
+    records: Sequence[OHLCVRecord],
+    overwrite: bool,
+    writer: ObjectWriter,
+    serializer: RecordSerializer,
+) -> _WriteResult:
+    grouped: dict[str, list[OHLCVRecord]] = {}
+    for record in records:
+        grouped.setdefault(record.ticker.upper(), []).append(record)
+
+    output_keys: list[str] = []
+    written = 0
+    skipped = 0
+    for ticker, ticker_records in sorted(grouped.items()):
+        key = raw_price_path(ticker)
+        if writer.exists(key) and not overwrite:
+            skipped += 1
+            continue
+        writer.put_object(key, serializer(_sort_ohlcv_records(ticker_records)))
+        output_keys.append(key)
+        written += 1
+
+    return _WriteResult(
+        output_keys=output_keys,
+        metadata={
+            "requested_records": len(records),
+            "written": written,
+            "skipped": skipped,
+            "empty": 0 if records else 1,
+            "output_keys": output_keys,
+        },
+    )
+
+
+def _write_universe_mask(
+    *,
+    as_of_date: date,
+    records: list[UniverseRecord],
+    overwrite: bool,
+    writer: ObjectWriter,
+    serializer: UniverseSerializer,
+) -> _WriteResult:
+    key = raw_universe_path(as_of_date)
+    if writer.exists(key) and not overwrite:
+        return _WriteResult(output_keys=[], metadata={"written": 0, "skipped": 1, "key": key})
+    writer.put_object(key, serializer(_sort_universe_records(records)))
+    return _WriteResult(
+        output_keys=[key],
+        metadata={"written": 1, "skipped": 0, "rows": len(records), "key": key},
+    )
+
+
+def _backfill_news(
+    *,
+    from_date: date,
+    to_date: date,
+    tickers: list[str],
+    limit: int,
+    overwrite: bool,
+    fetcher: NewsFetcher,
+    writer: ObjectWriter,
+    serializer: NewsSerializer,
+) -> _WriteResult:
+    output_keys: list[str] = []
+    written = 0
+    skipped = 0
+    empty = 0
+    total_articles = 0
+
+    for current_date in _date_range(from_date, to_date):
+        key = raw_news_path(current_date)
+        if writer.exists(key) and not overwrite:
+            skipped += 1
+            continue
+        articles = fetcher.fetch_news_day(
+            tickers=tickers,
+            as_of_date=current_date.isoformat(),
+            limit=limit,
+        )
+        if not articles:
+            empty += 1
+        total_articles += len(articles)
+        writer.put_object(key, serializer(_sort_articles(articles)))
+        output_keys.append(key)
+        written += 1
+
+    return _WriteResult(
+        output_keys=output_keys,
+        metadata={
+            "requested_days": len(_date_range(from_date, to_date)),
+            "written": written,
+            "skipped": skipped,
+            "empty": empty,
+            "total_articles": total_articles,
+            "output_keys": output_keys,
+        },
+    )
+
+
+def _write_fundamentals_archive(
+    *,
+    key: str,
+    from_date: date,
+    to_date: date,
+    tickers: Sequence[str],
+    statements: Sequence[str],
+    periods: Sequence[str],
+    limit: int,
+    overwrite: bool,
+    fetcher: FundamentalsFetcher,
+    writer: ObjectWriter,
+    serializer: RawRowSerializer,
+) -> _WriteResult:
+    if writer.exists(key) and not overwrite:
+        return _WriteResult(
+            output_keys=[],
+            metadata={"requested_tickers": len(tickers), "written": 0, "skipped": 1, "key": key},
+        )
+    rows = fetcher.fetch_all_fundamentals(
+        tickers=tickers,
+        start_date=from_date.isoformat(),
+        end_date=to_date.isoformat(),
+        statements=statements,
+        periods=periods,
+        retrieved_at=datetime.now(UTC),
+        limit=limit,
+    )
+    writer.put_object(key, serializer(_sort_raw_rows(rows, ("ticker", "report_date"))))
+    return _WriteResult(
+        output_keys=[key],
+        metadata={
+            "requested_tickers": len(tickers),
+            "written": 1,
+            "skipped": 0,
+            "empty": 0 if rows else 1,
+            "total_rows": len(rows),
+            "key": key,
+        },
+    )
+
+
+def _write_macro_archive(
+    *,
+    key: str,
+    from_date: date,
+    to_date: date,
+    series_ids: Sequence[str],
+    limit: int,
+    overwrite: bool,
+    fetcher: MacroFetcher,
+    writer: ObjectWriter,
+    serializer: RawRowSerializer,
+) -> _WriteResult:
+    if writer.exists(key) and not overwrite:
+        return _WriteResult(
+            output_keys=[],
+            metadata={"requested_series": len(series_ids), "written": 0, "skipped": 1, "key": key},
+        )
+    normalized_series = _normalize_tokens(series_ids)
+    rows = fetcher.fetch_all_macro_observations(
+        series_ids=normalized_series,
+        start_date=from_date.isoformat(),
+        end_date=to_date.isoformat(),
+        realtime_start=from_date.isoformat(),
+        realtime_end=to_date.isoformat(),
+        limit=limit,
+    )
+    writer.put_object(key, serializer(_sort_raw_rows(rows, ("series_id", "observation_date"))))
+    return _WriteResult(
+        output_keys=[key],
+        metadata={
+            "requested_series": len(normalized_series),
+            "written": 1,
+            "skipped": 0,
+            "empty": 0 if rows else 1,
+            "total_rows": len(rows),
+            "key": key,
+        },
+    )
+
+
+def _write_pipeline_manifest(
+    *,
+    writer: ObjectWriter,
+    run_id: str,
+    status: RunStatus,
+    started_at: datetime,
+    metadata: dict[str, object],
+) -> str:
+    manifest_key = pipeline_manifest_path("layer0", run_id)
+    manifest = PipelineManifestRecord(
+        run_id=run_id,
+        stage="layer0",
+        status=status,
+        started_at=started_at,
+        finished_at=datetime.now(UTC),
+        input_path="external:layer0",
+        output_path="raw/",
+        metadata=metadata,
+    )
+    writer.put_object(manifest_key, manifest.model_dump_json())
+    return manifest_key
+
+
+def _write_failure_manifest(
+    *,
+    writer: ObjectWriter,
+    run_id: str,
+    started_at: datetime,
+    metadata: dict[str, object],
+    output_keys: Sequence[str],
+    exc: Exception,
+) -> str:
+    failure_metadata = dict(metadata)
+    failure_metadata["output_keys"] = sorted(set(output_keys))
+    failure_metadata["error"] = {"type": type(exc).__name__, "message": str(exc)}
+    return _write_pipeline_manifest(
+        writer=writer,
+        run_id=run_id,
+        status=RunStatus.FAILED,
+        started_at=started_at,
+        metadata=failure_metadata,
+    )
+
+
+def _base_metadata(
+    *,
+    mode: str,
+    from_date: str,
+    to_date: str,
+    fred_series_ids: tuple[str, ...],
+) -> dict[str, object]:
+    return {
+        "mode": mode,
+        "from_date": from_date,
+        "to_date": to_date,
+        "input_families": {
+            "universe": "wikipedia_sp500_membership",
+            "prices": "tiingo_historical_or_alpaca_daily_bars",
+            "news": "tiingo_news",
+            "fundamentals": "simfin_as_reported",
+            "macro": "fred_macro_rates",
+            "manifest": "pipeline_manifest",
+        },
+        "fred_series_ids": list(fred_series_ids),
+    }
+
+
+def _records_to_parquet_bytes(records: list[OHLCVRecord]) -> bytes:
+    try:
+        import pandas as pd
+
+        importlib.import_module("pyarrow")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to serialize OHLCV records to Parquet."
+        ) from exc
+
+    frame = pd.DataFrame([record.model_dump() for record in records])
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def _raw_rows_to_parquet_bytes(rows: list[dict[str, object]]) -> bytes:
+    try:
+        import pandas as pd
+
+        importlib.import_module("pyarrow")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to serialize raw Layer 0 rows to Parquet."
+        ) from exc
+
+    frame = pd.DataFrame([_parquet_ready_row(row) for row in rows])
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def _parquet_ready_row(row: dict[str, object]) -> dict[str, object]:
+    output = dict(row)
+    raw = output.pop("raw", None)
+    if raw is not None:
+        output["raw_json"] = json.dumps(raw, sort_keys=True, separators=(",", ":"))
+    return output
+
+
+def _articles_to_jsonl_bytes(articles: list[dict[str, object]]) -> bytes:
+    if not articles:
+        return b""
+    lines = [json.dumps(article, sort_keys=True, separators=(",", ":")) for article in articles]
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def _universe_to_csv_bytes(records: list[UniverseRecord]) -> bytes:
+    buffer = io.StringIO()
+    fieldnames = [
+        "date",
+        "ticker",
+        "in_universe",
+        "tradable",
+        "liquid",
+        "halted",
+        "data_quality_ok",
+        "reason",
+    ]
+    writer = csv.DictWriter(buffer, fieldnames=fieldnames, lineterminator="\n")
+    writer.writeheader()
+    for record in records:
+        writer.writerow(record.model_dump())
+    return buffer.getvalue().encode("utf-8")
+
+
+def _copy_ohlcv_window(
+    window: Mapping[str, Sequence[OHLCVRecord]] | None,
+) -> dict[str, list[OHLCVRecord]]:
+    if window is None:
+        return {}
+    return {ticker.upper(): list(records) for ticker, records in window.items()}
+
+
+def _resolve_securities(
+    *,
+    security_master: SecurityMaster,
+    tickers: Sequence[str],
+) -> tuple[list[SecurityIdentity], tuple[str, ...]]:
+    resolved: list[SecurityIdentity] = []
+    missing: list[str] = []
+    seen_ids: set[tuple[str, str | None, str | None, str]] = set()
+    for ticker in tickers:
+        try:
+            securities = security_master.resolve_all(ticker)
+        except KeyError:
+            missing.append(ticker)
+            continue
+        for security in securities:
+            key = (security.ticker, security.start_date, security.end_date, security.security_id)
+            if key not in seen_ids:
+                seen_ids.add(key)
+                resolved.append(security)
+    return sorted(resolved, key=_security_sort_key), tuple(sorted(missing))
+
+
+def _group_securities_by_id(
+    securities: Iterable[SecurityIdentity],
+) -> dict[str, list[SecurityIdentity]]:
+    grouped: dict[str, list[SecurityIdentity]] = {}
+    for security in securities:
+        grouped.setdefault(security.security_id, []).append(security)
+    return {
+        security_id: sorted(rows, key=_security_sort_key)
+        for security_id, rows in sorted(grouped.items())
+    }
+
+
+def _security_reference_payload(
+    *,
+    from_date: date,
+    to_date: date,
+    securities: Sequence[SecurityIdentity],
+    missing_tickers: Sequence[str],
+) -> dict[str, object]:
+    return {
+        "source": "tiingo",
+        "from_date": from_date.isoformat(),
+        "to_date": to_date.isoformat(),
+        "generated_at": datetime.now(UTC).isoformat(),
+        "missing_tickers": list(missing_tickers),
+        "securities": [security.to_reference_row() for security in securities],
+    }
+
+
+def _security_overlaps_range(security: SecurityIdentity, from_date: date, to_date: date) -> bool:
+    if security.end_date is not None and date.fromisoformat(security.end_date) < from_date:
+        return False
+    if security.start_date is not None and date.fromisoformat(security.start_date) > to_date:
+        return False
+    return True
+
+
+def _security_fetch_range(
+    security: SecurityIdentity, from_date: date, to_date: date
+) -> tuple[date, date]:
+    fetch_from = (
+        max(from_date, date.fromisoformat(security.start_date))
+        if security.start_date
+        else from_date
+    )
+    fetch_to = min(to_date, date.fromisoformat(security.end_date)) if security.end_date else to_date
+    return fetch_from, fetch_to
+
+
+def _security_sort_key(security: SecurityIdentity) -> tuple[str, str, str, str]:
+    return (
+        security.security_id,
+        security.start_date or "0000-00-00",
+        security.end_date or "9999-99-99",
+        security.ticker,
+    )
+
+
+def _normalize_tickers(tickers: Iterable[str]) -> tuple[str, ...]:
+    normalized: set[str] = set()
+    for ticker in tickers:
+        if not isinstance(ticker, str):
+            raise TypeError("tickers must be strings")
+        cleaned = ticker.strip().upper()
+        if not cleaned:
+            raise ValueError("tickers cannot contain empty values")
+        normalized.add(cleaned)
+    return tuple(sorted(normalized))
+
+
+def _normalize_tokens(values: Sequence[str]) -> tuple[str, ...]:
+    normalized: set[str] = set()
+    for value in values:
+        if not isinstance(value, str):
+            raise TypeError("configured tokens must be strings")
+        cleaned = value.strip().upper()
+        if not cleaned:
+            raise ValueError("configured tokens cannot contain empty values")
+        normalized.add(cleaned)
+    return tuple(sorted(normalized))
+
+
+def _validate_date_window(from_date: date, to_date: date) -> None:
+    if from_date > to_date:
+        raise ValueError("from_date must be <= to_date")
+
+
+def _validate_positive_limit(value: int, field_name: str) -> None:
+    if value <= 0:
+        raise ValueError(f"{field_name} must be positive")
+
+
+def _date_range(start: date, end: date) -> list[date]:
+    days: list[date] = []
+    current = start
+    while current <= end:
+        days.append(current)
+        current += timedelta(days=1)
+    return days
+
+
+def _business_days(start: date, end: date) -> list[date]:
+    return [day for day in _date_range(start, end) if day.weekday() < 5]
+
+
+def _sort_ohlcv_records(records: Sequence[OHLCVRecord]) -> list[OHLCVRecord]:
+    return sorted(records, key=lambda record: (record.date, record.ticker))
+
+
+def _sort_universe_records(records: Sequence[UniverseRecord]) -> list[UniverseRecord]:
+    return sorted(records, key=lambda record: (record.date, record.ticker))
+
+
+def _sort_articles(articles: Sequence[dict[str, object]]) -> list[dict[str, object]]:
+    return sorted(
+        articles,
+        key=lambda article: (
+            str(article.get("publishedDate") or article.get("published_at") or ""),
+            str(article.get("id") or article.get("url") or ""),
+        ),
+    )
+
+
+def _sort_raw_rows(
+    rows: Sequence[dict[str, object]],
+    keys: Sequence[str],
+) -> list[dict[str, object]]:
+    return sorted(rows, key=lambda row: tuple(str(row.get(key) or "") for key in keys))

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any
+
+import pytest
+
+from core.contracts.schemas import OHLCVRecord, RunStatus
+from core.data.layer0_pipeline import (
+    DailyLayer0Config,
+    HistoricalLayer0Config,
+    build_universe_mask_records,
+    run_daily_layer0_incremental,
+    run_historical_layer0_backfill,
+)
+from core.data.quality import QualityFilterConfig
+from services.r2.paths import (
+    pipeline_manifest_path,
+    raw_fundamentals_path,
+    raw_macro_path,
+    raw_news_path,
+    raw_price_path,
+    raw_security_master_path,
+    raw_universe_path,
+)
+
+
+@dataclass(frozen=True)
+class _Security:
+    ticker: str
+    security_id: str
+    start_date: str | None = None
+    end_date: str | None = None
+
+    def to_reference_row(self) -> dict[str, str | None]:
+        return {
+            "ticker": self.ticker,
+            "security_id": self.security_id,
+            "perma_ticker": self.security_id,
+            "start_date": self.start_date,
+            "end_date": self.end_date,
+        }
+
+
+class _Writer:
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.put_counts: dict[str, int] = {}
+
+    def put_object(self, key: str, data: bytes | str) -> None:
+        self.objects[key] = data if isinstance(data, bytes) else data.encode("utf-8")
+        self.put_counts[key] = self.put_counts.get(key, 0) + 1
+
+    def exists(self, key: str) -> bool:
+        return key in self.objects
+
+
+class _UniverseProvider:
+    def __init__(self) -> None:
+        self.constituent_calls: list[str] = []
+
+    def get_constituents(self, as_of_date: str) -> list[str]:
+        self.constituent_calls.append(as_of_date)
+        return ["AAPL", "MSFT"]
+
+    def get_historical_tickers(self, from_date: str, to_date: str) -> set[str]:
+        return {"AAPL", "MSFT"}
+
+
+class _SecurityMaster:
+    def resolve_all(self, ticker: str) -> list[_Security]:
+        if ticker == "AAPL":
+            return [_Security(ticker="AAPL", security_id="perm-aapl", start_date="2020-01-01")]
+        if ticker == "MSFT":
+            return [_Security(ticker="MSFT", security_id="perm-msft", start_date="2020-01-01")]
+        raise KeyError(ticker)
+
+
+class _HistoricalPriceFetcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, str]] = []
+
+    def fetch_security_records(
+        self,
+        security: _Security,
+        from_date: str,
+        to_date: str,
+    ) -> list[OHLCVRecord]:
+        self.calls.append({"ticker": security.ticker, "from_date": from_date, "to_date": to_date})
+        return [_bar(date_value=from_date, ticker=security.ticker)]
+
+
+class _LivePriceFetcher:
+    def __init__(self, records: list[OHLCVRecord] | None = None) -> None:
+        self.records = records or [_bar(date_value="2024-01-02", ticker="AAPL")]
+        self.calls: list[dict[str, Any]] = []
+
+    def fetch_live_daily_bars(
+        self, *, tickers: list[str] | tuple[str, ...], as_of_date: str
+    ) -> list[OHLCVRecord]:
+        self.calls.append({"tickers": tuple(tickers), "as_of_date": as_of_date})
+        return self.records
+
+
+class _NewsFetcher:
+    def __init__(self, should_raise: bool = False) -> None:
+        self.should_raise = should_raise
+        self.calls: list[dict[str, Any]] = []
+
+    def fetch_news_day(
+        self,
+        *,
+        tickers: list[str] | None,
+        as_of_date: str,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        self.calls.append({"tickers": tickers, "as_of_date": as_of_date, "limit": limit})
+        if self.should_raise:
+            raise RuntimeError("news unavailable")
+        return [{"id": f"news-{as_of_date}", "publishedDate": as_of_date, "tickers": tickers or []}]
+
+
+class _FundamentalsFetcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def fetch_all_fundamentals(
+        self,
+        *,
+        tickers: list[str] | tuple[str, ...],
+        start_date: str,
+        end_date: str,
+        statements: list[str] | tuple[str, ...],
+        periods: list[str] | tuple[str, ...],
+        retrieved_at: datetime | None,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        self.calls.append(
+            {
+                "tickers": tuple(tickers),
+                "start_date": start_date,
+                "end_date": end_date,
+                "statements": tuple(statements),
+                "periods": tuple(periods),
+                "retrieved_at": retrieved_at,
+                "limit": limit,
+            }
+        )
+        return [{"ticker": tickers[0], "report_date": start_date, "raw": {"x": 1}}]
+
+
+class _MacroFetcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def fetch_all_macro_observations(
+        self,
+        *,
+        series_ids: list[str] | tuple[str, ...],
+        start_date: str,
+        end_date: str,
+        realtime_start: str | None,
+        realtime_end: str | None,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        self.calls.append(
+            {
+                "series_ids": tuple(series_ids),
+                "start_date": start_date,
+                "end_date": end_date,
+                "realtime_start": realtime_start,
+                "realtime_end": realtime_end,
+                "limit": limit,
+            }
+        )
+        return [{"series_id": series_ids[0], "observation_date": start_date, "value": "1.0"}]
+
+
+def _bar(*, date_value: str, ticker: str, dollar_volume: float = 2_000_000.0) -> OHLCVRecord:
+    return OHLCVRecord(
+        date=date_value,
+        ticker=ticker,
+        open=10.0,
+        high=11.0,
+        low=9.0,
+        close=10.5,
+        volume=100_000,
+        adj_close=10.5,
+        dollar_volume=dollar_volume,
+    )
+
+
+def _bytes_serializer(rows: list[Any]) -> bytes:
+    payload = [row.model_dump() if hasattr(row, "model_dump") else row for row in rows]
+    return json.dumps(payload, sort_keys=True, default=str).encode("utf-8")
+
+
+def _manifest(writer: _Writer, run_id: str) -> dict[str, Any]:
+    key = pipeline_manifest_path("layer0", run_id)
+    return json.loads(writer.objects[key])
+
+
+def test_build_universe_mask_records_applies_quality_filters() -> None:
+    records = build_universe_mask_records(
+        as_of_date=date(2024, 1, 2),
+        tickers=["aapl", "msft"],
+        ohlcv_window={"AAPL": [_bar(date_value="2024-01-02", ticker="AAPL")]},
+        quality_config=QualityFilterConfig(rolling_window_days=1),
+    )
+
+    by_ticker = {record.ticker: record for record in records}
+    assert by_ticker["AAPL"].data_quality_ok is True
+    assert by_ticker["MSFT"].data_quality_ok is False
+    assert by_ticker["MSFT"].reason == "missing_ohlcv_window"
+
+
+def test_historical_layer0_backfill_writes_all_raw_archives_and_manifest() -> None:
+    writer = _Writer()
+    run_id = "test-historical"
+    config = HistoricalLayer0Config(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 3),
+        fred_series_ids=("DGS10",),
+        run_id=run_id,
+        quality_config=QualityFilterConfig(rolling_window_days=1),
+    )
+
+    result = run_historical_layer0_backfill(
+        config=config,
+        universe_provider=_UniverseProvider(),
+        price_fetcher=_HistoricalPriceFetcher(),
+        security_master=_SecurityMaster(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+    )
+
+    expected_keys = {
+        raw_security_master_path(date(2024, 1, 3)),
+        raw_price_path("perm-aapl"),
+        raw_price_path("perm-msft"),
+        raw_universe_path("2024-01-02"),
+        raw_universe_path("2024-01-03"),
+        raw_news_path("2024-01-02"),
+        raw_news_path("2024-01-03"),
+        raw_fundamentals_path("2024-01-02", "2024-01-03"),
+        raw_macro_path("2024-01-02", "2024-01-03"),
+        pipeline_manifest_path("layer0", run_id),
+    }
+    assert expected_keys.issubset(writer.objects)
+    assert result.status == RunStatus.COMPLETED
+    manifest = _manifest(writer, run_id)
+    assert manifest["status"] == "completed"
+    assert set(manifest["metadata"]["input_families"]) == {
+        "universe",
+        "prices",
+        "news",
+        "fundamentals",
+        "macro",
+        "manifest",
+    }
+
+    universe_rows = list(
+        csv.DictReader(io.StringIO(writer.objects[raw_universe_path("2024-01-02")].decode()))
+    )
+    assert [row["ticker"] for row in universe_rows] == ["AAPL", "MSFT"]
+
+
+def test_daily_layer0_incremental_uses_alpaca_shape_and_canonical_paths() -> None:
+    writer = _Writer()
+    run_id = "test-daily"
+    config = DailyLayer0Config(
+        as_of_date=date(2024, 1, 2),
+        tickers=("AAPL",),
+        fred_series_ids=("dgs10",),
+        run_id=run_id,
+        quality_config=QualityFilterConfig(rolling_window_days=1),
+    )
+    live_fetcher = _LivePriceFetcher()
+
+    result = run_daily_layer0_incremental(
+        config=config,
+        live_price_fetcher=live_fetcher,
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+    )
+
+    assert live_fetcher.calls == [{"tickers": ("AAPL",), "as_of_date": "2024-01-02"}]
+    assert raw_price_path("AAPL") in writer.objects
+    assert raw_news_path("2024-01-02") in writer.objects
+    assert raw_fundamentals_path("2024-01-02", "2024-01-02") in writer.objects
+    assert raw_macro_path("2024-01-02", "2024-01-02") in writer.objects
+    assert raw_universe_path("2024-01-02") in writer.objects
+    assert pipeline_manifest_path("layer0", run_id) in writer.objects
+    assert result.status == RunStatus.COMPLETED
+
+    price_payload = json.loads(writer.objects[raw_price_path("AAPL")])
+    assert price_payload[0]["ticker"] == "AAPL"
+    assert price_payload[0]["date"] == "2024-01-02"
+
+
+def test_daily_layer0_incremental_is_idempotent_for_existing_raw_outputs() -> None:
+    writer = _Writer()
+    keys = [
+        raw_price_path("AAPL"),
+        raw_news_path("2024-01-02"),
+        raw_fundamentals_path("2024-01-02", "2024-01-02"),
+        raw_macro_path("2024-01-02", "2024-01-02"),
+        raw_universe_path("2024-01-02"),
+    ]
+    for key in keys:
+        writer.put_object(key, b"existing")
+        writer.put_counts[key] = 0
+
+    run_daily_layer0_incremental(
+        config=DailyLayer0Config(
+            as_of_date=date(2024, 1, 2),
+            tickers=("AAPL",),
+            fred_series_ids=("DGS10",),
+            run_id="test-idempotent",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        live_price_fetcher=_LivePriceFetcher(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+    )
+
+    assert {key: writer.put_counts[key] for key in keys} == {key: 0 for key in keys}
+    assert writer.objects[pipeline_manifest_path("layer0", "test-idempotent")]
+
+
+def test_layer0_pipeline_writes_failure_manifest_before_reraising() -> None:
+    writer = _Writer()
+    run_id = "test-failure"
+
+    with pytest.raises(RuntimeError, match="news unavailable"):
+        run_daily_layer0_incremental(
+            config=DailyLayer0Config(
+                as_of_date=date(2024, 1, 2),
+                tickers=("AAPL",),
+                fred_series_ids=("DGS10",),
+                run_id=run_id,
+                quality_config=QualityFilterConfig(rolling_window_days=1),
+            ),
+            live_price_fetcher=_LivePriceFetcher(),
+            news_fetcher=_NewsFetcher(should_raise=True),
+            fundamentals_fetcher=_FundamentalsFetcher(),
+            macro_fetcher=_MacroFetcher(),
+            writer=writer,
+            price_serializer=_bytes_serializer,
+            news_serializer=_bytes_serializer,
+            fundamentals_serializer=_bytes_serializer,
+            macro_serializer=_bytes_serializer,
+        )
+
+    manifest = _manifest(writer, run_id)
+    assert manifest["status"] == "failed"
+    assert manifest["metadata"]["error"] == {
+        "type": "RuntimeError",
+        "message": "news unavailable",
+    }
+    assert raw_price_path("AAPL") in manifest["metadata"]["output_keys"]
+
+
+def test_layer0_config_rejects_empty_inputs() -> None:
+    with pytest.raises(ValueError, match="tickers"):
+        DailyLayer0Config(
+            as_of_date=date(2024, 1, 2),
+            tickers=(),
+            fred_series_ids=("DGS10",),
+        )
+    with pytest.raises(ValueError, match="fred_series_ids"):
+        HistoricalLayer0Config(
+            from_date=date(2024, 1, 2),
+            to_date=date(2024, 1, 3),
+            fred_series_ids=(),
+        )

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -275,6 +275,46 @@ def test_historical_layer0_backfill_writes_all_raw_archives_and_manifest() -> No
     assert [row["ticker"] for row in universe_rows] == ["AAPL", "MSFT"]
 
 
+def test_historical_backfill_fetches_existing_price_archives_for_quality_masks() -> None:
+    writer = _Writer()
+    price_keys = [raw_price_path("perm-aapl"), raw_price_path("perm-msft")]
+    for key in price_keys:
+        writer.put_object(key, b"existing-price-archive")
+        writer.put_counts[key] = 0
+    price_fetcher = _HistoricalPriceFetcher()
+
+    run_historical_layer0_backfill(
+        config=HistoricalLayer0Config(
+            from_date=date(2024, 1, 2),
+            to_date=date(2024, 1, 2),
+            fred_series_ids=("DGS10",),
+            run_id="test-existing-price-quality",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        universe_provider=_UniverseProvider(),
+        price_fetcher=price_fetcher,
+        security_master=_SecurityMaster(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+    )
+
+    assert {key: writer.put_counts[key] for key in price_keys} == {key: 0 for key in price_keys}
+    assert [call["ticker"] for call in price_fetcher.calls] == ["AAPL", "MSFT"]
+    universe_rows = list(
+        csv.DictReader(io.StringIO(writer.objects[raw_universe_path("2024-01-02")].decode()))
+    )
+    assert {row["ticker"]: row["data_quality_ok"] for row in universe_rows} == {
+        "AAPL": "True",
+        "MSFT": "True",
+    }
+
+
 def test_daily_layer0_incremental_uses_alpaca_shape_and_canonical_paths() -> None:
     writer = _Writer()
     run_id = "test-daily"
@@ -312,6 +352,41 @@ def test_daily_layer0_incremental_uses_alpaca_shape_and_canonical_paths() -> Non
     price_payload = json.loads(writer.objects[raw_price_path("AAPL")])
     assert price_payload[0]["ticker"] == "AAPL"
     assert price_payload[0]["date"] == "2024-01-02"
+
+
+def test_daily_layer0_incremental_canonicalizes_dot_tickers_across_outputs() -> None:
+    writer = _Writer()
+    live_fetcher = _LivePriceFetcher(records=[_bar(date_value="2024-01-02", ticker="BRK.B")])
+
+    run_daily_layer0_incremental(
+        config=DailyLayer0Config(
+            as_of_date=date(2024, 1, 2),
+            tickers=("brk.b",),
+            fred_series_ids=("DGS10",),
+            run_id="test-dot-ticker",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        live_price_fetcher=live_fetcher,
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+    )
+
+    assert live_fetcher.calls == [{"tickers": ("BRK-B",), "as_of_date": "2024-01-02"}]
+    assert raw_price_path("BRK-B") in writer.objects
+    price_payload = json.loads(writer.objects[raw_price_path("BRK-B")])
+    assert price_payload[0]["ticker"] == "BRK-B"
+
+    universe_rows = list(
+        csv.DictReader(io.StringIO(writer.objects[raw_universe_path("2024-01-02")].decode()))
+    )
+    assert universe_rows[0]["ticker"] == "BRK-B"
+    assert universe_rows[0]["data_quality_ok"] == "True"
 
 
 def test_daily_layer0_incremental_is_idempotent_for_existing_raw_outputs() -> None:


### PR DESCRIPTION
## What this PR does
Adds complete Layer 0 orchestration for historical and daily raw-data ingestion. The new core pipeline coordinates universe masks, prices, news, SimFin fundamentals, FRED macro/rates, canonical R2 writes, and success/failure pipeline manifests. It also adds runnable historical backfill and Pi daily incremental entrypoints.

## Closes
Closes #51

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing data-quality window, and failure manifest behavior
- [x] No live API calls in unit tests — fixtures/fakes used from `data/sample/` patterns

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Validated locally:
- `python -m ruff check .`
- `pytest tests/unit/ -v --tb=short` → 250 passed

## Notes for reviewer
- Unit tests mock Wikipedia/Tiingo/SimFin/FRED/Alpaca/R2; no live external calls are made.
- Daily prices are written through the same OHLCV contract and canonical raw price path, using ticker as the live snapshot security key until Layer 1 consumes the archived data.
- The pipeline writes a `PipelineManifestRecord` on both success and failure, with metadata covering all Layer 0 input families.