### PR TITLE
Layer 1 terminal readiness reporting and stale-manifest metadata

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -279,6 +279,11 @@ def run_daily_layer1(
     active_writer = writer or R2Writer()
     started_at = (now or datetime.now(UTC)).replace(microsecond=0)
     manifest_key = pipeline_manifest_path(LAYER1_DAILY_STAGE, config.run_id)
+    report_path: Path | None = None
+    report: Layer1ValidationReport | None = None
+    tickers_processed = 0
+    history_files_written = 0
+    feature_rows_written = 0
     processed_dates = _business_dates(config.from_date, config.to_date)
     metadata: dict[str, object] = {
         "from_date": config.from_date,
@@ -323,6 +328,7 @@ def run_daily_layer1(
             requested_tickers=config.tickers,
         )
         scope_tickers = _scope_tickers(universe_by_date)
+        tickers_processed = len(scope_tickers)
         metadata["scope_tickers"] = scope_tickers
         _require_upstream_archives(
             active_writer,
@@ -367,29 +373,19 @@ def run_daily_layer1(
             regime_results=regime_results,
         )
 
-        report = validate_layer1_archive(
+        preliminary_report = validate_layer1_archive(
             run_id=config.run_id,
             from_date=config.from_date,
             to_date=config.to_date,
             universe=universe_by_date,
             reader=active_writer,
             output_prefixes=build_layer1_output_prefixes(processed_dates),
+            inspect_related_manifests=True,
         )
-        if report.report_key is None:
-            raise ValueError("Layer 1 validation report_key was not populated")
-        report_key = report.report_key
-        report_path = write_validation_report(
-            report,
-            validation_output_dir if validation_output_dir is not None else DEFAULT_REPORT_DIR,
-        )
-        active_writer.put_object(report_key, render_validation_report(report))
         metadata.update(
             {
                 "history_files_written": history_files_written,
                 "feature_rows_written": feature_rows_written,
-                "validation_report_path": str(report_path),
-                "validation_report_key": report_key,
-                "ready_for_layer2": report.ready_for_layer2,
                 "news_output_keys": {
                     date_text: result.output_key for date_text, result in news_results.items()
                 },
@@ -406,15 +402,56 @@ def run_daily_layer1(
                 },
             }
         )
-        if not report.ready_for_layer2:
-            raise Layer1ValidationError(report, report_path)
-
         finished_at = (now or datetime.now(UTC)).replace(microsecond=0)
+        final_status = (
+            RunStatus.COMPLETED if preliminary_report.ready_for_layer2 else RunStatus.FAILED
+        )
         _write_manifest(
             writer=active_writer,
             key=manifest_key,
             config=config,
-            status=RunStatus.COMPLETED,
+            status=final_status,
+            started_at=started_at,
+            finished_at=finished_at,
+            metadata=metadata,
+        )
+        report, report_path = _write_terminal_validation_report(
+            writer=active_writer,
+            config=config,
+            processed_dates=processed_dates,
+            universe_by_date=universe_by_date,
+            validation_output_dir=validation_output_dir,
+            require_completed_manifest=final_status is RunStatus.COMPLETED,
+        )
+        if report.report_key is None:
+            raise ValueError("Layer 1 validation report_key was not populated")
+        metadata.update(
+            {
+                "validation_report_path": str(report_path),
+                "validation_report_key": report.report_key,
+                "validation_status": report.validation_status,
+                "manifest_status": report.manifest_status,
+                "ready_for_layer2": report.ready_for_layer2,
+                "stale_manifest_keys": report.stale_manifest_keys,
+                "supersedes_manifest_keys": report.stale_manifest_keys,
+                "related_manifest_keys": [
+                    str(entry["key"])
+                    for entry in report.related_manifests
+                    if "key" in entry
+                ],
+            }
+        )
+        if not report.ready_for_layer2:
+            metadata["error"] = {
+                "type": Layer1ValidationError.__name__,
+                "message": "Layer 1 validation failed: ready_for_layer2 is false",
+                "validation_report_key": report.report_key,
+            }
+        _write_manifest(
+            writer=active_writer,
+            key=manifest_key,
+            config=config,
+            status=final_status,
             started_at=started_at,
             finished_at=finished_at,
             metadata=metadata,
@@ -423,19 +460,8 @@ def run_daily_layer1(
             "Layer 1 orchestration complete run_id={} dates={} tickers={} ready_for_layer2={}",
             config.run_id,
             len(processed_dates),
-            len(scope_tickers),
+            tickers_processed,
             report.ready_for_layer2,
-        )
-        return Layer1DailyResult(
-            run_id=config.run_id,
-            manifest_key=manifest_key,
-            validation_report_path=report_path,
-            validation_report_key=report_key,
-            processed_dates=processed_dates,
-            tickers_processed=len(scope_tickers),
-            history_files_written=history_files_written,
-            feature_rows_written=feature_rows_written,
-            ready_for_layer2=report.ready_for_layer2,
         )
     except Exception as exc:
         metadata["error"] = {"type": type(exc).__name__, "message": str(exc)}
@@ -451,6 +477,23 @@ def run_daily_layer1(
         )
         logger.exception("Layer 1 orchestration failed run_id={}", config.run_id)
         raise
+    if report is None or report_path is None:
+        raise RuntimeError("Layer 1 validation report was not written")
+    if not report.ready_for_layer2:
+        raise Layer1ValidationError(report, report_path)
+    if report.report_key is None:
+        raise ValueError("Layer 1 validation report_key was not populated")
+    return Layer1DailyResult(
+        run_id=config.run_id,
+        manifest_key=manifest_key,
+        validation_report_path=report_path,
+        validation_report_key=report.report_key,
+        processed_dates=processed_dates,
+        tickers_processed=tickers_processed,
+        history_files_written=history_files_written,
+        feature_rows_written=feature_rows_written,
+        ready_for_layer2=report.ready_for_layer2,
+    )
 
 
 def load_modal_runtime_config(path: Path = MODAL_CONFIG_PATH) -> ModalRuntimeConfig:
@@ -868,6 +911,36 @@ def _scope_tickers(universe_by_date: Mapping[str, Sequence[str]]) -> list[str]:
     """Return the sorted union ticker scope implied by the universe mapping."""
     tickers = {ticker for tickers in universe_by_date.values() for ticker in tickers}
     return sorted(tickers)
+
+
+def _write_terminal_validation_report(
+    *,
+    writer: ObjectStore,
+    config: Layer1DailyConfig,
+    processed_dates: Sequence[str],
+    universe_by_date: Mapping[str, Sequence[str]],
+    validation_output_dir: Path | None,
+    require_completed_manifest: bool,
+) -> tuple[Layer1ValidationReport, Path]:
+    """Write the final readiness report after the Layer 1 manifest reaches terminal state."""
+    report = validate_layer1_archive(
+        run_id=config.run_id,
+        from_date=config.from_date,
+        to_date=config.to_date,
+        universe=universe_by_date,
+        reader=writer,
+        output_prefixes=build_layer1_output_prefixes(processed_dates),
+        require_completed_manifest=require_completed_manifest,
+        inspect_related_manifests=not require_completed_manifest,
+    )
+    if report.report_key is None:
+        raise ValueError("Layer 1 validation report_key was not populated")
+    report_path = write_validation_report(
+        report,
+        validation_output_dir if validation_output_dir is not None else DEFAULT_REPORT_DIR,
+    )
+    writer.put_object(report.report_key, render_validation_report(report))
+    return report, report_path
 
 
 def _expected_dates_by_ticker(

--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -423,8 +423,6 @@ def run_daily_layer1(
             validation_output_dir=validation_output_dir,
             require_completed_manifest=final_status is RunStatus.COMPLETED,
         )
-        if report.report_key is None:
-            raise ValueError("Layer 1 validation report_key was not populated")
         metadata.update(
             {
                 "validation_report_path": str(report_path),
@@ -433,7 +431,6 @@ def run_daily_layer1(
                 "manifest_status": report.manifest_status,
                 "ready_for_layer2": report.ready_for_layer2,
                 "stale_manifest_keys": report.stale_manifest_keys,
-                "supersedes_manifest_keys": report.stale_manifest_keys,
                 "related_manifest_keys": [
                     str(entry["key"])
                     for entry in report.related_manifests
@@ -481,8 +478,6 @@ def run_daily_layer1(
         raise RuntimeError("Layer 1 validation report was not written")
     if not report.ready_for_layer2:
         raise Layer1ValidationError(report, report_path)
-    if report.report_key is None:
-        raise ValueError("Layer 1 validation report_key was not populated")
     return Layer1DailyResult(
         run_id=config.run_id,
         manifest_key=manifest_key,

--- a/app/lab/data_pipelines/validate_layer1_archive.py
+++ b/app/lab/data_pipelines/validate_layer1_archive.py
@@ -4,7 +4,7 @@ Mirrors the Layer 0 validator: confirms that every ticker in the declared
 universe has a per-ticker feature history at `features/layer1/{ticker}.parquet`,
 then checks that each file contains the expected universe dates. It emits a
 JSON report under
-`artifacts/reports/integration/layer1_archive_validation_{from}_to_{to}.json`.
+`artifacts/reports/integration/layer1_archive_validation_{run_id}_{from}_to_{to}.json`.
 Daily Layer 1 orchestration also uploads the rendered JSON to the durable R2 key
 `artifacts/reports/integration/layer1_archive_validation_{run_id}_{from}_to_{to}.json`.
 
@@ -389,7 +389,10 @@ def write_validation_report(
 
 def validation_report_filename(report: Layer1ValidationReport) -> str:
     """Return the deterministic local filename for a Layer 1 validation report."""
-    return f"layer1_archive_validation_{report.from_date}_to_{report.to_date}.json"
+    return (
+        f"layer1_archive_validation_{report.run_id}_{report.from_date}"
+        f"_to_{report.to_date}.json"
+    )
 
 
 def render_validation_report(report: Layer1ValidationReport) -> str:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -116,6 +116,16 @@ HOME=/home/juyoungoh ./.venv/bin/modal run app/lab/data_pipelines/run_daily_laye
     --allow-layer0-manifest-date-range
 ```
 
+Generate the final operator-facing readiness report for the same run/window:
+
+```bash
+HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/validate_layer1_archive.py \
+    --run-id layer1-readiness-2026-04-10-v7 \
+    --from-date 2026-04-10 \
+    --to-date 2026-04-10 \
+    --use-r2-universe
+```
+
 Inspect R2 outputs via:
 - `artifacts/manifests/layer1_news_preprocessing/{run_id}-{date}.json`
 - `artifacts/manifests/layer1_text_topics/{run_id}-{date}.json`
@@ -125,6 +135,13 @@ Inspect R2 outputs via:
 - `artifacts/reports/integration/layer1_archive_validation_{run_id}_{from}_to_{to}.json`
 - `features/layer1/`, `features/layer1/news_sentiment/`, `features/layer1/topic_features/`,
   `features/layer1/sentiment_features/`, and `features/layer1_5/regime/`
+
+Operational notes for the readiness report:
+- The local validator writes
+  `artifacts/reports/integration/layer1_archive_validation_{run_id}_{from}_to_{to}.json`.
+- The report records the authoritative manifest key/status plus sibling stale `running`
+  manifests so operators can distinguish the successful run from interrupted attempts such as
+  `...-v4` or `...-v6`.
 
 Baseline paper execution is long-only equities. Hedge and long-short capabilities must stay
 disabled by policy until the relevant risk and execution gates are implemented:

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -92,6 +93,17 @@ def test_run_daily_layer1_happy_path_writes_history_and_completed_manifest(
         manifest.metadata["validation_report_key"]
         == layer1_validation_report_path("layer1-daily", "2024-01-03", "2024-01-04")
     )
+    report_payload = json.loads(writer.get_object(result.validation_report_key).decode("utf-8"))
+    assert report_payload["manifest_status"] == "completed"
+    assert report_payload["ready_for_layer2"] is True
+    assert report_payload["related_manifests"] == [
+        {
+            "key": result.manifest_key,
+            "run_id": "layer1-daily",
+            "status": "completed",
+            "finished_at": "2024-01-05T12:00:00Z",
+        }
+    ]
 
 
 def test_run_daily_layer1_prefers_topic_sentence_count_when_sentiment_conflicts(
@@ -454,6 +466,57 @@ def test_run_daily_layer1_reuses_completed_branch_outputs_when_precomputed(
     assert history[0].features["nlp_topic_count"] == 1
     assert history[0].features["nlp_sentiment_score"] == pytest.approx(0.25)
     assert history[0].features["regime_label"] == "bull"
+
+
+def test_run_daily_layer1_marks_stale_sibling_manifests_in_report_and_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Final readiness artifacts call out interrupted sibling runs without deleting them."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2024-01-03"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-readiness-2024-01-03-v7",),
+    )
+    stale_key = pipeline_manifest_path("layer1", "layer1-readiness-2024-01-03-v4")
+    writer.put_object(
+        stale_key,
+        PipelineManifestRecord(
+            run_id="layer1-readiness-2024-01-03-v4",
+            stage=LAYER1_DAILY_STAGE,
+            status=RunStatus.RUNNING,
+            started_at=datetime(2024, 1, 3, 12, 0, tzinfo=UTC),
+            output_path="features/layer1/",
+        ).model_dump_json(),
+    )
+
+    result = run_daily_layer1(
+        Layer1DailyConfig(
+            run_id="layer1-readiness-2024-01-03-v7",
+            from_date="2024-01-03",
+            to_date="2024-01-03",
+        ),
+        writer=writer,
+        news_runner=fake_news_runner(writer, ["AAPL"]),
+        text_topic_runner=fake_topic_runner(writer, ["AAPL"]),
+        finbert_runner=fake_sentiment_runner(writer, ["AAPL"]),
+        regime_runner=fake_regime_runner(writer),
+        validation_output_dir=tmp_path / "reports",
+        now=datetime(2024, 1, 5, 12, 0, tzinfo=UTC),
+    )
+
+    manifest = PipelineManifestRecord.model_validate_json(writer.get_object(result.manifest_key))
+    report_payload = json.loads(writer.get_object(result.validation_report_key).decode("utf-8"))
+
+    assert manifest.status is RunStatus.COMPLETED
+    assert manifest.metadata["stale_manifest_keys"] == [stale_key]
+    assert manifest.metadata["supersedes_manifest_keys"] == [stale_key]
+    assert stale_key in manifest.metadata["related_manifest_keys"]
+    assert report_payload["manifest_status"] == "completed"
+    assert report_payload["stale_manifest_keys"] == [stale_key]
+    assert report_payload["ready_for_layer2"] is True
 
 
 def test_main_returns_nonzero_when_validation_is_not_ready(

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -512,7 +512,7 @@ def test_run_daily_layer1_marks_stale_sibling_manifests_in_report_and_metadata(
 
     assert manifest.status is RunStatus.COMPLETED
     assert manifest.metadata["stale_manifest_keys"] == [stale_key]
-    assert manifest.metadata["supersedes_manifest_keys"] == [stale_key]
+    assert "supersedes_manifest_keys" not in manifest.metadata
     assert stale_key in manifest.metadata["related_manifest_keys"]
     assert report_payload["manifest_status"] == "completed"
     assert report_payload["stale_manifest_keys"] == [stale_key]

--- a/tests/unit/test_validate_layer1_archive.py
+++ b/tests/unit/test_validate_layer1_archive.py
@@ -442,7 +442,7 @@ def test_write_validation_report_writes_json(tmp_path: Path) -> None:
 
     path = write_validation_report(report, tmp_path)
 
-    assert path.name == "layer1_archive_validation_2024-01-02_to_2024-01-02.json"
+    assert path.name == "layer1_archive_validation_layer1_2024-01-02_to_2024-01-02.json"
     payload = json.loads(path.read_text(encoding="utf-8"))
     assert payload["validation_status"] == "failed"
     assert payload["ready_for_layer2"] is False


### PR DESCRIPTION
## What this PR does
This PR makes Layer 1 readiness reporting terminal and durable. The daily Layer 1 runner now writes the final readiness report after the authoritative manifest reaches `completed` or `failed`, records stale sibling `running` manifests in both the report and manifest metadata, and the standalone validator now writes run-specific local report filenames. Deployment docs now include the operator validator command for the production readiness run/window.

## Closes
Closes #137

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [ ] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
- `./.venv/bin/pytest tests/unit/test_daily_layer1_runner.py tests/unit/test_validate_layer1_archive.py -v --tb=short`
- `./.venv/bin/pytest tests/unit/ -v --tb=short`

## Notes for reviewer
Please check the final Layer 1 manifest/report flow in `run_daily_layer1.py`, especially the second terminal manifest write that carries the authoritative report key plus stale sibling manifest metadata.