### PR TITLE
docs: align issue template process guidance

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,8 +17,8 @@ assignees: ''
 - [ ] Layer 4 — Risk
 - [ ] Layer 5 — Execution
 - [ ] Infrastructure / services
-- [ ] Observability
-- [ ] Other
+- [ ] Tests only
+- [ ] Docs only
 
 ## Proposed approach
 <!-- High-level design. If multiple approaches have meaningful tradeoffs, list them. -->

--- a/.github/ISSUE_TEMPLATE/my_task.md
+++ b/.github/ISSUE_TEMPLATE/my_task.md
@@ -1,7 +1,7 @@
 ---
 name: Human task
 about: Task Kenneth or another human must perform personally, usually credentials, account setup, approval, or external configuration
-title: "[My task] "
+title: "[Human task] "
 labels: backlog, owner:me
 assignees: ''
 ---

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -34,7 +34,7 @@ Closes #
 - [ ] No bare `except:` or silent exception swallowing
 
 ### Tests
-- [ ] `pytest tests/unit/ -v --tb=short` passes with zero failures
+- [ ] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
 - [ ] New public functions have at least one unit test each
 - [ ] Tests cover: happy path, empty input, missing columns, NaN input
 - [ ] No live API calls in unit tests — fixtures used from `data/sample/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,8 +29,10 @@ Before touching any code or issue, read these files in order:
 
 If you are about to create or comment on a GitHub issue, also read:
 - `.github/ISSUE_TEMPLATE/codex_task.md`
+- `.github/ISSUE_TEMPLATE/production_readiness.md`
 - `.github/ISSUE_TEMPLATE/schema_migration.md`
 - `.github/ISSUE_TEMPLATE/bug_report.md`
+- `.github/ISSUE_TEMPLATE/my_task.md`
 
 ---
 
@@ -155,7 +157,7 @@ For every issue you work on, follow this sequence exactly:
 6. gh issue edit <number> --remove-label "backlog" --add-label "in-progress"
 7. Write the code
 8. Write or update tests in tests/unit/ or tests/integration/
-9. Run: pytest tests/unit/ -v --tb=short
+9. Run: ./.venv/bin/pytest tests/unit/ -v --tb=short
 10. Fix all failures — never open a PR with failing tests
 11. Open PR using .github/pull_request_template.md
 12. Write "Closes #<number>" in the PR body
@@ -324,7 +326,7 @@ Every PR that adds or modifies logic must include tests. No exceptions.
 - Use `data/sample/` fixture files — never fetch live data in unit tests
 - Cover: happy path, empty input, missing columns, NaN input
 - Minimum: one test per public function
-- Must pass before opening PR: `pytest tests/unit/ -v --tb=short`
+- Must pass before opening PR: `./.venv/bin/pytest tests/unit/ -v --tb=short`
 
 ---
 


### PR DESCRIPTION
## Summary
- Addresses Claude Code follow-up from PR #138.
- Adds the new `production_readiness.md` issue template to the AGENTS.md issue-template read list.
- Aligns pytest command guidance to the project venv command.
- Fixes the Human task template title prefix.
- Makes the feature-request layer checklist match the other templates.

## Test Plan
- `git diff --check`
- `./.venv/bin/pytest tests/unit/ -v --tb=short` → 470 passed

## Notes
Follow-up to PR #138, which was already merged before the review follow-up landed.
