### PR TITLE
Fix R2Writer to honor explicit local_root (prevent test→prod leaks)

### DIFF
--- a/services/r2/writer.py
+++ b/services/r2/writer.py
@@ -52,13 +52,22 @@ class R2Writer:
     """Unified object-store wrapper for real R2 and the local mock."""
 
     def __init__(self, local_root: Path | None = None) -> None:
-        """Select the real client when credentials exist, otherwise use the local mock."""
-        if has_required_r2_env_vars():
+        """Select the local mock when `local_root` is supplied, otherwise the real client.
+
+        Passing an explicit `local_root` is a hard request for the local mock — even when
+        Cloudflare R2 credentials are present in the environment. This prevents tests that
+        intend to write to a temporary directory from silently leaking objects into the
+        production R2 bucket. Production callers continue to construct `R2Writer()` with
+        no arguments, which selects the real client whenever env vars are configured.
+        """
+        if local_root is not None:
+            self._client = LocalR2Client(root=local_root.resolve())
+            self.mode = "local"
+        elif has_required_r2_env_vars():
             self._client = CloudflareR2Client.from_env()
             self.mode = "r2"
         else:
-            root = (local_root or DEFAULT_LOCAL_R2_ROOT).resolve()
-            self._client = LocalR2Client(root=root)
+            self._client = LocalR2Client(root=DEFAULT_LOCAL_R2_ROOT.resolve())
             self.mode = "local"
 
     def put_object(self, key: str, data: bytes | str) -> None:

--- a/tests/unit/test_r2_client.py
+++ b/tests/unit/test_r2_client.py
@@ -298,6 +298,36 @@ def test_r2_writer_falls_back_to_local_mock(tmp_path: Path, monkeypatch) -> None
     assert writer.exists("raw/universe/2026-04-08.csv") is True
 
 
+def test_r2_writer_local_root_overrides_real_credentials(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """An explicit local_root forces the local mock even when env vars exist.
+
+    Regression: tests that pass `R2Writer(local_root=tmp_path)` must never silently
+    write to the production R2 bucket. Earlier behavior selected the real client whenever
+    env vars were configured, which polluted production R2 from integration tests.
+    """
+    monkeypatch.setenv(R2_ENDPOINT_ENV, "https://example.r2.cloudflarestorage.com")
+    monkeypatch.setenv(R2_ACCESS_KEY_ENV, "access-key")
+    monkeypatch.setenv(R2_SECRET_KEY_ENV, "secret-key")
+    monkeypatch.setenv(R2_BUCKET_ENV, "bucket-name")
+
+    def _fail(cls):
+        raise AssertionError("Real R2 client must not be constructed when local_root is given")
+
+    monkeypatch.setattr(
+        "services.r2.writer.CloudflareR2Client.from_env",
+        classmethod(_fail),
+    )
+
+    writer = R2Writer(local_root=tmp_path)
+    writer.put_object("raw/universe/2026-04-08.csv", "ticker,date")
+
+    assert writer.mode == "local"
+    assert (tmp_path / "raw/universe/2026-04-08.csv").read_text() == "ticker,date"
+
+
 def test_r2_writer_uses_remote_client_when_env_vars_exist(monkeypatch) -> None:
     """R2Writer should select the CloudflareR2Client when all env vars are present."""
     fake_client = FakeS3Client()


### PR DESCRIPTION
## What this PR does
Fixes a critical data-integrity bug in \`R2Writer\`: the \`local_root\` argument was silently ignored whenever the four \`R2_*\` environment variables were configured, so integration tests constructing \`R2Writer(local_root=tmp_path)\` were writing synthetic data into the production R2 bucket.

## Evidence of the leak
Production R2 currently contains test-fixture payloads at:
- \`raw/prices/AAPL.parquet\` — 220 rows, 2023-01-02 to 2023-11-03, prices \$100→\$154.75 (matches \`tests/integration/test_market_features_integration.py\` synthetic fixture exactly)
- \`raw/prices/SPY.parquet\` — same shape as AAPL
- \`raw/prices/MSFT.parquet\` — 1 row at \$370.92 (matches \`tests/unit/test_feature_io.py\` fixture)

A separate follow-up will re-fetch those tickers from Alpaca SIP via \`backfill_layer0.py --tickers AAPL MSFT SPY --overwrite\`.

## The fix
\`R2Writer.__init__\` now selects the local mock whenever an explicit \`local_root\` is supplied — even if R2 credentials exist in the environment. Production callers (which construct \`R2Writer()\` with no arguments) are unaffected.

## Closes
N/A — this is a hotfix surfaced while debugging the M2.11 production smoke run. No issue was filed.

## Layer(s) affected
- [x] Infrastructure / services

## Author
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist

### Correctness
- [x] No forbidden file touches
- [x] No hardcoded credentials
- [x] No \`print()\` statements
- [x] No bare \`except:\`

### Tests
- [x] \`pytest tests/unit/ tests/integration/ -v --tb=short\` passes (415 passed + 6 skipped)
- [x] \`ruff check .\` passes
- [x] New regression test \`test_r2_writer_local_root_overrides_real_credentials\` patches \`CloudflareR2Client.from_env\` to fail loudly if it is ever called when \`local_root\` is supplied
- [x] Existing \`test_r2_writer_uses_remote_client_when_env_vars_exist\` still passes (production behavior preserved when \`local_root\` is omitted)

### Code quality
- [x] Type hints + docstring updated to document the precedence rule

## Notes for reviewer
- Production behavior is unchanged: \`R2Writer()\` (no args) selects the real client whenever env vars exist.
- Once this is merged, I will re-fetch the polluted tickers from Alpaca SIP and re-run the M2.11 smoke test.
- I am NOT merging this myself — leaving for human review.