### PR TITLE
[codex] Add config env examples

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -2,23 +2,45 @@
 
 Non-secret project configuration.
 
-This folder contains schemas, examples, and static policy/configuration files that are safe to commit.
+This folder contains examples and static policy/configuration files that are safe to commit.
+Real credentials belong in local-only `config/*.env` files or a secret manager, never in git.
 
-Typical contents:
-- JSON schemas
-- non-secret execution settings
-- contract definitions
-- example environment files
-- policy and threshold documents
-- requirement split notes in `config/requirements/`
+## Local env files
 
-Do **not** commit real secrets here.
-Use `config/alpaca.env.example` as the template and keep the real `config/alpaca.env` local only.
-Use `config/r2.env` for local-only Cloudflare R2 credentials; the R2 client loads it
-automatically when present.
-Use `config/examples/simfin.env.example` as the template and keep the real
-`config/simfin.env` local only.
-Use `config/examples/fred.env.example` as the template and keep the real
-`config/fred.env` local only.
-Use `config/fred_series.json` for the default FRED macro/rate series and backfill
-date range.
+Copy the examples you need from `config/examples/` into `config/`:
+
+```bash
+cp config/examples/r2.env.example config/r2.env
+cp config/examples/tiingo.env.example config/tiingo.env
+cp config/examples/simfin.env.example config/simfin.env
+cp config/examples/fred.env.example config/fred.env
+cp config/examples/alpaca.env.example config/alpaca.env
+```
+
+Then replace the placeholder values in the local files.
+
+| Local file | Used for | Required keys |
+|---|---|---|
+| `config/r2.env` | Cloudflare R2 object storage | `R2_ENDPOINT_URL`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET_NAME` |
+| `config/tiingo.env` | Tiingo historical OHLCV and raw news | `TIINGO_API_TOKEN` |
+| `config/simfin.env` | SimFin as-reported fundamentals | `SIMFIN_API_KEY` |
+| `config/fred.env` | FRED macro/rate observations | `FRED_API_KEY` |
+| `config/alpaca.env` | Alpaca live daily bars | `ALPACA_API_KEY_ID`, `ALPACA_API_SECRET_KEY` |
+
+Alpaca also accepts the official `APCA_API_KEY_ID` and `APCA_API_SECRET_KEY` names.
+
+## Cloudflare R2 values
+
+For `config/r2.env`:
+
+- `R2_ENDPOINT_URL`: the S3 API endpoint from Cloudflare, usually `https://<account-id>.r2.cloudflarestorage.com`.
+- `R2_ACCESS_KEY_ID`: the access key ID from an R2 API token/access key.
+- `R2_SECRET_ACCESS_KEY`: the secret access key shown when the R2 access key is created.
+- `R2_BUCKET_NAME`: the exact bucket name created in R2 for this project.
+
+Use an R2 token/access key with read/write access to the bucket. Do not use the Cloudflare global API key.
+
+## Static config
+
+- `config/fred_series.json` controls the default FRED macro/rate series and historical backfill date range.
+- `config/requirements/` is deprecated; dependency files live under repository-root `requirements/`.

--- a/config/examples/alpaca.env.example
+++ b/config/examples/alpaca.env.example
@@ -1,0 +1,15 @@
+# Alpaca market-data and trading credentials.
+# Copy this file to config/alpaca.env and replace placeholders with local secrets.
+# Never commit config/alpaca.env.
+
+# Preferred names used by this repository.
+ALPACA_API_KEY_ID=replace_with_alpaca_key_id
+ALPACA_API_SECRET_KEY=replace_with_alpaca_secret_key
+
+# Optional market-data overrides. Defaults are shown here.
+ALPACA_DATA_BASE_URL=https://data.alpaca.markets
+ALPACA_DATA_FEED=iex
+
+# The code also accepts Alpaca's APCA-prefixed names instead of the two preferred names above.
+# APCA_API_KEY_ID=replace_with_alpaca_key_id
+# APCA_API_SECRET_KEY=replace_with_alpaca_secret_key

--- a/config/examples/fred.env.example
+++ b/config/examples/fred.env.example
@@ -1,2 +1,8 @@
-FRED_API_KEY=replace_me
+# FRED macro/rates API.
+# Copy this file to config/fred.env and replace placeholders with local secrets.
+# Never commit config/fred.env.
+
+FRED_API_KEY=replace_with_fred_api_key
+
+# Optional. The code defaults to https://api.stlouisfed.org/fred when omitted.
 FRED_BASE_URL=https://api.stlouisfed.org/fred

--- a/config/examples/r2.env.example
+++ b/config/examples/r2.env.example
@@ -1,0 +1,15 @@
+# Cloudflare R2 S3-compatible object storage.
+# Copy this file to config/r2.env and replace placeholders with local secrets.
+# Never commit config/r2.env.
+
+# Cloudflare R2 S3 API endpoint. Format:
+# https://<cloudflare-account-id>.r2.cloudflarestorage.com
+R2_ENDPOINT_URL=https://replace_with_account_id.r2.cloudflarestorage.com
+
+# R2 access keys from Cloudflare Dashboard -> R2 -> Manage R2 API Tokens.
+# Use an R2 token/access key with read/write access to the bucket below.
+R2_ACCESS_KEY_ID=replace_with_r2_access_key_id
+R2_SECRET_ACCESS_KEY=replace_with_r2_secret_access_key
+
+# Exact R2 bucket name used for this project, for example ai-stock-trader-layer0.
+R2_BUCKET_NAME=replace_with_bucket_name

--- a/config/examples/simfin.env.example
+++ b/config/examples/simfin.env.example
@@ -1,2 +1,8 @@
-SIMFIN_API_KEY=replace_me
+# SimFin as-reported fundamentals API.
+# Copy this file to config/simfin.env and replace placeholders with local secrets.
+# Never commit config/simfin.env.
+
+SIMFIN_API_KEY=replace_with_simfin_api_key
+
+# Optional. The code defaults to https://simfin.com/api/v3 when omitted.
 SIMFIN_BASE_URL=https://simfin.com/api/v3

--- a/config/examples/tiingo.env.example
+++ b/config/examples/tiingo.env.example
@@ -1,0 +1,9 @@
+# Tiingo market/news data API.
+# Copy this file to config/tiingo.env and replace placeholders with local secrets.
+# Never commit config/tiingo.env.
+
+# Tiingo account API token from https://www.tiingo.com/account/api/token.
+TIINGO_API_TOKEN=replace_with_tiingo_api_token
+
+# Optional. The code defaults to https://api.tiingo.com when omitted.
+# TIINGO_BASE_URL=https://api.tiingo.com

--- a/services/tiingo/ohlcv_fetcher.py
+++ b/services/tiingo/ohlcv_fetcher.py
@@ -4,10 +4,12 @@ import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from datetime import date as Date
+from pathlib import Path
 from typing import Any
 from urllib.parse import quote
 
 import requests
+from dotenv import load_dotenv
 
 from core.contracts.schemas import OHLCVRecord
 from core.data.ohlcv import build_ohlcv_record
@@ -15,6 +17,7 @@ from services.tiingo.security_master import TiingoSecurity
 
 TIINGO_API_TOKEN_ENV = "TIINGO_API_TOKEN"
 DEFAULT_TIINGO_BASE_URL = "https://api.tiingo.com"
+TIINGO_ENV_FILE = Path(__file__).resolve().parents[2] / "config" / "tiingo.env"
 
 
 @dataclass(frozen=True)
@@ -27,10 +30,13 @@ class TiingoClientConfig:
 
     @classmethod
     def from_env(cls) -> TiingoClientConfig:
-        """Build Tiingo config from environment variables."""
+        """Build Tiingo config from environment variables or config/tiingo.env."""
+        _load_local_tiingo_env_file()
         token = os.getenv(TIINGO_API_TOKEN_ENV)
         if not token:
-            raise ValueError(f"Missing required Tiingo environment variable: {TIINGO_API_TOKEN_ENV}")
+            raise ValueError(
+                f"Missing required Tiingo environment variable: {TIINGO_API_TOKEN_ENV}"
+            )
         return cls(api_token=token)
 
 
@@ -91,7 +97,9 @@ class TiingoOHLCVFetcher:
         return self.fetch_records(ticker=security.ticker, from_date=from_date, to_date=to_date)
 
 
-def normalize_tiingo_price_rows(ticker: str, rows: Sequence[Mapping[str, Any]]) -> list[OHLCVRecord]:
+def normalize_tiingo_price_rows(
+    ticker: str, rows: Sequence[Mapping[str, Any]]
+) -> list[OHLCVRecord]:
     """Normalize raw Tiingo price rows into schema-valid OHLCV records."""
     normalized_ticker = _normalize_ticker(ticker)
     records: list[OHLCVRecord] = []
@@ -154,3 +162,8 @@ def _normalize_ticker(ticker: str) -> str:
     if not normalized:
         raise ValueError("ticker cannot be empty")
     return normalized
+
+
+def _load_local_tiingo_env_file() -> None:
+    """Load local Tiingo settings from config/tiingo.env when the file exists."""
+    load_dotenv(dotenv_path=TIINGO_ENV_FILE, override=False)

--- a/tests/unit/test_tiingo_ohlcv_fetcher.py
+++ b/tests/unit/test_tiingo_ohlcv_fetcher.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import pytest
 
+import services.tiingo.ohlcv_fetcher as ohlcv_fetcher_module
 from app.lab.data_pipelines import backfill_ohlcv as backfill_module
 from app.lab.data_pipelines.backfill_ohlcv import backfill_ohlcv_archive
 from core.contracts.schemas import OHLCVRecord
@@ -25,6 +26,16 @@ from services.tiingo.security_master import (
 )
 
 FIXTURE_PATH = Path("data/sample/tiingo_ohlcv_response.json")
+
+
+@pytest.fixture(autouse=True)
+def no_local_tiingo_env_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep unit tests isolated from a developer's local config/tiingo.env."""
+    monkeypatch.setattr(
+        ohlcv_fetcher_module,
+        "TIINGO_ENV_FILE",
+        tmp_path / "does-not-exist-tiingo.env",
+    )
 
 
 class _FakeResponse:
@@ -106,6 +117,21 @@ def test_client_config_from_env_rejects_missing_token(monkeypatch: pytest.Monkey
 
     with pytest.raises(ValueError, match="TIINGO_API_TOKEN"):
         TiingoClientConfig.from_env()
+
+
+def test_client_config_from_env_loads_local_config_file(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Tiingo config loads config/tiingo.env when shell variables are absent."""
+    env_file = tmp_path / "tiingo.env"
+    env_file.write_text("TIINGO_API_TOKEN=file-token\n", encoding="utf-8")
+    monkeypatch.delenv("TIINGO_API_TOKEN", raising=False)
+    monkeypatch.setattr(ohlcv_fetcher_module, "TIINGO_ENV_FILE", env_file)
+
+    config = TiingoClientConfig.from_env()
+
+    assert config.api_token == "file-token"
 
 
 def test_fetch_price_rows_calls_tiingo_historical_endpoint() -> None:
@@ -267,8 +293,18 @@ def test_security_master_resolve_many_preserves_reused_ticker_rows() -> None:
     """A reused ticker resolves to every historical security row, not just the latest one."""
     master = TiingoSecurityMaster.from_rows(
         [
-            {"ticker": "XYZ", "permaTicker": "PT_XYZ_OLD", "startDate": "2010-01-01", "endDate": "2012-12-31"},
-            {"ticker": "XYZ", "permaTicker": "PT_XYZ_NEW", "startDate": "2020-01-01", "endDate": None},
+            {
+                "ticker": "XYZ",
+                "permaTicker": "PT_XYZ_OLD",
+                "startDate": "2010-01-01",
+                "endDate": "2012-12-31",
+            },
+            {
+                "ticker": "XYZ",
+                "permaTicker": "PT_XYZ_NEW",
+                "startDate": "2020-01-01",
+                "endDate": None,
+            },
         ]
     )
 
@@ -529,7 +565,9 @@ def test_backfill_clamps_fetch_window_to_security_active_dates() -> None:
         ]
     )
     writer = _FakeWriter()
-    fetcher = _FakeFetcher({"ABC": normalize_tiingo_price_rows("ABC", _fixture_payload()["prices"])})
+    fetcher = _FakeFetcher(
+        {"ABC": normalize_tiingo_price_rows("ABC", _fixture_payload()["prices"])}
+    )
 
     backfill_ohlcv_archive(
         from_date=date(2014, 1, 1),
@@ -549,7 +587,9 @@ def test_backfill_is_idempotent_for_existing_price_archive() -> None:
     master = TiingoSecurityMaster.from_rows(_fixture_payload()["security_master"])
     price_key = raw_price_path("PT_AAPL_001")
     writer = _FakeWriter(existing={price_key})
-    fetcher = _FakeFetcher({"AAPL": normalize_tiingo_price_rows("AAPL", _fixture_payload()["prices"])})
+    fetcher = _FakeFetcher(
+        {"AAPL": normalize_tiingo_price_rows("AAPL", _fixture_payload()["prices"])}
+    )
 
     result = backfill_ohlcv_archive(
         from_date=date(2024, 1, 2),


### PR DESCRIPTION
## What this PR does
Adds public-safe `.env.example` templates for the Layer 0 provider stack and documents exactly which local `config/*.env` files to create before running the production data pull.

This also fixes a config consistency gap: Tiingo now loads `config/tiingo.env` the same way R2, SimFin, FRED, and Alpaca already load their local env files. Without that change, the new Tiingo example would not have matched runtime behavior.

## Closes
Refs #68

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover local Tiingo env-file loading
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Validated locally:
- `python -m ruff check .`
- `pytest tests/unit/ -v --tb=short` → 253 passed

## Notes for reviewer
- This PR intentionally does not close #68. The issue remains blocked until real Tiingo, SimFin, FRED, Alpaca, and R2 credentials are available and the production R2 data pull is actually run.
- All added env files are examples with placeholders only; no secrets are committed.