### PR TITLE
[codex] Ignore local Codex state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,6 @@ $RECYCLE.BIN/
 # Backtest outputs — large, stored in R2
 artifacts/backtests/results/
 artifacts/backtests/equity_curves/
+
+# AI
+.codex


### PR DESCRIPTION
## What this PR does
Adds `.codex` to `.gitignore` so local Codex state files do not show up as accidental repository changes.

This PR intentionally does not include any `config/*.env` files. Real provider credentials must remain local-only and should never be committed.

## Closes
Refs #68

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [ ] `pytest tests/unit/ -v --tb=short` passes with zero failures
- [ ] New public functions have at least one unit test each
- [ ] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Not run; `.gitignore` only.

## Notes for reviewer
#68 remains open and blocked until the remaining real local provider credentials are present and the production R2 backfill can run.