### PR TITLE
[Codex] M2.9 Label generation

### DIFF
--- a/app/lab/data_pipelines/run_label_generation.py
+++ b/app/lab/data_pipelines/run_label_generation.py
@@ -1,0 +1,210 @@
+"""Modal-ready Layer 1 label-generation runner.
+
+Reads OHLCV archives from R2 (`raw/prices/{TICKER}.parquet`), computes forward
+returns + survival flags via `core.labels`, and persists per-(date, ticker)
+shards to `labels/layer1/{date}/{ticker}.parquet`. A pipeline manifest is
+written on completion or failure.
+
+This module operates exclusively on Layer 0 R2 archives — no external provider
+calls — in line with AGENTS.md and `docs/data_contracts.md`.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+from loguru import logger
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(_REPO_ROOT))
+
+from core.contracts.schemas import PipelineManifestRecord, RunStatus  # noqa: E402
+from core.features.loaders import load_ohlcv_frame  # noqa: E402
+from core.labels import (  # noqa: E402
+    compute_forward_return_labels,
+    forward_return_labels_to_records,
+    write_label_record,
+)
+from services.r2.paths import pipeline_manifest_path  # noqa: E402
+from services.r2.writer import R2Writer  # noqa: E402
+
+LABEL_STAGE = "layer1_labels"
+
+
+class ObjectStore(Protocol):
+    """Object-store operations required by the label runner."""
+
+    def put_object(self, key: str, data: bytes | str) -> None:
+        """Write an object to storage."""
+
+    def get_object(self, key: str) -> bytes:
+        """Read an object from storage."""
+
+
+@dataclass(frozen=True)
+class LabelGenerationConfig:
+    """Configuration for one label-generation run."""
+
+    run_id: str
+    tickers: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        """Validate run identity and ticker list."""
+        if not self.run_id.strip():
+            raise ValueError("run_id cannot be empty")
+        if not self.tickers:
+            raise ValueError("at least one ticker must be supplied")
+        for ticker in self.tickers:
+            if not ticker.strip():
+                raise ValueError("tickers cannot contain empty strings")
+
+
+@dataclass(frozen=True)
+class LabelGenerationResult:
+    """Summary of one label-generation run."""
+
+    run_id: str
+    tickers_processed: int
+    shards_written: int
+    started_at: datetime
+    finished_at: datetime
+    manifest_key: str
+
+
+def run_label_generation(
+    config: LabelGenerationConfig,
+    *,
+    writer: ObjectStore | None = None,
+    now: datetime | None = None,
+) -> LabelGenerationResult:
+    """Compute forward-return labels for every requested ticker and persist them."""
+    started = (now or datetime.now(UTC)).replace(microsecond=0)
+    active_writer = writer or R2Writer()
+
+    shards_written = 0
+    try:
+        for ticker in config.tickers:
+            logger.info("Generating labels for ticker={}", ticker)
+            ohlcv = load_ohlcv_frame(ticker, writer=active_writer)
+            labels = compute_forward_return_labels(ohlcv, ticker)
+            for record in forward_return_labels_to_records(labels):
+                write_label_record(record, writer=active_writer)
+                shards_written += 1
+        finished = (now or datetime.now(UTC)).replace(microsecond=0)
+        manifest_key = _write_manifest(
+            active_writer,
+            run_id=config.run_id,
+            status=RunStatus.COMPLETED,
+            started_at=started,
+            finished_at=finished,
+            metadata={
+                "tickers_processed": len(config.tickers),
+                "shards_written": shards_written,
+            },
+        )
+        logger.info(
+            "Label generation finished run_id={} shards={}",
+            config.run_id,
+            shards_written,
+        )
+        return LabelGenerationResult(
+            run_id=config.run_id,
+            tickers_processed=len(config.tickers),
+            shards_written=shards_written,
+            started_at=started,
+            finished_at=finished,
+            manifest_key=manifest_key,
+        )
+    except Exception:
+        finished = (now or datetime.now(UTC)).replace(microsecond=0)
+        _write_manifest(
+            active_writer,
+            run_id=config.run_id,
+            status=RunStatus.FAILED,
+            started_at=started,
+            finished_at=finished,
+            metadata={
+                "tickers_processed": len(config.tickers),
+                "shards_written": shards_written,
+            },
+        )
+        raise
+
+
+def _write_manifest(
+    writer: ObjectStore,
+    *,
+    run_id: str,
+    status: RunStatus,
+    started_at: datetime,
+    finished_at: datetime,
+    metadata: dict,
+) -> str:
+    """Persist a pipeline manifest entry for the label run."""
+    manifest = PipelineManifestRecord(
+        run_id=run_id,
+        stage=LABEL_STAGE,
+        status=status,
+        started_at=started_at,
+        finished_at=finished_at,
+        metadata=metadata,
+    )
+    key = pipeline_manifest_path(LABEL_STAGE, run_id)
+    payload = manifest.model_dump_json(indent=2).encode("utf-8")
+    writer.put_object(key, payload)
+    return key
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the label runner."""
+    parser = argparse.ArgumentParser(description="Generate Layer 1 forward-return labels.")
+    parser.add_argument("--run-id", required=True, help="Run identifier for the label batch.")
+    parser.add_argument(
+        "--tickers",
+        required=True,
+        help="Comma-separated tickers, or @path/to/tickers.json for a JSON array.",
+    )
+    return parser.parse_args(argv)
+
+
+def _resolve_tickers(value: str) -> tuple[str, ...]:
+    """Resolve the --tickers argument either inline or from a JSON file."""
+    if value.startswith("@"):
+        with Path(value[1:]).open("r", encoding="utf-8") as fp:
+            payload = json.load(fp)
+        if not isinstance(payload, list):
+            raise ValueError("Ticker JSON file must contain an array of strings")
+        return _validate_tickers(payload)
+    return _validate_tickers([token.strip() for token in value.split(",") if token.strip()])
+
+
+def _validate_tickers(values: Iterable[object]) -> tuple[str, ...]:
+    """Coerce an iterable to a tuple of non-empty ticker strings."""
+    cleaned: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            raise ValueError("ticker entries must be strings")
+        stripped = value.strip().upper()
+        if not stripped:
+            raise ValueError("ticker entries cannot be empty")
+        cleaned.append(stripped)
+    return tuple(cleaned)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point for `python -m app.lab.data_pipelines.run_label_generation`."""
+    args = _parse_args(argv)
+    tickers = _resolve_tickers(args.tickers)
+    config = LabelGenerationConfig(run_id=args.run_id.strip(), tickers=tickers)
+    run_label_generation(config)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/labels/__init__.py
+++ b/core/labels/__init__.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from core.labels.forward_returns import (
+    LABEL_FEATURE_COLUMNS,
+    compute_forward_return_labels,
+    forward_return_labels_to_records,
+    read_label_record,
+    write_label_record,
+)
+
+__all__ = [
+    "LABEL_FEATURE_COLUMNS",
+    "compute_forward_return_labels",
+    "forward_return_labels_to_records",
+    "read_label_record",
+    "write_label_record",
+]

--- a/core/labels/forward_returns.py
+++ b/core/labels/forward_returns.py
@@ -1,0 +1,239 @@
+"""Layer 1 supervised-learning labels: forward returns and survival flags.
+
+Labels are computed from the canonical Layer 0 OHLCV archive
+(`raw/prices/{TICKER}.parquet`) and persisted to a separate label archive
+(`labels/layer1/{date}/{ticker}.parquet`) so Layer 2 training can opt in per
+experiment without coupling features to targets.
+
+For row date T, `forward_return_Hd` = `adj_close(T+H) / adj_close(T) - 1`.
+A delisting (or end-of-history) leaves later horizons with `None` and the
+matching `survives_to_tH` set to `0`. Forward returns therefore never silently
+drop a ticker; the survival flag exposes the gap.
+
+This module reads only Layer 0 R2 archives — Layer 1 is forbidden from making
+direct external provider calls. The Modal-runnable entrypoint at
+`app/lab/data_pipelines/run_label_generation.py` orchestrates archive reads,
+label computation, and per-(date, ticker) persistence.
+"""
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import math
+from collections.abc import Mapping
+from datetime import date as Date
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from core.contracts.schemas import FeatureRecord
+from services.r2.paths import layer1_label_path
+from services.r2.writer import R2Writer
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+LABEL_FEATURE_COLUMNS: tuple[str, ...] = (
+    "forward_return_1d",
+    "forward_return_5d",
+    "forward_return_20d",
+    "forward_log_return_1d",
+    "forward_log_return_5d",
+    "forward_log_return_20d",
+    "survives_to_t1",
+    "survives_to_t5",
+    "survives_to_t20",
+)
+
+LABEL_HORIZONS: tuple[int, ...] = (1, 5, 20)
+
+REQUIRED_OHLCV_COLUMNS: frozenset[str] = frozenset({"date", "adj_close"})
+
+
+def compute_forward_return_labels(
+    ohlcv: pd.DataFrame,
+    ticker: str,
+) -> pd.DataFrame:
+    """Return per-date forward-return labels for one ticker.
+
+    Args:
+        ohlcv: OHLCV frame matching the OHLCVRecord contract; only `date` and
+            `adj_close` are consulted but the full schema is required so this
+            function can be composed with `core.features.loaders.load_ohlcv_frame`.
+        ticker: Ticker symbol stamped on every output row.
+
+    Returns:
+        DataFrame with columns (`date`, `ticker`, *LABEL_FEATURE_COLUMNS*). One
+        row per trading day in the OHLCV frame, sorted ascending. Rows whose
+        forward window extends past the end of the archive emit `None` for the
+        return columns and `0` for the matching survival flag.
+    """
+    pd = _require_pandas()
+
+    _validate_columns(ohlcv)
+
+    if len(ohlcv) == 0:
+        return _empty_frame(pd)
+
+    frame = ohlcv.sort_values("date").drop_duplicates("date").reset_index(drop=True)
+    adj_close = frame["adj_close"].astype(float)
+
+    labels = pd.DataFrame({"date": frame["date"].to_numpy(), "ticker": ticker})
+    for horizon in LABEL_HORIZONS:
+        future = adj_close.shift(-horizon)
+        simple_return = future / adj_close - 1.0
+        log_return = (future / adj_close).map(_safe_log)
+        survives = future.notna().astype("int64")
+
+        labels[f"forward_return_{horizon}d"] = simple_return
+        labels[f"forward_log_return_{horizon}d"] = log_return
+        labels[f"survives_to_t{horizon}"] = survives
+
+    return labels[["date", "ticker", *LABEL_FEATURE_COLUMNS]]
+
+
+def forward_return_labels_to_records(labels: pd.DataFrame) -> list[FeatureRecord]:
+    """Convert a labels frame into validated FeatureRecord rows."""
+    records: list[FeatureRecord] = []
+    for row in labels.to_dict(orient="records"):
+        feature_values: dict[str, float | int | bool | None] = {
+            name: _normalize_label_value(name, row.get(name)) for name in LABEL_FEATURE_COLUMNS
+        }
+        records.append(
+            FeatureRecord(
+                date=str(row["date"]),
+                ticker=str(row["ticker"]),
+                features=feature_values,
+            )
+        )
+    return records
+
+
+def write_label_record(
+    record: FeatureRecord | Mapping[str, object],
+    writer: R2Writer | None = None,
+) -> str:
+    """Validate and persist one label shard to the active R2 backend."""
+    pd = _require_pandas()
+    validated = _coerce_feature_record(record)
+    key = layer1_label_path(validated.date, validated.ticker)
+    active_writer = writer or R2Writer()
+    payload = _label_record_to_parquet_bytes(pd, validated)
+    active_writer.put_object(key, payload)
+    return key
+
+
+def read_label_record(
+    as_of_date: str | Date | datetime,
+    ticker: str,
+    writer: R2Writer | None = None,
+) -> FeatureRecord:
+    """Read one label shard from the active R2 backend."""
+    pd = _require_pandas()
+    key = layer1_label_path(as_of_date, ticker)
+    active_writer = writer or R2Writer()
+    return _parquet_bytes_to_label_record(pd, active_writer.get_object(key))
+
+
+def _label_record_to_parquet_bytes(pd: Any, record: FeatureRecord) -> bytes:
+    """Serialize one FeatureRecord-shaped label into Parquet bytes."""
+    frame = pd.DataFrame([_parquet_ready_row(record)])
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
+def _parquet_bytes_to_label_record(pd: Any, data: bytes) -> FeatureRecord:
+    """Deserialize one Layer 1 label shard from Parquet bytes."""
+    frame = pd.read_parquet(io.BytesIO(data))
+    rows = frame.to_dict(orient="records")
+    if len(rows) != 1:
+        raise ValueError(
+            "Layer 1 label shards must contain exactly one record per parquet file."
+        )
+    raw_features = rows[0].get("features")
+    if not isinstance(raw_features, str):
+        raise ValueError("Label shard parquet rows must store the features field as JSON text.")
+
+    parsed_features = json.loads(raw_features)
+    if not isinstance(parsed_features, dict):
+        raise ValueError("Label shard parquet rows must decode to a feature dictionary.")
+
+    return FeatureRecord(
+        date=str(rows[0]["date"]),
+        ticker=str(rows[0]["ticker"]),
+        features=parsed_features,
+    )
+
+
+def _parquet_ready_row(record: FeatureRecord) -> dict[str, object]:
+    """Convert a FeatureRecord into a deterministic Parquet-compatible row."""
+    return {
+        "date": record.date,
+        "ticker": record.ticker,
+        "features": json.dumps(record.features, sort_keys=True, separators=(",", ":")),
+    }
+
+
+def _coerce_feature_record(record: FeatureRecord | Mapping[str, object]) -> FeatureRecord:
+    """Normalize input into a validated FeatureRecord instance."""
+    if isinstance(record, FeatureRecord):
+        return record
+    return FeatureRecord(**dict(record))
+
+
+def _validate_columns(ohlcv: pd.DataFrame) -> None:
+    """Raise when the OHLCV frame is missing a required column."""
+    missing = sorted(REQUIRED_OHLCV_COLUMNS - set(ohlcv.columns))
+    if missing:
+        raise ValueError(f"OHLCV frame missing required columns: {missing}")
+
+
+def _empty_frame(pd: Any) -> pd.DataFrame:
+    """Return an empty labels frame with canonical columns."""
+    return pd.DataFrame(columns=["date", "ticker", *LABEL_FEATURE_COLUMNS])
+
+
+def _safe_log(ratio: Any) -> float | None:
+    """Return ln(ratio) when ratio is finite and positive, else None."""
+    if ratio is None:
+        return None
+    try:
+        numeric = float(ratio)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or numeric <= 0.0:
+        return None
+    return math.log(numeric)
+
+
+def _normalize_label_value(name: str, value: Any) -> float | int | bool | None:
+    """Coerce a pandas/numpy scalar to a FeatureRecord-compatible primitive."""
+    if value is None:
+        return None
+    if name.startswith("survives_to_t"):
+        try:
+            survives = int(value)
+        except (TypeError, ValueError):
+            return None
+        return 1 if survives else 0
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
+
+
+def _require_pandas() -> Any:
+    """Import pandas/pyarrow lazily with a clear error when absent."""
+    try:
+        import pandas as pd
+
+        importlib.import_module("pyarrow")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required for label generation."
+        ) from exc
+    return pd

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -123,6 +123,12 @@ def layer1_sentiment_feature_path(as_of_date: str | Date | datetime, run_id: str
     )
 
 
+def layer1_label_path(as_of_date: str | Date | datetime, ticker: str) -> str:
+    """Return the canonical Layer 1 label-shard Parquet path for one date/ticker pair."""
+    safe_ticker = _validate_key_part(ticker)
+    return build_r2_key("labels", "layer1", _format_date(as_of_date), f"{safe_ticker}.parquet")
+
+
 def pipeline_manifest_path(stage: str, run_id: str) -> str:
     """Return the canonical pipeline manifest path for one stage/run pair."""
     safe_stage = _validate_key_part(stage)

--- a/tests/integration/test_label_generation_integration.py
+++ b/tests/integration/test_label_generation_integration.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.features import load_ohlcv_frame
+from core.labels import (
+    compute_forward_return_labels,
+    forward_return_labels_to_records,
+    read_label_record,
+    write_label_record,
+)
+from services.r2.client import (
+    R2_ACCESS_KEY_ENV,
+    R2_BUCKET_ENV,
+    R2_ENDPOINT_ENV,
+    R2_SECRET_KEY_ENV,
+)
+from services.r2.paths import raw_price_path
+from services.r2.writer import R2Writer
+
+
+def _local_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> R2Writer:
+    """Return a local mock R2 writer regardless of developer env files."""
+    for name in (R2_ENDPOINT_ENV, R2_ACCESS_KEY_ENV, R2_SECRET_KEY_ENV, R2_BUCKET_ENV):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr("services.r2.client.R2_ENV_FILE", tmp_path / "missing-r2.env")
+    return R2Writer(local_root=tmp_path)
+
+
+def _write_synthetic_archive(writer: R2Writer, ticker: str, num_bars: int) -> None:
+    """Persist a synthetic OHLCV parquet for one ticker beneath the local mock R2 root."""
+    rows = []
+    start = pd.Timestamp("2024-01-02")
+    for offset in range(num_bars):
+        date = (start + pd.tseries.offsets.BDay(offset)).date().isoformat()
+        price = 100.0 * (1.0 + offset * 0.01)
+        rows.append(
+            {
+                "date": date,
+                "ticker": ticker,
+                "open": price,
+                "high": price * 1.01,
+                "low": price * 0.99,
+                "close": price,
+                "adj_close": price,
+                "volume": 1_000_000 + offset,
+                "dollar_volume": price * (1_000_000 + offset),
+            }
+        )
+    buffer = io.BytesIO()
+    pd.DataFrame(rows).to_parquet(buffer, index=False)
+    writer.put_object(raw_price_path(ticker), buffer.getvalue())
+
+
+def test_label_generation_end_to_end_through_local_r2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Labels round-trip from the OHLCV archive into a label-shard archive."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    _write_synthetic_archive(writer, "AAPL", num_bars=30)
+
+    ohlcv = load_ohlcv_frame("AAPL", writer=writer)
+    labels = compute_forward_return_labels(ohlcv, "AAPL")
+    records = forward_return_labels_to_records(labels)
+
+    assert len(records) == 30
+    assert records[0].features["survives_to_t20"] == 1
+    # The last row has no future bars at all — survives_to_t1/5/20 are 0
+    assert records[-1].features["survives_to_t1"] == 0
+    assert records[-1].features["survives_to_t20"] == 0
+
+    # Persist a representative shard and read it back
+    target = records[0]
+    key = write_label_record(target, writer=writer)
+    assert key.startswith("labels/layer1/")
+
+    loaded = read_label_record(target.date, target.ticker, writer=writer)
+    assert loaded == target

--- a/tests/unit/test_label_generation.py
+++ b/tests/unit/test_label_generation.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import io
+import json
+import math
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.contracts.schemas import FeatureRecord
+from core.labels import (
+    LABEL_FEATURE_COLUMNS,
+    compute_forward_return_labels,
+    forward_return_labels_to_records,
+    read_label_record,
+    write_label_record,
+)
+from services.r2.client import (
+    R2_ACCESS_KEY_ENV,
+    R2_BUCKET_ENV,
+    R2_ENDPOINT_ENV,
+    R2_SECRET_KEY_ENV,
+)
+from services.r2.paths import layer1_label_path
+from services.r2.writer import R2Writer
+
+
+def _local_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> R2Writer:
+    """Return a local mock R2 writer regardless of developer env files."""
+    for name in (R2_ENDPOINT_ENV, R2_ACCESS_KEY_ENV, R2_SECRET_KEY_ENV, R2_BUCKET_ENV):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr("services.r2.client.R2_ENV_FILE", tmp_path / "missing-r2.env")
+    return R2Writer(local_root=tmp_path)
+
+
+def _ohlcv_frame(dates: list[str], prices: list[float]) -> pd.DataFrame:
+    """Build a minimal OHLCV frame with date and adj_close (others ignored by labels)."""
+    return pd.DataFrame({"date": dates, "adj_close": prices})
+
+
+def test_compute_forward_return_labels_returns_canonical_columns_and_shape() -> None:
+    """The labels frame contains the canonical columns and one row per input bar."""
+    ohlcv = _ohlcv_frame(
+        [f"2024-01-{i + 1:02d}" for i in range(30)],
+        [100.0 + i for i in range(30)],
+    )
+
+    labels = compute_forward_return_labels(ohlcv, "AAPL")
+
+    assert list(labels.columns)[:2] == ["date", "ticker"]
+    for column in LABEL_FEATURE_COLUMNS:
+        assert column in labels.columns
+    assert len(labels) == len(ohlcv)
+    assert (labels["ticker"] == "AAPL").all()
+
+
+def test_forward_returns_compute_against_known_prices() -> None:
+    """Forward returns equal adj_close(T+H)/adj_close(T) - 1 for each horizon."""
+    prices = [100.0, 110.0, 121.0, 133.1, 146.41, 161.05]
+    ohlcv = _ohlcv_frame([f"2024-01-{i + 1:02d}" for i in range(len(prices))], prices)
+
+    labels = compute_forward_return_labels(ohlcv, "AAPL")
+
+    assert labels.loc[0, "forward_return_1d"] == pytest.approx(0.10)
+    assert labels.loc[0, "forward_return_5d"] == pytest.approx((161.05 / 100.0) - 1.0)
+    assert labels.loc[0, "forward_log_return_1d"] == pytest.approx(math.log(110.0 / 100.0))
+
+
+def test_end_of_history_emits_none_returns_and_zero_survival_flag() -> None:
+    """A row whose forward window extends past the archive end is None + survives=0."""
+    ohlcv = _ohlcv_frame(
+        [f"2024-01-{i + 1:02d}" for i in range(3)],
+        [100.0, 101.0, 102.0],
+    )
+
+    labels = compute_forward_return_labels(ohlcv, "AAPL")
+
+    # Last row has no T+1 observation
+    assert pd.isna(labels.loc[2, "forward_return_1d"])
+    assert labels.loc[2, "survives_to_t1"] == 0
+    # Every row lacks T+5 because the archive only spans 3 days
+    assert (labels["survives_to_t5"] == 0).all()
+
+
+def test_compute_forward_return_labels_rejects_missing_columns() -> None:
+    """OHLCV frames lacking required columns raise ValueError naming them."""
+    ohlcv = pd.DataFrame({"adj_close": [100.0, 101.0]})
+
+    with pytest.raises(ValueError, match="date"):
+        compute_forward_return_labels(ohlcv, "AAPL")
+
+
+def test_compute_forward_return_labels_handles_empty_frame() -> None:
+    """Empty input yields an empty canonical frame."""
+    empty = pd.DataFrame(columns=["date", "adj_close"])
+
+    labels = compute_forward_return_labels(empty, "AAPL")
+
+    assert len(labels) == 0
+    assert list(labels.columns)[:2] == ["date", "ticker"]
+    for column in LABEL_FEATURE_COLUMNS:
+        assert column in labels.columns
+
+
+def test_compute_forward_return_labels_sorts_input_and_drops_duplicates() -> None:
+    """Unsorted/duplicate input does not corrupt the forward-return alignment."""
+    ohlcv = _ohlcv_frame(
+        ["2024-01-03", "2024-01-01", "2024-01-02", "2024-01-01"],
+        [102.0, 100.0, 101.0, 100.0],
+    )
+
+    labels = compute_forward_return_labels(ohlcv, "AAPL")
+
+    dates = labels["date"].tolist()
+    assert dates == sorted(set(dates))
+    assert labels.loc[0, "forward_return_1d"] == pytest.approx(0.01)
+
+
+def test_forward_return_labels_to_records_coerces_nan_to_none() -> None:
+    """Last-row NaN returns convert to None in the FeatureRecord output."""
+    ohlcv = _ohlcv_frame(["2024-01-01", "2024-01-02"], [100.0, 105.0])
+
+    labels = compute_forward_return_labels(ohlcv, "AAPL")
+    records = forward_return_labels_to_records(labels)
+
+    assert len(records) == 2
+    assert records[0].features["forward_return_1d"] == pytest.approx(0.05)
+    assert records[1].features["forward_return_1d"] is None
+    # Survival flags are integers, not None
+    assert records[0].features["survives_to_t1"] == 1
+    assert records[1].features["survives_to_t1"] == 0
+
+
+def test_label_record_round_trips_through_local_r2(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Label shards round-trip through the local R2 mock at the canonical path."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    record = FeatureRecord(
+        date="2024-01-02",
+        ticker="AAPL",
+        features={
+            "forward_return_1d": 0.0125,
+            "forward_log_return_1d": 0.0124,
+            "survives_to_t1": 1,
+            "forward_return_5d": None,
+            "survives_to_t5": 0,
+        },
+    )
+
+    key = write_label_record(record, writer=writer)
+    loaded = read_label_record("2024-01-02", "AAPL", writer=writer)
+
+    assert key == "labels/layer1/2024-01-02/AAPL.parquet"
+    assert key == layer1_label_path("2024-01-02", "AAPL")
+    assert loaded == record
+
+
+def test_read_label_record_rejects_multi_row_archives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A label shard containing more than one row raises ValueError on read."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    frame = pd.DataFrame(
+        [
+            {"date": "2024-01-02", "ticker": "AAPL", "features": json.dumps({})},
+            {"date": "2024-01-02", "ticker": "MSFT", "features": json.dumps({})},
+        ]
+    )
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    writer.put_object(layer1_label_path("2024-01-02", "AAPL"), buffer.getvalue())
+
+    with pytest.raises(ValueError, match="exactly one record"):
+        read_label_record("2024-01-02", "AAPL", writer=writer)

--- a/tests/unit/test_label_generation_runner.py
+++ b/tests/unit/test_label_generation_runner.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import io
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from app.lab.data_pipelines.run_label_generation import (
+    LABEL_STAGE,
+    LabelGenerationConfig,
+    _resolve_tickers,
+    run_label_generation,
+)
+from services.r2.client import (
+    R2_ACCESS_KEY_ENV,
+    R2_BUCKET_ENV,
+    R2_ENDPOINT_ENV,
+    R2_SECRET_KEY_ENV,
+)
+from services.r2.paths import pipeline_manifest_path, raw_price_path
+from services.r2.writer import R2Writer
+
+
+def _local_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> R2Writer:
+    """Return a local mock R2 writer regardless of developer env files."""
+    for name in (R2_ENDPOINT_ENV, R2_ACCESS_KEY_ENV, R2_SECRET_KEY_ENV, R2_BUCKET_ENV):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr("services.r2.client.R2_ENV_FILE", tmp_path / "missing-r2.env")
+    return R2Writer(local_root=tmp_path)
+
+
+def _write_synthetic_archive(writer: R2Writer, ticker: str, num_bars: int) -> None:
+    """Persist a synthetic OHLCV parquet for one ticker."""
+    rows = []
+    start = pd.Timestamp("2024-02-01")
+    for offset in range(num_bars):
+        date = (start + pd.tseries.offsets.BDay(offset)).date().isoformat()
+        price = 50.0 + offset
+        rows.append(
+            {
+                "date": date,
+                "ticker": ticker,
+                "open": price,
+                "high": price * 1.01,
+                "low": price * 0.99,
+                "close": price,
+                "adj_close": price,
+                "volume": 1_000_000,
+                "dollar_volume": price * 1_000_000,
+            }
+        )
+    buffer = io.BytesIO()
+    pd.DataFrame(rows).to_parquet(buffer, index=False)
+    writer.put_object(raw_price_path(ticker), buffer.getvalue())
+
+
+def test_run_label_generation_writes_shards_and_manifest(tmp_path, monkeypatch) -> None:
+    """The runner persists per-(date, ticker) label shards and a completed manifest."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    _write_synthetic_archive(writer, "AAPL", num_bars=10)
+    config = LabelGenerationConfig(run_id="labels-2024-02-01", tickers=("AAPL",))
+
+    fixed_now = datetime(2024, 2, 15, 12, 0, tzinfo=UTC)
+    result = run_label_generation(config, writer=writer, now=fixed_now)
+
+    assert result.shards_written == 10
+    assert result.manifest_key == pipeline_manifest_path(LABEL_STAGE, "labels-2024-02-01")
+
+    label_keys = writer.list_keys("labels/layer1/")
+    assert len(label_keys) == 10
+    manifest_payload = writer.get_object(result.manifest_key)
+    payload = json.loads(manifest_payload.decode("utf-8"))
+    assert payload["status"] == "completed"
+    assert payload["metadata"]["shards_written"] == 10
+
+
+def test_run_label_generation_writes_failed_manifest_on_error(tmp_path, monkeypatch) -> None:
+    """When a ticker is missing the runner records a failed manifest before raising."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    config = LabelGenerationConfig(run_id="missing-tickers", tickers=("AAPL",))
+    fixed_now = datetime(2024, 2, 15, 12, 0, tzinfo=UTC)
+
+    with pytest.raises(FileNotFoundError):
+        run_label_generation(config, writer=writer, now=fixed_now)
+
+    manifest_payload = writer.get_object(pipeline_manifest_path(LABEL_STAGE, "missing-tickers"))
+    payload = json.loads(manifest_payload.decode("utf-8"))
+    assert payload["status"] == "failed"
+
+
+def test_label_generation_config_rejects_invalid_inputs() -> None:
+    """LabelGenerationConfig validates run_id and ticker contents."""
+    with pytest.raises(ValueError, match="run_id"):
+        LabelGenerationConfig(run_id="", tickers=("AAPL",))
+    with pytest.raises(ValueError, match="at least one ticker"):
+        LabelGenerationConfig(run_id="run", tickers=())
+    with pytest.raises(ValueError, match="tickers cannot contain empty"):
+        LabelGenerationConfig(run_id="run", tickers=("AAPL", "  "))
+
+
+def test_resolve_tickers_supports_inline_and_file_inputs(tmp_path) -> None:
+    """The CLI helper accepts inline CSV and @path/to/file.json inputs."""
+    inline = _resolve_tickers("aapl, MSFT, googl")
+    assert inline == ("AAPL", "MSFT", "GOOGL")
+
+    json_path = tmp_path / "tickers.json"
+    json_path.write_text(json.dumps(["spy", "qqq"]), encoding="utf-8")
+    file_based = _resolve_tickers(f"@{json_path}")
+    assert file_based == ("SPY", "QQQ")
+
+
+def test_resolve_tickers_rejects_non_array_files(tmp_path) -> None:
+    """A ticker JSON file with the wrong shape raises a clear error."""
+    bad_path = tmp_path / "bad.json"
+    bad_path.write_text(json.dumps({"tickers": ["aapl"]}), encoding="utf-8")
+    with pytest.raises(ValueError, match="array"):
+        _resolve_tickers(f"@{bad_path}")


### PR DESCRIPTION
## What this PR does
Adds Layer 1 supervised-learning labels: forward returns and survival flags computed from the Layer 0 OHLCV R2 archive. Resolves the M2.9 BLOCKED comment with Option A (read R2 archives, no direct provider calls) per AGENTS.md and \`docs/data_contracts.md\`.

## Closes
Closes #91

## Layer(s) affected
- [x] Layer 1 — Features
- [x] Infrastructure / services (new \`labels/layer1/\` R2 path family)

## Author
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist

### Correctness
- [x] Output reuses \`FeatureRecord\` schema (no schema migration required)
- [x] No forbidden file touches
- [x] No hardcoded credentials, API keys, or absolute paths
- [x] No \`print()\` statements — uses loguru
- [x] No bare \`except:\` or silent exception swallowing

### Tests
- [x] \`pytest tests/unit/ tests/integration/\` passes (402 tests + 6 skipped — same as main)
- [x] \`ruff check .\` passes
- [x] Unit tests cover known prices, end-of-history (delisting/horizon overshoot), missing columns, empty input, sort/dedupe, NaN→None coercion, R2 round-trip
- [x] Integration test exercises the end-to-end OHLCV→labels→shard write/read flow through the local R2 mock
- [x] Runner tests cover the happy path, failed-manifest path, and the CLI ticker resolver

### Code quality
- [x] Type hints + docstrings on every public function
- [x] Imports ordered: stdlib → third-party → internal

### Project hygiene
- [x] Branch named \`codex/91-label-generation\`
- [x] No unrelated files modified

## Feature list
- \`forward_return_{1,5,20}d\` — simple returns
- \`forward_log_return_{1,5,20}d\` — log returns
- \`survives_to_t{1,5,20}\` — 1 if a future bar exists at T+H, else 0

## Notes for reviewer
- Labels live in \`core/labels/\` (new package) instead of \`core/features/\` because they are training targets, not predictors. Consumers can opt in by reading from \`labels/layer1/{date}/{ticker}.parquet\`.
- The shard payload reuses \`FeatureRecord\` so no schema migration is needed; \`features\` carries the label columns.
- A Modal-ready runner at \`app/lab/data_pipelines/run_label_generation.py\` orchestrates per-ticker iteration and writes a \`PipelineManifestRecord\`.
- Test pattern follows \`test_finbert_sentiment_runner.py\`: \`monkeypatch\` clears R2 env vars and rewires \`R2_ENV_FILE\` so \`R2Writer\` reliably uses the local mock.