### PR TITLE
docs: improve issue templates for readiness workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,38 +1,58 @@
 ---
 name: Bug report
-about: Something is broken in production or tests
+about: Something is broken in production, CI, tests, Modal, R2, or runtime behavior
 title: "[Bug] "
 labels: backlog, bug
 assignees: ''
 ---
 
 ## What is broken
-<!-- One sentence description -->
+<!-- One sentence description. -->
+
+## Layer(s) affected
+- [ ] Layer 0 — Data & universe
+- [ ] Layer 1 — Features
+- [ ] Layer 2 — Model
+- [ ] Layer 3 — Portfolio
+- [ ] Layer 4 — Risk
+- [ ] Layer 5 — Execution
+- [ ] Infrastructure / services
+- [ ] Tests only
+- [ ] Docs only
 
 ## Where it breaks
-<!-- File and function name if known -->
+<!-- File/function, command, Modal app, R2 prefix, CI job, or runtime surface if known. -->
 
 ## How to reproduce
-<!-- Minimal steps or command that triggers the bug -->
+<!-- Minimal steps or command that triggers the bug. Do not paste secrets. -->
+```bash
+# command(s)
+```
 
-## Expected behaviour
+## Expected behavior
 
-## Actual behaviour
+## Actual behavior
 
-## Error output
-<!-- paste error or stack trace here -->
+## Error output / evidence
+<!-- Paste stack trace/log excerpt, manifest status, report path, or R2 key evidence. Redact secrets. -->
 
 ## Environment
-- Mode: [ ] paper [ ] live [ ] backtest [ ] local
+- Mode: [ ] paper [ ] live [ ] backtest [ ] local [ ] Modal [ ] Pi/container [ ] CI
 - Date/time of failure:
-- Relevant logs: `logs/`
-
-## Suggested fix
-<!-- Optional — if you have a hypothesis -->
+- Relevant logs/reports:
 
 ## Files likely involved
-- 
+-
+
+## Suggested fix
+<!-- Optional — if you have a hypothesis. -->
+
+## Acceptance criteria
+- [ ] Bug is reproduced or evidence is sufficient to prove it
+- [ ] Fix includes regression test or documented reason test is not feasible
+- [ ] Relevant unit/integration tests pass
+- [ ] If production artifacts were affected, validation/report paths are included in the PR/issue comment
 
 ---
-<!-- If assigning to Codex: change label to owner:codex -->
-<!-- If handling yourself: change label to owner:me -->
+<!-- If assigning to Codex: add/change label to owner:codex. -->
+<!-- If handling yourself: add/change label to owner:me. -->

--- a/.github/ISSUE_TEMPLATE/codex_task.md
+++ b/.github/ISSUE_TEMPLATE/codex_task.md
@@ -1,47 +1,89 @@
 ---
 name: Codex task
-about: Task delegated to Codex — will be worked autonomously
+about: Implementation, repair, or validation task delegated to Codex
 title: "[Codex] "
 labels: backlog, owner:codex
 assignees: ''
 ---
 
 ## Task
-<!-- One clear sentence. What should exist after this is done that doesn't exist now. -->
+<!-- One clear sentence: what should exist after this is done that does not exist now? -->
+
+## Layer(s) affected
+- [ ] Layer 0 — Data & universe
+- [ ] Layer 1 — Features
+- [ ] Layer 2 — Model
+- [ ] Layer 3 — Portfolio
+- [ ] Layer 4 — Risk
+- [ ] Layer 5 — Execution
+- [ ] Infrastructure / services
+- [ ] Tests only
+- [ ] Docs only
+
+## Current evidence / context
+<!-- Facts, commands, logs, R2 keys, manifests, reports, linked issues/PRs. Do not paste secrets. -->
+- Related:
+- See: `docs/architecture.md`
 
 ## Files to read first
 <!-- Codex must read these before writing any code. Be explicit. -->
+- `AGENTS.md`
+- `TODO.md`
+- `docs/architecture.md`
+- `docs/data_contracts.md`
 - `core/contracts/schemas.py`
-- 
 
-## Files to create or modify
-<!-- Explicit list. Codex must not touch anything outside this list. -->
-- 
+## Expected files / allowed scope
+<!-- List expected files. If Codex discovers another file must change, explain why in the PR. -->
+-
 
 ## Never touch for this task
-<!-- Reinforce forbidden files specific to this task -->
-- 
+<!-- Reinforce forbidden files or paths specific to this task. Include secret-bearing files if not required. -->
+-
+
+## Production / external dependency impact
+- [ ] Touches R2 data
+- [ ] Touches Modal apps/secrets
+- [ ] Touches Alpaca/FRED/SimFin/provider APIs
+- [ ] Touches Pi runtime / cron / Docker
+- [ ] Requires human action or credentials
+- [ ] No external side effects
+
+## Required commands / reproduction
+<!-- Exact commands to run, if known. Use HOME=/home/juyoungoh for gh/modal where needed. -->
+```bash
+# command(s)
+```
 
 ## Acceptance criteria
-<!-- Every checkbox must be satisfied before the PR is opened -->
-- [ ] Output matches schema in `core/contracts/schemas.py`
-- [ ] `pytest tests/unit/ -v` passes with no failures
+<!-- Every checkbox must be satisfied before the PR is opened, or the issue must be blocked with a precise reason. -->
+- [ ] Output matches schema in `core/contracts/schemas.py` when schemas are involved
+- [ ] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with no failures
+- [ ] Relevant integration/readiness tests pass or are explicitly documented as skipped with reason
 - [ ] All new public functions have type hints and docstrings
 - [ ] No `print()` statements — use logger from `services/observability/logging.py`
-- [ ] No hardcoded values — config goes in `config/`
-- [ ] 
-- [ ] 
+- [ ] No hardcoded secrets, credentials, or local-only paths
+- [ ] Docs are updated if behavior, commands, or artifact locations change
 
-## Context and references
-<!-- Links to related issues, design decisions, architecture docs -->
-- Related: #
-- See: `docs/architecture.md`
+## Verification artifacts to include in PR/issue comment
+- Commands run:
+- Test result summary:
+- Manifest key(s):
+- Report path(s):
+- R2 output prefix(es):
+- Known skipped/missing data:
 
-## Sample data
-<!-- Point to fixture files to use in tests -->
-- `data/sample/`
+## Test fixtures / sample data
+<!-- Point to existing fixtures or say “create minimal fixtures under tests/fixtures/...” -->
+-
+
+## Idempotency / cleanup guidance
+- [ ] Safe to rerun with a new run_id
+- [ ] Existing production artifacts must not be deleted unless explicitly justified
+- [ ] Stale/interrupted manifests must be superseded or documented
+- [ ] Destructive cleanup requires explicit justification in the PR
 
 ---
-<!-- Codex: update labels and project board as work progresses (see AGENTS.md → GitHub issue/board ownership) -->
-<!-- Codex: backlog → in-progress when starting, in-progress → review when PR opens -->
-<!-- Codex: if you need a human decision, post BLOCKED comment format and stop -->
+<!-- Codex: update labels and project board as work progresses (see AGENTS.md). -->
+<!-- Codex: backlog → in-progress when starting, in-progress → review when PR opens. -->
+<!-- Codex: if you need a human decision, post BLOCKED comment format and stop. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,39 +1,48 @@
 ---
 name: Feature request
-about: New capability or improvement to the system
+about: New capability or improvement to the system before it is broken into implementation tasks
 title: "[Feature] "
 labels: backlog
 assignees: ''
 ---
 
 ## What and why
-<!-- What should the system be able to do that it can't do now, and why does it matter -->
+<!-- What should the system be able to do that it cannot do now, and why does it matter? -->
 
-## Which layer(s)
+## Layer(s)
 - [ ] Layer 0 — Data & universe
 - [ ] Layer 1 — Features
 - [ ] Layer 2 — Model
 - [ ] Layer 3 — Portfolio
 - [ ] Layer 4 — Risk
 - [ ] Layer 5 — Execution
-- [ ] Infrastructure
+- [ ] Infrastructure / services
 - [ ] Observability
 - [ ] Other
 
 ## Proposed approach
-<!-- How you think this should be implemented — high level -->
+<!-- High-level design. If multiple approaches have meaningful tradeoffs, list them. -->
+
+## Production / external dependency impact
+- [ ] Touches R2 data
+- [ ] Touches Modal apps/secrets
+- [ ] Touches Alpaca/FRED/SimFin/provider APIs
+- [ ] Touches Pi runtime / cron / Docker
+- [ ] Requires human action or credentials
+- [ ] No external side effects
 
 ## Files likely involved
-- 
+-
 
 ## Definition of done
-- [ ] 
-- [ ] Tests written
-- [ ] Docs updated if behaviour changes
+- [ ] User-visible behavior/capability exists
+- [ ] Tests written or follow-up test issue created
+- [ ] Docs updated if behavior, commands, or artifact locations change
+- [ ] Operational/readiness evidence is documented if production-facing
 
 ## Breakdown into Codex tasks
-<!-- Once agreed, break this into smaller codex_task issues -->
-- [ ] Create sub-issues before assigning to Codex
+<!-- Once agreed, break this into smaller codex_task or production_readiness issues. -->
+- [ ] Create sub-issues before assigning implementation to Codex
 
 ---
-<!-- Triage: add owner:codex or owner:me label before moving out of backlog -->
+<!-- Triage: add owner:codex or owner:me label before moving out of backlog. -->

--- a/.github/ISSUE_TEMPLATE/my_task.md
+++ b/.github/ISSUE_TEMPLATE/my_task.md
@@ -1,16 +1,28 @@
 ---
-name: My task
-about: Task I am working on personally
-labels: owner:me
+name: Human task
+about: Task Kenneth or another human must perform personally, usually credentials, account setup, approval, or external configuration
+title: "[My task] "
+labels: backlog, owner:me
+assignees: ''
 ---
 
 ## Goal
+<!-- What human action must be completed? -->
 
-## Approach
+## Why this cannot be delegated
+<!-- Credential, account, billing, approval, architectural decision, or external-console access. -->
 
-## Files I will touch
+## Steps
+1.
+
+## Information needed by Codex/Hermes after completion
+<!-- What should the human report back? Do not paste secrets. -->
+-
 
 ## Definition of done
-- [ ] 
-- [ ] Unit tests written
-- [ ] Codex follow-up tasks created for any testable utilities I produce
+- [ ] Human action completed
+- [ ] Non-secret confirmation posted on this issue
+- [ ] Codex follow-up tasks created or unblocked if needed
+
+## Related blocked issues / PRs
+-

--- a/.github/ISSUE_TEMPLATE/production_readiness.md
+++ b/.github/ISSUE_TEMPLATE/production_readiness.md
@@ -1,0 +1,74 @@
+---
+name: Production readiness
+about: Validate a layer, pipeline, Modal/R2 run, or data archive for downstream readiness
+title: "[Readiness] "
+labels: backlog, owner:codex
+assignees: ''
+---
+
+## Readiness target
+- Layer:
+- Date/window:
+- Candidate run_id:
+- Upstream dependency/run_id:
+- Downstream consumer/layer:
+
+## Current evidence
+<!-- Facts from R2, manifests, local reports, logs, previous issues/PRs. Do not paste secrets. -->
+- Existing manifests:
+- Existing reports:
+- R2 prefixes inspected:
+- Known gaps:
+
+## Files to read first
+- `AGENTS.md`
+- `TODO.md`
+- `docs/architecture.md`
+- `docs/data_contracts.md`
+- `docs/deployment.md`
+- `core/contracts/schemas.py`
+
+## Required commands
+<!-- Use HOME=/home/juyoungoh for authenticated gh/modal operations where needed. -->
+```bash
+# readiness command(s)
+```
+
+## R2 artifacts that must exist
+<!-- List exact manifest/report/data prefixes expected for success. -->
+- `artifacts/manifests/...`
+- `artifacts/reports/...`
+- `features/...`
+
+## Validation criteria
+- [ ] Manifest has a terminal successful status, not `running`
+- [ ] Validator/readiness report exists in a durable documented location
+- [ ] Report includes run_id, date/window, manifest key, output prefixes, counts, validation status, and next-layer readiness boolean
+- [ ] Output counts match expected universe/date window or exceptions are documented
+- [ ] Stale/interrupted manifests are superseded or documented so operators do not mistake them for active success
+- [ ] `ready_for_next_layer` / `ready_for_layer2` is true, or the issue is blocked with a precise human-action reason
+
+## Verification artifacts to include in PR/issue comment
+- Final run_id:
+- Authoritative manifest key:
+- Readiness report path/key:
+- R2 output prefix(es):
+- Validation summary/counts:
+- Commands/tests run:
+
+## Production / external dependency impact
+- [ ] Touches R2 data
+- [ ] Touches Modal apps/secrets
+- [ ] Touches provider APIs
+- [ ] Touches Pi runtime / cron / Docker
+- [ ] Requires human action or credentials
+- [ ] No external side effects
+
+## Idempotency / stale artifact handling
+- [ ] Safe to rerun with a new run_id
+- [ ] Existing production artifacts must not be deleted unless explicitly justified
+- [ ] Stale/interrupted manifests must be superseded or documented
+- [ ] Destructive cleanup requires explicit justification in the PR
+
+## Blocked protocol
+If blocked by secrets, Modal workspace state, auth, provider access, or a human decision, apply the `blocked` label, post the AGENTS.md BLOCKED comment format, and stop work on this issue.

--- a/.github/ISSUE_TEMPLATE/schema_migration.md
+++ b/.github/ISSUE_TEMPLATE/schema_migration.md
@@ -7,7 +7,16 @@ assignees: ''
 ---
 
 ## Which schema is changing
-<!-- File and class name in core/contracts/ -->
+<!-- File and class name in core/contracts/. -->
+
+## Layers affected
+- [ ] Layer 0 — Data & universe
+- [ ] Layer 1 — Features
+- [ ] Layer 2 — Model
+- [ ] Layer 3 — Portfolio
+- [ ] Layer 4 — Risk
+- [ ] Layer 5 — Execution
+- [ ] Infrastructure / services
 
 ## Current schema
 ```python
@@ -21,22 +30,26 @@ assignees: ''
 
 ## Reason for change
 
-## Layers affected
-<!-- List every layer that reads or writes this schema -->
-- 
-
 ## Migration plan
-<!-- How will existing Parquet files in R2 be handled? -->
+<!-- How will existing Parquet files/manifests/reports in R2 be handled? -->
 - [ ] Backward compatible — no migration needed
 - [ ] Migration script needed → `scripts/migrate_<schema>_v<N>.py`
 - [ ] Breaking change — coordinate with all consumers before merging
 
-## Checklist
+## Files to read first
+- `AGENTS.md`
+- `TODO.md`
+- `docs/data_contracts.md`
+- `core/contracts/schemas.py`
+
+## Acceptance checklist
+- [ ] Human approved the proposed contract change before implementation
 - [ ] All consumers updated in same PR or follow-up issues created
 - [ ] Migration script written and tested if needed
-- [ ] R2 sample fixtures updated in `data/sample/`
-- [ ] `config/schemas/` JSON schemas updated
+- [ ] Fixtures updated under `tests/fixtures/` or another documented test fixture location
+- [ ] Docs updated: `docs/data_contracts.md` and any affected runtime/deployment docs
+- [ ] R2/backfill impact documented
 
 ---
-<!-- Schema changes must be reviewed by human before Codex implements consumers -->
-<!-- Label: blocked until human approves the proposed schema -->
+<!-- Schema changes must be reviewed by human before Codex implements consumers. -->
+<!-- Use blocked label until human approves the proposed schema when needed. -->


### PR DESCRIPTION
## Summary
- Expands GitHub issue templates with layer, production-impact, verification-artifact, and idempotency sections.
- Adds a dedicated production readiness template for Modal/R2/data-archive readiness work.
- Updates the personal-task template into a clearer human-action template while preserving the existing filename.

## Related issue updates
- Rewrote #135, #136, and #137 in the new production-readiness format.

## Test Plan
- Verified all issue templates have frontmatter.
- Verified #135–#137 contain the production readiness sections.
- Markdown-only/template-only change; no Python tests run.

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [x] Docs only

## Author
- [x] Written by Hermes per Kenneth request
- [ ] Generated by Codex — reviewed and approved by me
