### PR TITLE
Implement Layer 1 feature correctness audit harness

### DIFF
--- a/app/lab/data_pipelines/audit_layer1_features.py
+++ b/app/lab/data_pipelines/audit_layer1_features.py
@@ -1,0 +1,85 @@
+"""Operator-facing Layer 1 feature correctness audit."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from loguru import logger
+
+
+def _resolve_repo_root() -> Path:
+    """Return the repository root for local runs and Modal-mounted runs."""
+    env_root = os.getenv("AI_STOCK_TRADER_REPO_ROOT")
+    if env_root:
+        return Path(env_root).resolve()
+    resolved = Path(__file__).resolve()
+    return resolved.parents[3] if len(resolved.parents) > 3 else resolved.parent
+
+
+_REPO_ROOT = _resolve_repo_root()
+sys.path.insert(0, str(_REPO_ROOT))
+
+from core.features.audit import (  # noqa: E402
+    DEFAULT_AUDIT_OUTPUT_DIR,
+    audit_layer1_features,
+    render_audit_summary,
+    write_audit_report,
+)
+from services.r2.writer import R2Writer  # noqa: E402
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the Layer 1 feature audit."""
+    parser = argparse.ArgumentParser(description="Audit Layer 1 feature correctness.")
+    parser.add_argument(
+        "--run-id",
+        default=None,
+        help="Optional audit run identifier used in output filenames.",
+    )
+    parser.add_argument(
+        "--as-of-date",
+        required=True,
+        help="Audit date in YYYY-MM-DD format.",
+    )
+    parser.add_argument(
+        "--tickers",
+        required=True,
+        help="Comma-delimited ticker sample to audit, for example AAPL,MSFT.",
+    )
+    parser.add_argument(
+        "--benchmark-ticker",
+        default="SPY",
+        help="Benchmark ticker used for market cross-asset features.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_AUDIT_OUTPUT_DIR,
+        help="Directory where the JSON report and text summary are written.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the Layer 1 audit from the command line."""
+    args = parse_args(argv)
+    tickers = tuple(item.strip() for item in str(args.tickers).split(",") if item.strip())
+    run_id = args.run_id or f"layer1-audit-{args.as_of_date}"
+    report = audit_layer1_features(
+        run_id=run_id,
+        as_of_date=str(args.as_of_date),
+        tickers=tickers,
+        benchmark_ticker=str(args.benchmark_ticker),
+        writer=R2Writer(),
+    )
+    output_paths = write_audit_report(report, output_dir=args.output_dir)
+    logger.info("Layer 1 feature audit report written: {}", output_paths.json_path)
+    logger.info("Layer 1 feature audit summary written: {}", output_paths.summary_path)
+    logger.info("\n{}", render_audit_summary(report))
+    return 1 if report.summary.get("fail", 0) > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/core/features/audit.py
+++ b/core/features/audit.py
@@ -12,8 +12,6 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Literal, Protocol
 
-from loguru import logger
-
 from core.contracts.schemas import FeatureRecord, PipelineManifestRecord, RunStatus
 from core.features.context_features import (
     CONTEXT_FEATURE_COLUMNS,
@@ -46,7 +44,6 @@ from core.features.sentiment_features import (
 from core.features.text_topics import TOPIC_FEATURE_COLUMNS, topic_labels_to_feature_records
 from services.r2.paths import (
     layer1_ticker_history_path,
-    pipeline_manifest_path,
     raw_news_path,
     raw_universe_path,
 )
@@ -204,7 +201,7 @@ def audit_layer1_features(
     )
     macro_frame = load_macro_frame(writer=active_writer)  # type: ignore[arg-type]
 
-    preprocessed_records = _audit_news_preprocessing(
+    _audit_news_preprocessing(
         writer=active_writer,
         as_of_date=as_of_date,
         tickers=normalized_tickers,

--- a/core/features/audit.py
+++ b/core/features/audit.py
@@ -1,0 +1,1466 @@
+"""Layer 1 feature correctness audit helpers."""
+from __future__ import annotations
+
+import csv
+import importlib
+import io
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Literal, Protocol
+
+from loguru import logger
+
+from core.contracts.schemas import FeatureRecord, PipelineManifestRecord, RunStatus
+from core.features.context_features import (
+    CONTEXT_FEATURE_COLUMNS,
+    compute_context_features,
+    context_features_to_records,
+)
+from core.features.fundamentals_features import FUNDAMENTAL_FEATURE_COLUMNS
+from core.features.io import parquet_bytes_to_feature_records
+from core.features.loaders import load_fundamentals_frame, load_macro_frame, load_ohlcv_frame
+from core.features.macro_features import MACRO_FEATURE_COLUMNS, compute_macro_features
+from core.features.market_features import (
+    MARKET_FEATURE_COLUMNS,
+    compute_market_features,
+    market_features_to_records,
+)
+from core.features.news_preprocessing import (
+    news_sentiment_frame_to_records,
+    preprocess_news_articles,
+)
+from core.features.regime_detection import (
+    HMM_REGIME_COLUMNS,
+    HMM_REGIME_FEATURE_COLUMNS,
+    regime_features_to_records,
+)
+from core.features.sentiment_features import (
+    SENTIMENT_FEATURE_COLUMNS,
+    load_source_credibility_config,
+    sentiment_feature_records_from_scored_news,
+)
+from core.features.text_topics import TOPIC_FEATURE_COLUMNS, topic_labels_to_feature_records
+from services.r2.paths import (
+    layer1_ticker_history_path,
+    pipeline_manifest_path,
+    raw_news_path,
+    raw_universe_path,
+)
+from services.r2.writer import R2Writer
+
+AuditStatus = Literal["pass", "warn", "fail"]
+DEFAULT_AUDIT_OUTPUT_DIR = Path("artifacts/reports/diagnostics")
+FLOAT_REL_TOL = 1e-7
+FLOAT_ABS_TOL = 1e-9
+_SENTIMENT_BUCKET_TIMEZONE = "America/New_York"
+
+
+class AuditReader(Protocol):
+    """Object-store operations required by the Layer 1 audit harness."""
+
+    def exists(self, key: str) -> bool:
+        """Return True when `key` exists."""
+
+    def get_object(self, key: str) -> bytes:
+        """Return object bytes stored at `key`."""
+
+    def list_keys(self, prefix: str) -> list[str]:
+        """List keys beneath `prefix`."""
+
+
+@dataclass(frozen=True)
+class FeatureRule:
+    """Catalog rule for one named feature."""
+
+    owner: str
+    kind: Literal["number", "string", "boolean"]
+    required: bool
+    nullable: bool = True
+    minimum: float | None = None
+    maximum: float | None = None
+    allowed_values: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class AuditFinding:
+    """One operator-facing audit result."""
+
+    status: AuditStatus
+    category: str
+    subject: str
+    message: str
+    details: dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class BranchAuditResult:
+    """Comparison result for one branch/ticker/date audit."""
+
+    branch: str
+    ticker: str
+    as_of_date: str
+    status: AuditStatus
+    compared_features: int
+    mismatches: list[str] = field(default_factory=list)
+    missing_expected_features: list[str] = field(default_factory=list)
+    unexpected_actual_features: list[str] = field(default_factory=list)
+    artifact_key: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class Layer1FeatureAuditReport:
+    """Durable Layer 1 audit report for one date/ticker sample."""
+
+    run_id: str
+    as_of_date: str
+    benchmark_ticker: str
+    tickers: tuple[str, ...]
+    generated_at: str
+    summary: dict[str, int]
+    catalog_summary: dict[str, object]
+    branch_results: list[dict[str, object]]
+    leakage_checks: list[dict[str, object]]
+    history_rows: dict[str, dict[str, object]]
+    findings: list[dict[str, object]]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AuditOutputPaths:
+    """Filesystem targets written for one completed audit."""
+
+    json_path: Path
+    summary_path: Path
+
+
+def audit_layer1_features(
+    *,
+    run_id: str,
+    as_of_date: str,
+    tickers: Sequence[str],
+    benchmark_ticker: str = "SPY",
+    writer: AuditReader | None = None,
+) -> Layer1FeatureAuditReport:
+    """Audit stored Layer 1 histories against deterministic recomputation."""
+    _validate_iso_date(as_of_date, label="as_of_date")
+    normalized_tickers = _normalize_tickers(tickers)
+    if not normalized_tickers:
+        raise ValueError("tickers must contain at least one non-empty ticker")
+
+    active_writer = writer or R2Writer()
+    findings: list[AuditFinding] = []
+    branch_results: list[BranchAuditResult] = []
+    leakage_checks: list[AuditFinding] = []
+    catalog = feature_catalog()
+    history_rows = _load_history_rows(
+        writer=active_writer,
+        as_of_date=as_of_date,
+        tickers=normalized_tickers,
+        findings=findings,
+    )
+
+    universe_scope = _load_universe_scope(active_writer, as_of_date, findings)
+    news_artifact = _load_daily_branch_manifest(
+        writer=active_writer,
+        stage="layer1_news_preprocessing",
+        as_of_date=as_of_date,
+    )
+    topic_artifact = _load_daily_branch_manifest(
+        writer=active_writer,
+        stage="layer1_text_topics",
+        as_of_date=as_of_date,
+    )
+    sentiment_artifact = _load_daily_branch_manifest(
+        writer=active_writer,
+        stage="layer1_finbert_sentiment",
+        as_of_date=as_of_date,
+    )
+    regime_artifact = _load_regime_manifest(writer=active_writer, as_of_date=as_of_date)
+
+    catalog_summary = _validate_catalog(
+        history_rows=history_rows,
+        catalog=catalog,
+        findings=findings,
+    )
+
+    benchmark_bars = load_ohlcv_frame(  # type: ignore[arg-type]
+        benchmark_ticker,
+        writer=active_writer,
+    )
+    macro_frame = load_macro_frame(writer=active_writer)  # type: ignore[arg-type]
+
+    preprocessed_records = _audit_news_preprocessing(
+        writer=active_writer,
+        as_of_date=as_of_date,
+        tickers=normalized_tickers,
+        allowed_universe=universe_scope,
+        artifact=news_artifact,
+        findings=findings,
+        leakage_checks=leakage_checks,
+    )
+    topic_expected = _audit_topic_branch(
+        writer=active_writer,
+        artifact=topic_artifact,
+        as_of_date=as_of_date,
+        tickers=normalized_tickers,
+        findings=findings,
+    )
+    sentiment_expected = _audit_sentiment_branch(
+        writer=active_writer,
+        artifact=sentiment_artifact,
+        as_of_date=as_of_date,
+        tickers=normalized_tickers,
+        findings=findings,
+        leakage_checks=leakage_checks,
+    )
+    regime_expected = _audit_regime_branch(
+        writer=active_writer,
+        artifact=regime_artifact,
+        as_of_date=as_of_date,
+        tickers=normalized_tickers,
+        findings=findings,
+        leakage_checks=leakage_checks,
+    )
+
+    for ticker in normalized_tickers:
+        history = history_rows.get(ticker)
+        if history is None:
+            continue
+        ohlcv = load_ohlcv_frame(ticker, writer=active_writer)  # type: ignore[arg-type]
+        try:
+            fundamentals = load_fundamentals_frame(  # type: ignore[arg-type]
+                ticker,
+                writer=active_writer,
+            )
+        except FileNotFoundError:
+            fundamentals = _empty_fundamentals_frame()
+            findings.append(
+                AuditFinding(
+                    status="warn",
+                    category="layer0",
+                    subject=f"{ticker} fundamentals archive",
+                    message="Fundamentals archive missing; audit used an empty archive.",
+                )
+            )
+
+        market_record = _record_for_date(
+            market_features_to_records(
+                compute_market_features(ohlcv, ticker, benchmark_bars=benchmark_bars)
+            ),
+            as_of_date,
+        )
+        context_record = _record_for_date(
+            context_features_to_records(
+                compute_context_features(
+                    fundamentals=fundamentals,
+                    ohlcv=ohlcv,
+                    macro=macro_frame,
+                    ticker=ticker,
+                    macro_features=compute_macro_features(macro_frame, ohlcv["date"].tolist()),
+                    target_dates=(as_of_date,),
+                )
+            ),
+            as_of_date,
+        )
+
+        branch_results.append(
+            _compare_branch(
+                branch="market",
+                ticker=ticker,
+                as_of_date=as_of_date,
+                actual=history.features,
+                expected=market_record.features if market_record is not None else {},
+                feature_names=MARKET_FEATURE_COLUMNS,
+                artifact_key=None,
+                findings=findings,
+            )
+        )
+        branch_results.append(
+            _compare_branch(
+                branch="context",
+                ticker=ticker,
+                as_of_date=as_of_date,
+                actual=history.features,
+                expected=context_record.features if context_record is not None else {},
+                feature_names=CONTEXT_FEATURE_COLUMNS,
+                artifact_key=None,
+                findings=findings,
+            )
+        )
+        branch_results.append(
+            _compare_branch(
+                branch="topics",
+                ticker=ticker,
+                as_of_date=as_of_date,
+                actual=history.features,
+                expected=topic_expected.get(ticker, {}),
+                feature_names=TOPIC_FEATURE_COLUMNS,
+                artifact_key=topic_artifact.output_path if topic_artifact is not None else None,
+                findings=findings,
+            )
+        )
+        branch_results.append(
+            _compare_branch(
+                branch="sentiment",
+                ticker=ticker,
+                as_of_date=as_of_date,
+                actual=history.features,
+                expected=sentiment_expected.get(ticker, {}),
+                feature_names=SENTIMENT_FEATURE_COLUMNS,
+                artifact_key=(
+                    _manifest_metadata_str(sentiment_artifact, "sentiment_feature_key")
+                    if sentiment_artifact is not None
+                    else None
+                ),
+                findings=findings,
+            )
+        )
+        branch_results.append(
+            _compare_branch(
+                branch="regime",
+                ticker=ticker,
+                as_of_date=as_of_date,
+                actual=history.features,
+                expected=regime_expected.get(ticker, {}),
+                feature_names=HMM_REGIME_FEATURE_COLUMNS,
+                artifact_key=regime_artifact.output_path if regime_artifact is not None else None,
+                findings=findings,
+            )
+        )
+        leakage_checks.extend(
+            _fundamentals_leakage_checks(
+                ticker=ticker,
+                as_of_date=as_of_date,
+                fundamentals=fundamentals,
+            )
+        )
+        leakage_checks.extend(
+            _macro_leakage_checks(
+                as_of_date=as_of_date,
+                macro_frame=macro_frame,
+            )
+        )
+
+    all_findings = findings + leakage_checks
+    summary = _summarize_findings(all_findings)
+    return Layer1FeatureAuditReport(
+        run_id=run_id,
+        as_of_date=as_of_date,
+        benchmark_ticker=benchmark_ticker,
+        tickers=normalized_tickers,
+        generated_at=datetime.now(UTC).replace(microsecond=0).isoformat(),
+        summary=summary,
+        catalog_summary=catalog_summary,
+        branch_results=[result.to_dict() for result in branch_results],
+        leakage_checks=[item.to_dict() for item in leakage_checks],
+        history_rows={
+            ticker: {
+                "history_key": layer1_ticker_history_path(ticker),
+                "feature_count": len(record.features),
+            }
+            for ticker, record in history_rows.items()
+        },
+        findings=[item.to_dict() for item in all_findings],
+    )
+
+
+def feature_catalog() -> dict[str, FeatureRule]:
+    """Return the canonical Layer 1 feature catalog used by the audit."""
+    rules: dict[str, FeatureRule] = {}
+    for name in MARKET_FEATURE_COLUMNS:
+        rules[name] = FeatureRule(owner="market", kind="number", required=True)
+    for name in (
+        "realized_vol_5d",
+        "realized_vol_21d",
+        "vol_ratio_5_21",
+        "atr_14",
+        "volume_ratio_20",
+    ):
+        rules[name] = FeatureRule(owner="market", kind="number", required=True, minimum=0.0)
+    rules["golden_cross_50_200"] = FeatureRule(
+        owner="market",
+        kind="number",
+        required=True,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    rules["rsi_14"] = FeatureRule(
+        owner="market",
+        kind="number",
+        required=True,
+        minimum=0.0,
+        maximum=100.0,
+    )
+
+    for name in FUNDAMENTAL_FEATURE_COLUMNS:
+        rules[name] = FeatureRule(owner="fundamentals", kind="number", required=True)
+    rules["days_to_next_earnings"] = FeatureRule(
+        owner="fundamentals",
+        kind="number",
+        required=True,
+        minimum=0.0,
+    )
+    rules["pre_earnings_flag"] = FeatureRule(
+        owner="fundamentals",
+        kind="number",
+        required=True,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    rules["post_earnings_flag"] = FeatureRule(
+        owner="fundamentals",
+        kind="number",
+        required=True,
+        minimum=0.0,
+        maximum=1.0,
+    )
+
+    for name in MACRO_FEATURE_COLUMNS:
+        rules[name] = FeatureRule(owner="macro", kind="number", required=True)
+    for name in (
+        "fed_funds_rate",
+        "treasury_3m",
+        "treasury_2y",
+        "treasury_10y",
+        "vix_level",
+        "dollar_index",
+        "cpi_level",
+        "high_yield_spread",
+    ):
+        rules[name] = FeatureRule(owner="macro", kind="number", required=True, minimum=0.0)
+
+    rules["nlp_sentence_count"] = FeatureRule(
+        owner="nlp",
+        kind="number",
+        required=False,
+        minimum=0.0,
+    )
+    rules["nlp_topic_count"] = FeatureRule(
+        owner="topics",
+        kind="number",
+        required=False,
+        minimum=0.0,
+    )
+    rules["nlp_dominant_topic_id"] = FeatureRule(owner="topics", kind="number", required=False)
+    rules["nlp_dominant_topic_probability"] = FeatureRule(
+        owner="topics",
+        kind="number",
+        required=False,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    rules["nlp_mean_topic_probability"] = FeatureRule(
+        owner="topics",
+        kind="number",
+        required=False,
+        minimum=0.0,
+        maximum=1.0,
+    )
+
+    for name in (
+        "nlp_sentiment_positive",
+        "nlp_sentiment_negative",
+        "nlp_sentiment_neutral",
+        "nlp_sentiment_strength",
+    ):
+        rules[name] = FeatureRule(
+            owner="sentiment",
+            kind="number",
+            required=False,
+            minimum=0.0,
+            maximum=1.0,
+        )
+    rules["nlp_sentiment_score"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+        minimum=-1.0,
+        maximum=1.0,
+    )
+    rules["nlp_sentiment_std"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+        minimum=0.0,
+    )
+    rules["nlp_article_count"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+        minimum=0.0,
+    )
+    rules["nlp_relevance_score"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+        minimum=0.0,
+    )
+
+    rules["regime_label"] = FeatureRule(
+        owner="regime",
+        kind="string",
+        required=True,
+        nullable=False,
+        allowed_values=("bear", "sideways", "bull"),
+    )
+    rules["regime_confidence"] = FeatureRule(
+        owner="regime",
+        kind="number",
+        required=True,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    for name in ("regime_prob_bear", "regime_prob_sideways", "regime_prob_bull"):
+        rules[name] = FeatureRule(
+            owner="regime",
+            kind="number",
+            required=True,
+            minimum=0.0,
+            maximum=1.0,
+        )
+    return rules
+
+
+def write_audit_report(
+    report: Layer1FeatureAuditReport,
+    *,
+    output_dir: Path | None = None,
+) -> AuditOutputPaths:
+    """Write the durable JSON report and a human-readable summary file."""
+    target_dir = output_dir or DEFAULT_AUDIT_OUTPUT_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    json_path = target_dir / audit_report_json_filename(report)
+    summary_path = target_dir / audit_report_summary_filename(report)
+    json_path.write_text(json.dumps(report.to_dict(), indent=2, sort_keys=True), encoding="utf-8")
+    summary_path.write_text(render_audit_summary(report), encoding="utf-8")
+    return AuditOutputPaths(json_path=json_path, summary_path=summary_path)
+
+
+def audit_report_json_filename(report: Layer1FeatureAuditReport) -> str:
+    """Return the deterministic JSON filename for one Layer 1 audit."""
+    return f"layer1_feature_audit_{report.run_id}_{report.as_of_date}.json"
+
+
+def audit_report_summary_filename(report: Layer1FeatureAuditReport) -> str:
+    """Return the deterministic text-summary filename for one Layer 1 audit."""
+    return f"layer1_feature_audit_{report.run_id}_{report.as_of_date}.txt"
+
+
+def render_audit_summary(report: Layer1FeatureAuditReport) -> str:
+    """Render a concise operator summary for one completed audit."""
+    lines = [
+        "Layer 1 Feature Audit",
+        f"Run ID: {report.run_id}",
+        f"As-of date: {report.as_of_date}",
+        f"Tickers: {', '.join(report.tickers)}",
+        f"Benchmark: {report.benchmark_ticker}",
+        (
+            "Summary: "
+            f"PASS={report.summary.get('pass', 0)} "
+            f"WARN={report.summary.get('warn', 0)} "
+            f"FAIL={report.summary.get('fail', 0)}"
+        ),
+        "",
+        "Catalog:",
+        (
+            f"  features_checked={report.catalog_summary.get('features_checked', 0)} "
+            f"unknown={report.catalog_summary.get('unknown_features', 0)} "
+            f"missing_required={report.catalog_summary.get('missing_required', 0)} "
+            f"type_or_range_failures={report.catalog_summary.get('value_failures', 0)}"
+        ),
+        "",
+        "Branch Results:",
+    ]
+    for branch_result in report.branch_results:
+        lines.append(
+            "  "
+            f"{branch_result['branch']}:{branch_result['ticker']} "
+            f"{str(branch_result['status']).upper()} "
+            f"compared={branch_result['compared_features']} "
+            f"mismatches={len(branch_result['mismatches'])}"
+        )
+    lines.extend(["", "Key Findings:"])
+    for finding in report.findings:
+        if finding["status"] == "pass":
+            continue
+        lines.append(
+            f"  {str(finding['status']).upper()} "
+            f"[{finding['category']}] {finding['subject']}: {finding['message']}"
+        )
+    if all(item["status"] == "pass" for item in report.findings):
+        lines.append("  PASS [audit] No warnings or failures.")
+    return "\n".join(lines) + "\n"
+
+
+def _load_history_rows(
+    *,
+    writer: AuditReader,
+    as_of_date: str,
+    tickers: Sequence[str],
+    findings: list[AuditFinding],
+) -> dict[str, FeatureRecord]:
+    rows: dict[str, FeatureRecord] = {}
+    for ticker in tickers:
+        key = layer1_ticker_history_path(ticker)
+        if not writer.exists(key):
+            findings.append(
+                AuditFinding(
+                    status="fail",
+                    category="history",
+                    subject=ticker,
+                    message="Missing per-ticker Layer 1 history file.",
+                    details={"history_key": key},
+                )
+            )
+            continue
+        records = parquet_bytes_to_feature_records(writer.get_object(key))
+        matches = [record for record in records if record.date == as_of_date]
+        if len(matches) != 1:
+            findings.append(
+                AuditFinding(
+                    status="fail",
+                    category="history",
+                    subject=ticker,
+                    message="Expected exactly one history row for the audited date.",
+                    details={
+                        "history_key": key,
+                        "matching_rows": len(matches),
+                        "as_of_date": as_of_date,
+                    },
+                )
+            )
+            continue
+        rows[ticker] = matches[0]
+        findings.append(
+            AuditFinding(
+                status="pass",
+                category="history",
+                subject=ticker,
+                message="Loaded Layer 1 history row for the audited date.",
+                details={"history_key": key, "feature_count": len(matches[0].features)},
+            )
+        )
+    return rows
+
+
+def _load_universe_scope(
+    writer: AuditReader,
+    as_of_date: str,
+    findings: list[AuditFinding],
+) -> set[str] | None:
+    key = raw_universe_path(as_of_date)
+    if not writer.exists(key):
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="layer0",
+                subject=as_of_date,
+                message="Universe mask missing; news preprocessing audit used no ticker filter.",
+                details={"universe_key": key},
+            )
+        )
+        return None
+    payload = writer.get_object(key).decode("utf-8")
+    eligible: set[str] = set()
+    for row in csv.DictReader(io.StringIO(payload)):
+        ticker = _normalize_ticker(row.get("ticker"))
+        if ticker is None:
+            continue
+        if (
+            _truthy(row.get("in_universe"))
+            and _truthy(row.get("tradable"), default=True)
+            and _truthy(row.get("liquid"), default=True)
+            and _truthy(row.get("data_quality_ok"), default=True)
+            and not _truthy(row.get("halted"))
+        ):
+            eligible.add(ticker)
+    findings.append(
+        AuditFinding(
+            status="pass",
+            category="layer0",
+            subject=as_of_date,
+            message="Loaded Layer 0 eligible universe mask for the audited date.",
+            details={"universe_key": key, "eligible_ticker_count": len(eligible)},
+        )
+    )
+    return eligible
+
+
+def _validate_catalog(
+    *,
+    history_rows: Mapping[str, FeatureRecord],
+    catalog: Mapping[str, FeatureRule],
+    findings: list[AuditFinding],
+) -> dict[str, object]:
+    features_checked = 0
+    unknown_features = 0
+    missing_required = 0
+    value_failures = 0
+
+    for ticker, record in sorted(history_rows.items()):
+        row_unknown = sorted(set(record.features) - set(catalog))
+        row_missing = sorted(
+            name for name, rule in catalog.items() if rule.required and name not in record.features
+        )
+        row_failures: list[str] = []
+        for feature_name, feature_value in sorted(record.features.items()):
+            rule = catalog.get(feature_name)
+            if rule is None:
+                continue
+            features_checked += 1
+            message = _validate_feature_value(feature_name, feature_value, rule)
+            if message is not None:
+                row_failures.append(message)
+        unknown_features += len(row_unknown)
+        missing_required += len(row_missing)
+        value_failures += len(row_failures)
+
+        if row_unknown:
+            findings.append(
+                AuditFinding(
+                    status="warn",
+                    category="catalog",
+                    subject=ticker,
+                    message="History row contains uncataloged feature names.",
+                    details={"unknown_features": row_unknown},
+                )
+            )
+        if row_missing:
+            findings.append(
+                AuditFinding(
+                    status="fail",
+                    category="catalog",
+                    subject=ticker,
+                    message="History row is missing required catalog features.",
+                    details={"missing_required_features": row_missing},
+                )
+            )
+        if row_failures:
+            findings.append(
+                AuditFinding(
+                    status="fail",
+                    category="catalog",
+                    subject=ticker,
+                    message="History row violates feature type/range expectations.",
+                    details={"violations": row_failures},
+                )
+            )
+        if not row_unknown and not row_missing and not row_failures:
+            findings.append(
+                AuditFinding(
+                    status="pass",
+                    category="catalog",
+                    subject=ticker,
+                    message="Feature catalog validation passed.",
+                    details={"feature_count": len(record.features)},
+                )
+            )
+
+    return {
+        "features_checked": features_checked,
+        "unknown_features": unknown_features,
+        "missing_required": missing_required,
+        "value_failures": value_failures,
+    }
+
+
+def _validate_feature_value(
+    feature_name: str,
+    value: object,
+    rule: FeatureRule,
+) -> str | None:
+    if value is None:
+        if rule.nullable:
+            return None
+        return f"{feature_name}: null value is not allowed"
+    if rule.kind == "string":
+        if not isinstance(value, str):
+            return f"{feature_name}: expected string, got {type(value).__name__}"
+        if rule.allowed_values and value not in rule.allowed_values:
+            return f"{feature_name}: {value!r} not in {sorted(rule.allowed_values)}"
+        return None
+    if rule.kind == "boolean":
+        if not isinstance(value, bool):
+            return f"{feature_name}: expected boolean, got {type(value).__name__}"
+        return None
+
+    numeric = _to_float(value)
+    if numeric is None:
+        return f"{feature_name}: expected numeric value, got {value!r}"
+    if rule.minimum is not None and numeric < rule.minimum:
+        return f"{feature_name}: {numeric} < minimum {rule.minimum}"
+    if rule.maximum is not None and numeric > rule.maximum:
+        return f"{feature_name}: {numeric} > maximum {rule.maximum}"
+    return None
+
+
+def _audit_news_preprocessing(
+    *,
+    writer: AuditReader,
+    as_of_date: str,
+    tickers: Sequence[str],
+    allowed_universe: set[str] | None,
+    artifact: PipelineManifestRecord | None,
+    findings: list[AuditFinding],
+    leakage_checks: list[AuditFinding],
+) -> list[FeatureRecord]:
+    key = raw_news_path(as_of_date)
+    if not writer.exists(key):
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="news",
+                subject=as_of_date,
+                message="Raw Layer 0 news archive missing; skipped preprocessing audit.",
+                details={"raw_news_key": key},
+            )
+        )
+        return []
+    raw_articles = _load_json_lines(writer.get_object(key))
+    preprocessed = preprocess_news_articles(
+        raw_articles,
+        as_of_date=as_of_date,
+        point_in_time_tickers=allowed_universe,
+    )
+    leakage_checks.append(
+        AuditFinding(
+            status="pass",
+            category="leakage",
+            subject="news timestamps",
+            message="Recomputed news preprocessing from Layer 0 raw articles.",
+            details={
+                "raw_news_key": key,
+                "recomputed_sentence_rows": len(preprocessed),
+                "tickers_requested": list(tickers),
+            },
+        )
+    )
+
+    if artifact is None:
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="news",
+                subject=as_of_date,
+                message="No completed news preprocessing manifest found for the audited date.",
+            )
+        )
+        return []
+
+    stored_records = news_sentiment_frame_to_records(
+        _read_parquet_frame(writer, artifact.output_path or "")
+    )
+    expected_index = {
+        _news_identity(record): record
+        for record in preprocessed
+        if record.ticker in tickers
+    }
+    stored_index = {
+        _news_identity(record): record
+        for record in stored_records
+        if record.ticker in tickers
+    }
+    missing = sorted(set(expected_index) - set(stored_index))
+    unexpected = sorted(set(stored_index) - set(expected_index))
+    timestamp_mismatches = []
+    for identity in sorted(set(expected_index) & set(stored_index)):
+        if expected_index[identity].published_at != stored_index[identity].published_at:
+            timestamp_mismatches.append(identity)
+    if missing or unexpected or timestamp_mismatches:
+        findings.append(
+            AuditFinding(
+                status="fail",
+                category="news",
+                subject=as_of_date,
+                message="Stored news preprocessing artifact does not match raw Layer 0 inputs.",
+                details={
+                    "artifact_key": artifact.output_path,
+                    "missing_rows": missing,
+                    "unexpected_rows": unexpected,
+                    "timestamp_mismatches": timestamp_mismatches,
+                },
+            )
+        )
+    else:
+        findings.append(
+            AuditFinding(
+                status="pass",
+                category="news",
+                subject=as_of_date,
+                message="Stored news preprocessing artifact matches raw Layer 0 inputs.",
+                details={"artifact_key": artifact.output_path, "rows_compared": len(stored_index)},
+            )
+        )
+    return []
+
+
+def _audit_topic_branch(
+    *,
+    writer: AuditReader,
+    artifact: PipelineManifestRecord | None,
+    as_of_date: str,
+    tickers: Sequence[str],
+    findings: list[AuditFinding],
+) -> dict[str, dict[str, object]]:
+    if artifact is None:
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="topics",
+                subject=as_of_date,
+                message="No completed text-topic manifest found for the audited date.",
+            )
+        )
+        return {}
+    topic_label_key = _manifest_metadata_str(artifact, "topic_label_key")
+    if topic_label_key is None:
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="topics",
+                subject=artifact.run_id,
+                message="Text-topic manifest is missing topic_label_key metadata.",
+                details={"artifact_key": artifact.output_path},
+            )
+        )
+        return {}
+    records = topic_labels_to_feature_records(_read_parquet_frame(writer, topic_label_key))
+    expected = {
+        record.ticker: dict(record.features)
+        for record in records
+        if record.date == as_of_date and record.ticker in tickers
+    }
+    findings.append(
+        AuditFinding(
+            status="pass",
+            category="topics",
+            subject=as_of_date,
+            message="Recomputed topic feature rows from stored topic labels.",
+            details={"topic_label_key": topic_label_key, "records": len(expected)},
+        )
+    )
+    return expected
+
+
+def _audit_sentiment_branch(
+    *,
+    writer: AuditReader,
+    artifact: PipelineManifestRecord | None,
+    as_of_date: str,
+    tickers: Sequence[str],
+    findings: list[AuditFinding],
+    leakage_checks: list[AuditFinding],
+) -> dict[str, dict[str, object]]:
+    if artifact is None:
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="sentiment",
+                subject=as_of_date,
+                message="No completed FinBERT sentiment manifest found for the audited date.",
+            )
+        )
+        return {}
+    scored_news_key = _manifest_metadata_str(artifact, "scored_news_key")
+    if scored_news_key is None:
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="sentiment",
+                subject=artifact.run_id,
+                message="FinBERT manifest is missing scored_news_key metadata.",
+                details={"artifact_key": artifact.output_path},
+            )
+        )
+        return {}
+    scored_news = _read_parquet_frame(writer, scored_news_key)
+    records = sentiment_feature_records_from_scored_news(
+        scored_news,
+        credibility_config=load_source_credibility_config(),
+        bucket_timezone=_SENTIMENT_BUCKET_TIMEZONE,
+    )
+    expected = {
+        record.ticker: dict(record.features)
+        for record in records
+        if record.date == as_of_date and record.ticker in tickers
+    }
+    findings.append(
+        AuditFinding(
+            status="pass",
+            category="sentiment",
+            subject=as_of_date,
+            message="Recomputed sentiment feature rows from stored scored-news artifacts.",
+            details={"scored_news_key": scored_news_key, "records": len(expected)},
+        )
+    )
+    leakage_checks.append(
+        AuditFinding(
+            status="pass",
+            category="leakage",
+            subject="news sentiment bucketing",
+            message="Sentiment features were recomputed using published_at bucket dates.",
+            details={"scored_news_key": scored_news_key},
+        )
+    )
+    return expected
+
+
+def _audit_regime_branch(
+    *,
+    writer: AuditReader,
+    artifact: PipelineManifestRecord | None,
+    as_of_date: str,
+    tickers: Sequence[str],
+    findings: list[AuditFinding],
+    leakage_checks: list[AuditFinding],
+) -> dict[str, dict[str, object]]:
+    if artifact is None:
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="regime",
+                subject=as_of_date,
+                message="No completed regime manifest found for the audited date.",
+            )
+        )
+        return {}
+    frame = _read_parquet_frame(writer, artifact.output_path or "")
+    _require_columns(frame, HMM_REGIME_COLUMNS, label="regime output")
+    records = regime_features_to_records(frame)
+    expected_record = _record_for_date(records, as_of_date)
+    if expected_record is None:
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="regime",
+                subject=artifact.run_id,
+                message="Regime output does not contain the audited inference date.",
+                details={"artifact_key": artifact.output_path, "as_of_date": as_of_date},
+            )
+        )
+        return {}
+    train_end_date = _manifest_metadata_str(artifact, "train_end_date")
+    if train_end_date is not None and train_end_date >= as_of_date:
+        leakage_checks.append(
+            AuditFinding(
+                status="fail",
+                category="leakage",
+                subject="regime training window",
+                message="Regime manifest train_end_date is not strictly before the audited date.",
+                details={"train_end_date": train_end_date, "as_of_date": as_of_date},
+            )
+        )
+    else:
+        leakage_checks.append(
+            AuditFinding(
+                status="pass",
+                category="leakage",
+                subject="regime training window",
+                message="Regime manifest train_end_date is strictly before the audited date.",
+                details={"train_end_date": train_end_date, "as_of_date": as_of_date},
+            )
+        )
+    findings.append(
+        AuditFinding(
+            status="pass",
+            category="regime",
+            subject=as_of_date,
+            message="Loaded broadcast regime features for the audited date.",
+            details={"artifact_key": artifact.output_path},
+        )
+    )
+    return {ticker: dict(expected_record.features) for ticker in tickers}
+
+
+def _compare_branch(
+    *,
+    branch: str,
+    ticker: str,
+    as_of_date: str,
+    actual: Mapping[str, object],
+    expected: Mapping[str, object],
+    feature_names: Sequence[str],
+    artifact_key: str | None,
+    findings: list[AuditFinding],
+) -> BranchAuditResult:
+    mismatches: list[str] = []
+    missing_expected: list[str] = []
+    unexpected_actual: list[str] = []
+    compared_features = 0
+
+    for feature_name in feature_names:
+        in_actual = feature_name in actual
+        in_expected = feature_name in expected
+        if in_actual and not in_expected:
+            unexpected_actual.append(feature_name)
+            continue
+        if in_expected and not in_actual:
+            missing_expected.append(feature_name)
+            continue
+        if not in_expected and not in_actual:
+            continue
+        compared_features += 1
+        if not _values_match(actual.get(feature_name), expected.get(feature_name)):
+            mismatches.append(
+                f"{feature_name}: actual={actual.get(feature_name)!r} "
+                f"expected={expected.get(feature_name)!r}"
+            )
+
+    status: AuditStatus
+    if mismatches or missing_expected or unexpected_actual:
+        status = "fail"
+        findings.append(
+            AuditFinding(
+                status="fail",
+                category=branch,
+                subject=f"{ticker}/{as_of_date}",
+                message="Branch recomputation does not match the stored Layer 1 history row.",
+                details={
+                    "artifact_key": artifact_key,
+                    "mismatches": mismatches,
+                    "missing_expected_features": missing_expected,
+                    "unexpected_actual_features": unexpected_actual,
+                },
+            )
+        )
+    elif compared_features == 0:
+        status = "warn"
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category=branch,
+                subject=f"{ticker}/{as_of_date}",
+                message="No branch features were available to compare for this ticker/date.",
+                details={"artifact_key": artifact_key},
+            )
+        )
+    else:
+        status = "pass"
+        findings.append(
+            AuditFinding(
+                status="pass",
+                category=branch,
+                subject=f"{ticker}/{as_of_date}",
+                message="Stored Layer 1 history row matches deterministic branch recomputation.",
+                details={"artifact_key": artifact_key, "compared_features": compared_features},
+            )
+        )
+
+    return BranchAuditResult(
+        branch=branch,
+        ticker=ticker,
+        as_of_date=as_of_date,
+        status=status,
+        compared_features=compared_features,
+        mismatches=mismatches,
+        missing_expected_features=missing_expected,
+        unexpected_actual_features=unexpected_actual,
+        artifact_key=artifact_key,
+    )
+
+
+def _fundamentals_leakage_checks(
+    *,
+    ticker: str,
+    as_of_date: str,
+    fundamentals: Any,
+) -> list[AuditFinding]:
+    if len(fundamentals) == 0 or "availability_date" not in fundamentals.columns:
+        return [
+            AuditFinding(
+                status="warn",
+                category="leakage",
+                subject=f"{ticker} fundamentals",
+                message="No fundamentals availability rows were present for leakage inspection.",
+            )
+        ]
+    prior_rows = fundamentals[fundamentals["availability_date"] < as_of_date]
+    future_rows = fundamentals[fundamentals["availability_date"] >= as_of_date]
+    latest_prior = (
+        None if len(prior_rows) == 0 else str(prior_rows.iloc[-1]["availability_date"])
+    )
+    earliest_future = (
+        None
+        if len(future_rows) == 0
+        else str(future_rows.sort_values("availability_date").iloc[0]["availability_date"])
+    )
+    return [
+        AuditFinding(
+            status="pass",
+            category="leakage",
+            subject=f"{ticker} fundamentals",
+            message="Fundamentals leakage guard inspected availability_date boundaries.",
+            details={
+                "latest_prior_availability_date": latest_prior,
+                "earliest_non_prior_availability_date": earliest_future,
+                "as_of_date": as_of_date,
+            },
+        )
+    ]
+
+
+def _macro_leakage_checks(
+    *,
+    as_of_date: str,
+    macro_frame: Any,
+) -> list[AuditFinding]:
+    if len(macro_frame) == 0:
+        return [
+            AuditFinding(
+                status="warn",
+                category="leakage",
+                subject="macro vintages",
+                message="Macro archive is empty; skipped realtime_start leakage inspection.",
+            )
+        ]
+    violating = macro_frame[macro_frame["realtime_start"].astype(str) >= as_of_date]
+    if len(violating) == len(macro_frame):
+        return [
+            AuditFinding(
+                status="warn",
+                category="leakage",
+                subject="macro vintages",
+                message="No macro vintages were strictly prior to the audited date.",
+                details={"as_of_date": as_of_date},
+            )
+        ]
+    return [
+        AuditFinding(
+            status="pass",
+            category="leakage",
+            subject="macro vintages",
+            message="Macro realtime_start values were inspected for strictly-prior availability.",
+            details={
+                "rows_total": int(len(macro_frame)),
+                "rows_on_or_after_audit_date": int(len(violating)),
+                "as_of_date": as_of_date,
+            },
+        )
+    ]
+
+
+def _load_daily_branch_manifest(
+    *,
+    writer: AuditReader,
+    stage: str,
+    as_of_date: str,
+) -> PipelineManifestRecord | None:
+    selected: PipelineManifestRecord | None = None
+    for manifest in _completed_manifests(writer=writer, stage=stage):
+        manifest_date = _manifest_metadata_str(manifest, "as_of_date")
+        if manifest_date != as_of_date:
+            continue
+        if selected is None or _manifest_rank(manifest) >= _manifest_rank(selected):
+            selected = manifest
+    return selected
+
+
+def _load_regime_manifest(
+    *,
+    writer: AuditReader,
+    as_of_date: str,
+) -> PipelineManifestRecord | None:
+    selected: PipelineManifestRecord | None = None
+    for manifest in _completed_manifests(writer=writer, stage="layer1_5_regime"):
+        inference_dates = manifest.metadata.get("inference_dates")
+        if not isinstance(inference_dates, list) or as_of_date not in inference_dates:
+            continue
+        if selected is None or _manifest_rank(manifest) >= _manifest_rank(selected):
+            selected = manifest
+    return selected
+
+
+def _completed_manifests(
+    *,
+    writer: AuditReader,
+    stage: str,
+) -> list[PipelineManifestRecord]:
+    prefix = f"artifacts/manifests/{stage}/"
+    manifests: list[PipelineManifestRecord] = []
+    for key in writer.list_keys(prefix):
+        if not key.endswith(".json"):
+            continue
+        manifest = PipelineManifestRecord.model_validate_json(writer.get_object(key))
+        if manifest.status is RunStatus.COMPLETED:
+            manifests.append(manifest)
+    return manifests
+
+
+def _manifest_rank(manifest: PipelineManifestRecord) -> datetime:
+    return manifest.finished_at or manifest.started_at
+
+
+def _manifest_metadata_str(
+    manifest: PipelineManifestRecord | None,
+    field_name: str,
+) -> str | None:
+    if manifest is None:
+        return None
+    raw_value = manifest.metadata.get(field_name)
+    if raw_value is None:
+        return None
+    if not isinstance(raw_value, str):
+        raise ValueError(f"manifest {manifest.run_id} metadata[{field_name!r}] must be a string")
+    return raw_value
+
+
+def _record_for_date(
+    records: Sequence[FeatureRecord],
+    as_of_date: str,
+) -> FeatureRecord | None:
+    matches = [record for record in records if record.date == as_of_date]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise ValueError(f"Multiple FeatureRecords found for {as_of_date}")
+    return matches[0]
+
+
+def _load_json_lines(payload: bytes) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for line in payload.decode("utf-8").splitlines():
+        text = line.strip()
+        if not text:
+            continue
+        row = json.loads(text)
+        if not isinstance(row, dict):
+            raise ValueError("JSON Lines payload must contain one object per line")
+        rows.append(row)
+    return rows
+
+
+def _news_identity(record: Any) -> str:
+    published = record.published_at.isoformat() if getattr(record, "published_at", None) else ""
+    return "|".join(
+        [
+            str(record.date),
+            str(record.ticker),
+            str(record.article_id or ""),
+            str(record.sentence_index if record.sentence_index is not None else ""),
+            str(record.text or ""),
+            published,
+        ]
+    )
+
+
+def _read_parquet_frame(writer: AuditReader, key: str) -> Any:
+    if not key:
+        raise ValueError("artifact key cannot be empty")
+    pd = _require_pandas()
+    return pd.read_parquet(io.BytesIO(writer.get_object(key)))
+
+
+def _require_columns(frame: Any, columns: Sequence[str], *, label: str) -> None:
+    missing = sorted(set(columns) - set(frame.columns))
+    if missing:
+        raise ValueError(f"{label} missing required columns: {missing}")
+
+
+def _require_pandas() -> Any:
+    try:
+        import pandas as pd
+
+        importlib.import_module("pyarrow")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to run the Layer 1 feature audit."
+        ) from exc
+    return pd
+
+
+def _empty_fundamentals_frame() -> Any:
+    pd = _require_pandas()
+    return pd.DataFrame(
+        columns=[
+            "source",
+            "ticker",
+            "report_date",
+            "availability_date",
+            "retrieved_at",
+            "fiscal_year",
+            "fiscal_period",
+            "statement",
+            "earnings_date",
+            "raw_json",
+        ]
+    )
+
+
+def _normalize_tickers(tickers: Sequence[str]) -> tuple[str, ...]:
+    unique = []
+    seen: set[str] = set()
+    for ticker in tickers:
+        normalized = _normalize_ticker(ticker)
+        if normalized is None or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(normalized)
+    return tuple(sorted(unique))
+
+
+def _normalize_ticker(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip().upper()
+    return text or None
+
+
+def _truthy(value: object, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return str(value).strip().lower() in {"1", "true", "t", "yes", "y"}
+
+
+def _to_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
+
+
+def _values_match(left: object, right: object) -> bool:
+    if left is None or right is None:
+        return left is None and right is None
+    if isinstance(left, str) or isinstance(right, str):
+        return left == right
+    left_float = _to_float(left)
+    right_float = _to_float(right)
+    if left_float is None or right_float is None:
+        return left == right
+    return math.isclose(left_float, right_float, rel_tol=FLOAT_REL_TOL, abs_tol=FLOAT_ABS_TOL)
+
+
+def _validate_iso_date(value: str, *, label: str) -> None:
+    try:
+        parsed = datetime.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be YYYY-MM-DD") from exc
+    if parsed.date().isoformat() != value:
+        raise ValueError(f"{label} must be YYYY-MM-DD")
+
+
+def _summarize_findings(findings: Sequence[AuditFinding]) -> dict[str, int]:
+    summary = {"pass": 0, "warn": 0, "fail": 0}
+    for finding in findings:
+        summary[finding.status] += 1
+    return summary

--- a/core/features/audit.py
+++ b/core/features/audit.py
@@ -815,7 +815,7 @@ def _audit_news_preprocessing(
     artifact: PipelineManifestRecord | None,
     findings: list[AuditFinding],
     leakage_checks: list[AuditFinding],
-) -> list[FeatureRecord]:
+) -> None:
     key = raw_news_path(as_of_date)
     if not writer.exists(key):
         findings.append(
@@ -827,8 +827,12 @@ def _audit_news_preprocessing(
                 details={"raw_news_key": key},
             )
         )
-        return []
-    raw_articles = _load_json_lines(writer.get_object(key))
+        return
+    raw_articles = _load_json_lines(
+        writer.get_object(key),
+        findings=findings,
+        subject=as_of_date,
+    )
     preprocessed = preprocess_news_articles(
         raw_articles,
         as_of_date=as_of_date,
@@ -857,7 +861,7 @@ def _audit_news_preprocessing(
                 message="No completed news preprocessing manifest found for the audited date.",
             )
         )
-        return []
+        return
 
     stored_records = news_sentiment_frame_to_records(
         _read_parquet_frame(writer, artifact.output_path or "")
@@ -903,7 +907,7 @@ def _audit_news_preprocessing(
                 details={"artifact_key": artifact.output_path, "rows_compared": len(stored_index)},
             )
         )
-    return []
+    return None
 
 
 def _audit_topic_branch(
@@ -1196,6 +1200,24 @@ def _fundamentals_leakage_checks(
         if len(future_rows) == 0
         else str(future_rows.sort_values("availability_date").iloc[0]["availability_date"])
     )
+    if len(future_rows) > 0:
+        return [
+            AuditFinding(
+                status="warn",
+                category="leakage",
+                subject=f"{ticker} fundamentals",
+                message=(
+                    "Fundamentals archive contains rows on or after the audited date; "
+                    "verify the feature path used only prior availability_date values."
+                ),
+                details={
+                    "latest_prior_availability_date": latest_prior,
+                    "earliest_non_prior_availability_date": earliest_future,
+                    "rows_on_or_after_audit_date": int(len(future_rows)),
+                    "as_of_date": as_of_date,
+                },
+            )
+        ]
     return [
         AuditFinding(
             status="pass",
@@ -1205,6 +1227,7 @@ def _fundamentals_leakage_checks(
             details={
                 "latest_prior_availability_date": latest_prior,
                 "earliest_non_prior_availability_date": earliest_future,
+                "rows_on_or_after_audit_date": 0,
                 "as_of_date": as_of_date,
             },
         )
@@ -1226,14 +1249,21 @@ def _macro_leakage_checks(
             )
         ]
     violating = macro_frame[macro_frame["realtime_start"].astype(str) >= as_of_date]
-    if len(violating) == len(macro_frame):
+    if len(violating) > 0:
         return [
             AuditFinding(
                 status="warn",
                 category="leakage",
                 subject="macro vintages",
-                message="No macro vintages were strictly prior to the audited date.",
-                details={"as_of_date": as_of_date},
+                message=(
+                    "Macro archive contains rows on or after the audited date; "
+                    "verify the feature path used only strictly prior realtime_start values."
+                ),
+                details={
+                    "rows_total": int(len(macro_frame)),
+                    "rows_on_or_after_audit_date": int(len(violating)),
+                    "as_of_date": as_of_date,
+                },
             )
         ]
     return [
@@ -1244,7 +1274,7 @@ def _macro_leakage_checks(
             message="Macro realtime_start values were inspected for strictly-prior availability.",
             details={
                 "rows_total": int(len(macro_frame)),
-                "rows_on_or_after_audit_date": int(len(violating)),
+                "rows_on_or_after_audit_date": 0,
                 "as_of_date": as_of_date,
             },
         )
@@ -1328,16 +1358,42 @@ def _record_for_date(
     return matches[0]
 
 
-def _load_json_lines(payload: bytes) -> list[dict[str, object]]:
+def _load_json_lines(
+    payload: bytes,
+    *,
+    findings: list[AuditFinding] | None = None,
+    subject: str = "jsonl payload",
+) -> list[dict[str, object]]:
     rows: list[dict[str, object]] = []
-    for line in payload.decode("utf-8").splitlines():
+    malformed_line_numbers: list[int] = []
+    non_object_line_numbers: list[int] = []
+    for line_number, line in enumerate(payload.decode("utf-8").splitlines(), start=1):
         text = line.strip()
         if not text:
             continue
-        row = json.loads(text)
+        try:
+            row = json.loads(text)
+        except json.JSONDecodeError:
+            malformed_line_numbers.append(line_number)
+            continue
         if not isinstance(row, dict):
-            raise ValueError("JSON Lines payload must contain one object per line")
+            non_object_line_numbers.append(line_number)
+            continue
         rows.append(row)
+    if findings is not None and (malformed_line_numbers or non_object_line_numbers):
+        findings.append(
+            AuditFinding(
+                status="warn",
+                category="news",
+                subject=subject,
+                message="Skipped malformed JSON Lines rows while reading the raw news archive.",
+                details={
+                    "rows_loaded": len(rows),
+                    "malformed_line_numbers": malformed_line_numbers,
+                    "non_object_line_numbers": non_object_line_numbers,
+                },
+            )
+        )
     return rows
 
 

--- a/core/features/sentiment_features.py
+++ b/core/features/sentiment_features.py
@@ -46,6 +46,18 @@ REQUIRED_SENTIMENT_COLUMNS: frozenset[str] = frozenset(
     }
 )
 
+SENTIMENT_FEATURE_COLUMNS: tuple[str, ...] = (
+    "nlp_sentiment_positive",
+    "nlp_sentiment_negative",
+    "nlp_sentiment_neutral",
+    "nlp_sentiment_score",
+    "nlp_sentiment_strength",
+    "nlp_sentiment_std",
+    "nlp_article_count",
+    "nlp_sentence_count",
+    "nlp_relevance_score",
+)
+
 
 @dataclass(frozen=True)
 class SourceCredibilityConfig:

--- a/core/features/text_topics.py
+++ b/core/features/text_topics.py
@@ -35,6 +35,14 @@ TOPIC_LABEL_COLUMNS: tuple[str, ...] = (
     "topic_probability",
 )
 
+TOPIC_FEATURE_COLUMNS: tuple[str, ...] = (
+    "nlp_sentence_count",
+    "nlp_topic_count",
+    "nlp_dominant_topic_id",
+    "nlp_dominant_topic_probability",
+    "nlp_mean_topic_probability",
+)
+
 
 class SentenceEmbedder(Protocol):
     """Sentence embedding provider used by Layer 1 topic features."""

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,7 +113,7 @@ Config ownership:
 Production readiness command and inspection:
 
 ```bash
-HOME=/home/juyoungoh ./.venv/bin/modal run app/lab/data_pipelines/run_daily_layer1.py \
+./.venv/bin/modal run app/lab/data_pipelines/run_daily_layer1.py \
     --run-id layer1-readiness-2026-04-10-v7 \
     --as-of-date 2026-04-10 \
     --layer0-run-id layer0-historical-2017-01-01_to_2026-04-10 \
@@ -123,7 +123,7 @@ HOME=/home/juyoungoh ./.venv/bin/modal run app/lab/data_pipelines/run_daily_laye
 Generate the final operator-facing readiness report for the same run/window:
 
 ```bash
-HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/validate_layer1_archive.py \
+./.venv/bin/python app/lab/data_pipelines/validate_layer1_archive.py \
     --run-id layer1-readiness-2026-04-10-v7 \
     --from-date 2026-04-10 \
     --to-date 2026-04-10 \
@@ -143,7 +143,7 @@ Inspect R2 outputs via:
 For a targeted correctness audit on a sample of stored Layer 1 histories, run:
 
 ```bash
-HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/audit_layer1_features.py \
+./.venv/bin/python app/lab/data_pipelines/audit_layer1_features.py \
     --as-of-date 2026-04-10 \
     --tickers AAPL,MSFT \
     --output-dir artifacts/reports/diagnostics

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -11,9 +11,12 @@ This document describes deployment surfaces and responsibilities.
 ## External dependency roles
 
 - Wikipedia revision history: point-in-time S&P 500 membership source
-- Alpaca delayed SIP market data: canonical historical adjusted OHLCV archives from 2017-01-01 onward
+- Alpaca delayed SIP market data:
+  canonical historical adjusted OHLCV archives from 2017-01-01 onward
 - Alpaca News: Layer 0 raw Benzinga-sourced news archive used by Layer 1 text features
-- SimFin: Layer 0 as-reported fundamentals and earnings-date archive used by Layer 1 context features
+- SimFin:
+  Layer 0 as-reported fundamentals and earnings-date archive used by Layer 1
+  context features
 - FRED: Layer 0 macro and rates archive used by Layer 1 context and regime features
 - Alpaca Trading API: broker reconciliation and execution
 
@@ -42,7 +45,8 @@ Expected execution chain:
 ## Baseline rollout order
 
 1. Build and validate the complete Layer 0 historical backfill in R2:
-   Wikipedia universe, Alpaca delayed SIP OHLCV, Alpaca news, SimFin fundamentals/earnings, and FRED macro/rates
+   Wikipedia universe, Alpaca delayed SIP OHLCV, Alpaca news,
+   SimFin fundamentals/earnings, and FRED macro/rates
 2. Validate the Layer 0 daily incremental path:
    Alpaca live bars/news, SimFin refreshes, FRED refreshes, universe masks, and manifests
 3. Validate the Pi -> Modal Layer 1 handoff:
@@ -135,6 +139,20 @@ Inspect R2 outputs via:
 - `artifacts/reports/integration/layer1_archive_validation_{run_id}_{from}_to_{to}.json`
 - `features/layer1/`, `features/layer1/news_sentiment/`, `features/layer1/topic_features/`,
   `features/layer1/sentiment_features/`, and `features/layer1_5/regime/`
+
+For a targeted correctness audit on a sample of stored Layer 1 histories, run:
+
+```bash
+HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/audit_layer1_features.py \
+    --as-of-date 2026-04-10 \
+    --tickers AAPL,MSFT \
+    --output-dir artifacts/reports/diagnostics
+```
+
+This audit is read-only with respect to production feature artifacts. It recomputes
+deterministic Layer 0/1 branches from existing archives, validates the feature
+catalog, and writes a local JSON report plus text summary. See
+`docs/layer1_feature_audit.md` for interpretation details.
 
 Operational notes for the readiness report:
 - The local validator writes

--- a/docs/layer1_feature_audit.md
+++ b/docs/layer1_feature_audit.md
@@ -21,7 +21,7 @@ The audit focuses on Layer 0/1 correctness only:
 ## Command
 
 ```bash
-HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/audit_layer1_features.py \
+./.venv/bin/python app/lab/data_pipelines/audit_layer1_features.py \
     --as-of-date 2026-04-10 \
     --tickers AAPL,MSFT \
     --output-dir artifacts/reports/diagnostics

--- a/docs/layer1_feature_audit.md
+++ b/docs/layer1_feature_audit.md
@@ -1,0 +1,64 @@
+# Layer 1 Feature Audit
+
+## Purpose
+
+`app/lab/data_pipelines/audit_layer1_features.py` is an operator-facing audit for
+Layer 1 feature correctness. It does not rebuild production histories or write to
+R2. It reads existing Layer 0 and Layer 1 artifacts, recomputes deterministic
+feature branches, and writes local reports under `artifacts/reports/diagnostics/`
+by default.
+
+The audit focuses on Layer 0/1 correctness only:
+- market features from raw OHLCV and benchmark OHLCV
+- context features from raw fundamentals and macro archives
+- NLP topic aggregates from stored topic-label artifacts
+- NLP sentiment aggregates from stored scored-news artifacts
+- regime broadcast features from stored Layer 1.5 regime artifacts
+- schema/catalog checks for stored `FeatureRecord` histories
+- point-in-time checks for news timestamps, fundamentals `availability_date`, and
+  macro `realtime_start`
+
+## Command
+
+```bash
+HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/audit_layer1_features.py \
+    --as-of-date 2026-04-10 \
+    --tickers AAPL,MSFT \
+    --output-dir artifacts/reports/diagnostics
+```
+
+Optional flags:
+- `--run-id`: override the report identifier used in filenames
+- `--benchmark-ticker`: override the market benchmark, default `SPY`
+
+## Outputs
+
+For a run id of `layer1-audit-2026-04-10`, the audit writes:
+
+- `artifacts/reports/diagnostics/layer1_feature_audit_layer1-audit-2026-04-10_2026-04-10.json`
+- `artifacts/reports/diagnostics/layer1_feature_audit_layer1-audit-2026-04-10_2026-04-10.txt`
+
+The JSON report is the durable machine-readable artifact. The text file is the
+operator summary with PASS/WARN/FAIL counts and the key findings.
+
+## How To Read The Report
+
+- `history`: confirms the target `features/layer1/{TICKER}.parquet` row exists.
+- `catalog`: validates required feature names, branch ownership, types, nullability,
+  and configured value ranges.
+- `market` / `context`: compare stored history values to direct recomputation from
+  Layer 0 raw archives.
+- `topics` / `sentiment` / `regime`: compare stored history values to deterministic
+  recomputation from the latest completed branch artifacts for the audited date.
+- `leakage`: records the date-boundary checks used for raw news timestamps,
+  fundamentals `availability_date`, macro `realtime_start`, and regime
+  `train_end_date`.
+
+Interpretation:
+- `PASS`: the stored history matched the recomputed branch or passed the structural check.
+- `WARN`: the audit could not verify a branch because an optional artifact was missing.
+- `FAIL`: the stored history, branch artifact, or point-in-time boundary was inconsistent.
+
+Exit code:
+- `0` when the audit produced no failures
+- `1` when at least one failure was detected

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -123,7 +123,7 @@ Execution chain:
    - Example readiness rerun command used during Issue `#126`:
 
 ```bash
-HOME=/home/juyoungoh ./.venv/bin/modal run app/lab/data_pipelines/run_daily_layer1.py \
+./.venv/bin/modal run app/lab/data_pipelines/run_daily_layer1.py \
     --run-id layer1-readiness-2026-04-10-v7 \
     --as-of-date 2026-04-10 \
     --layer0-run-id layer0-historical-2017-01-01_to_2026-04-10 \

--- a/tests/fixtures/layer1_audit_support.py
+++ b/tests/fixtures/layer1_audit_support.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.contracts.schemas import FeatureRecord, PipelineManifestRecord, RunStatus
+from core.features.context_features import (
+    compute_context_features,
+    context_features_to_records,
+)
+from core.features.io import feature_records_to_parquet_bytes
+from core.features.market_features import compute_market_features, market_features_to_records
+from core.features.news_preprocessing import (
+    preprocess_news_articles,
+    records_to_news_sentiment_frame,
+)
+from core.features.regime_detection import HMM_REGIME_COLUMNS
+from core.features.sentiment_features import sentiment_feature_records_from_scored_news
+from core.features.text_topics import TOPIC_LABEL_COLUMNS, topic_labels_to_feature_records
+from services.r2.client import (
+    R2_ACCESS_KEY_ENV,
+    R2_BUCKET_ENV,
+    R2_ENDPOINT_ENV,
+    R2_SECRET_KEY_ENV,
+)
+from services.r2.paths import (
+    layer1_news_preprocessing_path,
+    layer1_regime_path,
+    layer1_sentiment_feature_path,
+    layer1_sentiment_score_path,
+    layer1_ticker_history_path,
+    layer1_topic_feature_path,
+    layer1_topic_label_path,
+    pipeline_manifest_path,
+    raw_fundamentals_path,
+    raw_macro_path,
+    raw_news_path,
+    raw_price_path,
+    raw_universe_path,
+)
+from services.r2.writer import R2Writer
+
+
+def local_writer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> R2Writer:
+    """Return a local mock R2 writer with cloud credentials disabled."""
+    for name in (R2_ENDPOINT_ENV, R2_ACCESS_KEY_ENV, R2_SECRET_KEY_ENV, R2_BUCKET_ENV):
+        monkeypatch.delenv(name, raising=False)
+    monkeypatch.setattr("services.r2.client.R2_ENV_FILE", tmp_path / "missing-r2.env")
+    return R2Writer(local_root=tmp_path)
+
+
+def seed_layer1_audit_fixture(
+    writer: R2Writer,
+    *,
+    as_of_date: str = "2024-05-06",
+    ticker: str = "AAPL",
+    benchmark_ticker: str = "SPY",
+) -> dict[str, object]:
+    """Seed a deterministic Layer 0/1 sample suitable for the audit harness."""
+    ohlcv = _price_history(ticker, end_date=as_of_date)
+    benchmark = _price_history(benchmark_ticker, end_date=as_of_date, start_price=400.0)
+    fundamentals = _fundamentals_archive(ticker)
+    macro_by_key = _macro_archives()
+    raw_articles = _raw_articles(ticker, as_of_date=as_of_date)
+
+    _write_parquet(writer, raw_price_path(ticker), ohlcv)
+    _write_parquet(writer, raw_price_path(benchmark_ticker), benchmark)
+    _write_parquet(writer, raw_fundamentals_path(ticker), fundamentals)
+    for key, frame in macro_by_key.items():
+        _write_parquet(writer, key, frame)
+    writer.put_object(raw_news_path(as_of_date), _jsonl(raw_articles))
+    writer.put_object(raw_universe_path(as_of_date), _raw_universe_csv([ticker]))
+
+    preprocessed_records = preprocess_news_articles(
+        raw_articles,
+        as_of_date=as_of_date,
+        point_in_time_tickers=[ticker],
+    )
+    preprocessed_key = layer1_news_preprocessing_path(as_of_date, "audit-news")
+    _write_parquet(writer, preprocessed_key, records_to_news_sentiment_frame(preprocessed_records))
+    _write_manifest(
+        writer,
+        stage="layer1_news_preprocessing",
+        run_id="audit-news",
+        output_path=preprocessed_key,
+        metadata={"as_of_date": as_of_date},
+    )
+
+    topic_label_key = layer1_topic_label_path(as_of_date, "audit-topics")
+    topic_feature_key = layer1_topic_feature_path(as_of_date, "audit-topics")
+    topic_labels = pd.DataFrame(
+        [
+            {
+                "date": as_of_date,
+                "ticker": ticker,
+                "article_id": str(preprocessed_records[0].article_id),
+                "sentence_index": int(preprocessed_records[0].sentence_index or 0),
+                "text": str(preprocessed_records[0].text),
+                "embedding_cache_key": "audit-embedding-1",
+                "topic_model": "BERTopic",
+                "topic_model_version": "test",
+                "topic_id": 7,
+                "topic_probability": 0.9,
+            }
+        ],
+        columns=list(TOPIC_LABEL_COLUMNS),
+    )
+    _write_parquet(writer, topic_label_key, topic_labels)
+    topic_feature_records = topic_labels_to_feature_records(topic_labels)
+    writer.put_object(topic_feature_key, feature_records_to_parquet_bytes(topic_feature_records))
+    _write_manifest(
+        writer,
+        stage="layer1_text_topics",
+        run_id="audit-topics",
+        output_path=topic_feature_key,
+        metadata={
+            "as_of_date": as_of_date,
+            "topic_label_key": topic_label_key,
+            "topic_feature_key": topic_feature_key,
+        },
+    )
+
+    scored_news_key = layer1_sentiment_score_path(as_of_date, "audit-sentiment")
+    sentiment_feature_key = layer1_sentiment_feature_path(as_of_date, "audit-sentiment")
+    scored_news = pd.DataFrame(
+        [
+            {
+                "date": as_of_date,
+                "ticker": ticker,
+                "article_id": str(preprocessed_records[0].article_id),
+                "source": "Reuters",
+                "published_at": "2024-05-06T11:30:00Z",
+                "sentiment_positive": 0.8,
+                "sentiment_negative": 0.1,
+                "sentiment_neutral": 0.1,
+                "sentiment_score": 0.7,
+                "relevance_score": 1.0,
+            }
+        ]
+    )
+    _write_parquet(writer, scored_news_key, scored_news)
+    sentiment_feature_records = sentiment_feature_records_from_scored_news(scored_news)
+    writer.put_object(
+        sentiment_feature_key,
+        feature_records_to_parquet_bytes(sentiment_feature_records),
+    )
+    _write_manifest(
+        writer,
+        stage="layer1_finbert_sentiment",
+        run_id="audit-sentiment",
+        output_path=sentiment_feature_key,
+        metadata={
+            "as_of_date": as_of_date,
+            "scored_news_key": scored_news_key,
+            "sentiment_feature_key": sentiment_feature_key,
+        },
+    )
+
+    regime_key = layer1_regime_path("audit-regime")
+    regime_output = pd.DataFrame(
+        [
+            {
+                "date": as_of_date,
+                "regime_label": "bull",
+                "regime_confidence": 0.8,
+                "regime_prob_bear": 0.1,
+                "regime_prob_sideways": 0.1,
+                "regime_prob_bull": 0.8,
+            }
+        ],
+        columns=list(HMM_REGIME_COLUMNS),
+    )
+    _write_parquet(writer, regime_key, regime_output)
+    _write_manifest(
+        writer,
+        stage="layer1_5_regime",
+        run_id="audit-regime",
+        output_path=regime_key,
+        metadata={
+            "train_end_date": "2024-05-03",
+            "inference_dates": [as_of_date],
+        },
+    )
+
+    market_record = _single_record(
+        market_features_to_records(
+            compute_market_features(ohlcv, ticker, benchmark_bars=benchmark)
+        ),
+        as_of_date,
+    )
+    context_record = _single_record(
+        context_features_to_records(
+            compute_context_features(
+                fundamentals=fundamentals,
+                ohlcv=ohlcv,
+                macro=pd.concat(list(macro_by_key.values()), ignore_index=True),
+                ticker=ticker,
+                target_dates=[as_of_date],
+            )
+        ),
+        as_of_date,
+    )
+    topic_record = _single_record(topic_feature_records, as_of_date)
+    sentiment_record = _single_record(sentiment_feature_records, as_of_date)
+    history_record = FeatureRecord(
+        date=as_of_date,
+        ticker=ticker,
+        features={
+            **dict(market_record.features if market_record is not None else {}),
+            **dict(context_record.features if context_record is not None else {}),
+            **dict(topic_record.features if topic_record is not None else {}),
+            **dict(sentiment_record.features if sentiment_record is not None else {}),
+            "regime_label": "bull",
+            "regime_confidence": 0.8,
+            "regime_prob_bear": 0.1,
+            "regime_prob_sideways": 0.1,
+            "regime_prob_bull": 0.8,
+        },
+    )
+    writer.put_object(
+        layer1_ticker_history_path(ticker),
+        feature_records_to_parquet_bytes([history_record]),
+    )
+
+    return {
+        "as_of_date": as_of_date,
+        "ticker": ticker,
+        "benchmark_ticker": benchmark_ticker,
+        "history_record": history_record,
+    }
+
+
+def _single_record(records: list[FeatureRecord], as_of_date: str) -> FeatureRecord | None:
+    """Return the single record for `as_of_date`, if present."""
+    matches = [record for record in records if record.date == as_of_date]
+    if not matches:
+        return None
+    if len(matches) > 1:
+        raise ValueError(f"Multiple records found for {as_of_date}")
+    return matches[0]
+
+
+def _write_parquet(writer: R2Writer, key: str, frame: pd.DataFrame) -> None:
+    """Serialize a DataFrame and persist it through the active R2 writer."""
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    writer.put_object(key, buffer.getvalue())
+
+
+def _write_manifest(
+    writer: R2Writer,
+    *,
+    stage: str,
+    run_id: str,
+    output_path: str,
+    metadata: dict[str, object],
+) -> None:
+    """Persist one completed pipeline manifest for a stage artifact."""
+    manifest = PipelineManifestRecord(
+        run_id=run_id,
+        stage=stage,
+        status=RunStatus.COMPLETED,
+        started_at=datetime(2024, 5, 6, 12, 0, tzinfo=UTC),
+        finished_at=datetime(2024, 5, 6, 12, 5, tzinfo=UTC),
+        output_path=output_path,
+        metadata=metadata,
+    )
+    writer.put_object(pipeline_manifest_path(stage, run_id), manifest.model_dump_json())
+
+
+def _price_history(
+    ticker: str,
+    *,
+    end_date: str,
+    start_price: float = 100.0,
+) -> pd.DataFrame:
+    """Build an OHLCV history with enough lookback for rolling features."""
+    rows: list[dict[str, object]] = []
+    close = start_price
+    end_timestamp = pd.Timestamp(end_date)
+    for index, day in enumerate(pd.bdate_range(end=end_timestamp, periods=90)):
+        close += 0.4
+        rows.append(
+            {
+                "date": day.date().isoformat(),
+                "ticker": ticker,
+                "open": close - 0.2,
+                "high": close + 0.5,
+                "low": close - 0.5,
+                "close": close,
+                "adj_close": close,
+                "volume": 1_000_000 + index * 100,
+                "dollar_volume": close * (1_000_000 + index * 100),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _fundamentals_archive(ticker: str) -> pd.DataFrame:
+    """Return a small point-in-time fundamentals history with a prior-year comparator."""
+    rows = [
+        {
+            "source": "simfin",
+            "ticker": ticker,
+            "report_date": "2023-03-31",
+            "availability_date": "2023-05-04",
+            "retrieved_at": "2023-05-04T00:00:00Z",
+            "fiscal_year": 2023,
+            "fiscal_period": "Q1",
+            "statement": "pl",
+            "earnings_date": "2023-05-04",
+            "raw_json": json.dumps(
+                {
+                    "revenue": 900.0,
+                    "netIncome": 90.0,
+                    "totalAssets": 4_000.0,
+                    "totalLiabilities": 1_700.0,
+                    "sharesBasic": 100.0,
+                    "eps": 0.9,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+        {
+            "source": "simfin",
+            "ticker": ticker,
+            "report_date": "2024-03-31",
+            "availability_date": "2024-05-03",
+            "retrieved_at": "2024-05-03T00:00:00Z",
+            "fiscal_year": 2024,
+            "fiscal_period": "Q1",
+            "statement": "pl",
+            "earnings_date": "2024-05-07",
+            "raw_json": json.dumps(
+                {
+                    "revenue": 1_000.0,
+                    "netIncome": 100.0,
+                    "totalAssets": 4_200.0,
+                    "totalLiabilities": 1_800.0,
+                    "sharesBasic": 100.0,
+                    "eps": 1.0,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+        },
+    ]
+    return pd.DataFrame(rows)
+
+
+def _macro_archives() -> dict[str, pd.DataFrame]:
+    """Return per-day raw macro shards covering the audit date."""
+    rows_by_date: dict[str, list[dict[str, object]]] = {
+        "2024-04-01": [
+            _macro_row("CPIAUCSL", "2024-04-01", "2024-05-01", 310.0),
+        ],
+        "2024-05-01": [
+            _macro_row("FEDFUNDS", "2024-05-01", "2024-05-01", 5.33),
+        ],
+        "2024-05-02": [
+            _macro_row("DGS3MO", "2024-05-02", "2024-05-02", 5.25),
+            _macro_row("DGS2", "2024-05-02", "2024-05-02", 4.95),
+            _macro_row("DGS10", "2024-05-02", "2024-05-02", 4.60),
+            _macro_row("VIXCLS", "2024-05-02", "2024-05-02", 14.5),
+            _macro_row("DTWEXBGS", "2024-05-02", "2024-05-02", 120.0),
+            _macro_row("BAMLH0A0HYM2", "2024-05-02", "2024-05-02", 3.4),
+        ],
+        "2024-05-03": [
+            _macro_row("DGS3MO", "2024-05-03", "2024-05-03", 5.20),
+            _macro_row("DGS2", "2024-05-03", "2024-05-03", 4.90),
+            _macro_row("DGS10", "2024-05-03", "2024-05-03", 4.55),
+            _macro_row("VIXCLS", "2024-05-03", "2024-05-03", 15.0),
+            _macro_row("DTWEXBGS", "2024-05-03", "2024-05-03", 119.5),
+            _macro_row("BAMLH0A0HYM2", "2024-05-03", "2024-05-03", 3.5),
+        ],
+    }
+    return {
+        raw_macro_path(observation_date): pd.DataFrame(rows)
+        for observation_date, rows in rows_by_date.items()
+    }
+
+
+def _macro_row(
+    series_id: str,
+    observation_date: str,
+    realtime_start: str,
+    value: float,
+) -> dict[str, object]:
+    """Return one normalized FRED observation row."""
+    return {
+        "source": "fred",
+        "series_id": series_id,
+        "observation_date": observation_date,
+        "realtime_start": realtime_start,
+        "realtime_end": realtime_start,
+        "retrieved_at": f"{realtime_start}T00:00:00Z",
+        "value": value,
+        "is_missing": False,
+        "raw": {"series_id": series_id},
+    }
+
+
+def _raw_articles(ticker: str, *, as_of_date: str) -> list[dict[str, object]]:
+    """Return one raw news article matching the Layer 0 JSON Lines archive shape."""
+    return [
+        {
+            "id": f"article-{as_of_date}",
+            "headline": f"{ticker} beats estimates.",
+            "summary": "Revenue and margins improved.",
+            "content": "Management raised guidance.",
+            "symbols": [ticker],
+            "source": "Reuters",
+            "url": f"https://example.com/{ticker.lower()}-{as_of_date}",
+            "published_at": "2024-05-06T11:30:00Z",
+        }
+    ]
+
+
+def _jsonl(rows: list[dict[str, object]]) -> str:
+    """Serialize objects as a JSON Lines string."""
+    return "\n".join(json.dumps(row, sort_keys=True) for row in rows) + "\n"
+
+
+def _raw_universe_csv(tickers: list[str]) -> str:
+    """Return a minimal Layer 0 universe-mask CSV payload."""
+    buffer = io.StringIO()
+    writer = csv.DictWriter(
+        buffer,
+        fieldnames=[
+            "date",
+            "ticker",
+            "in_universe",
+            "tradable",
+            "liquid",
+            "halted",
+            "data_quality_ok",
+        ],
+    )
+    writer.writeheader()
+    for ticker in tickers:
+        writer.writerow(
+            {
+                "date": "2024-05-06",
+                "ticker": ticker,
+                "in_universe": "true",
+                "tradable": "true",
+                "liquid": "true",
+                "halted": "false",
+                "data_quality_ok": "true",
+            }
+        )
+    return buffer.getvalue()

--- a/tests/fixtures/layer1_audit_support.py
+++ b/tests/fixtures/layer1_audit_support.py
@@ -15,6 +15,7 @@ from core.features.context_features import (
     context_features_to_records,
 )
 from core.features.io import feature_records_to_parquet_bytes
+from core.features.macro_features import compute_macro_features
 from core.features.market_features import compute_market_features, market_features_to_records
 from core.features.news_preprocessing import (
     preprocess_news_articles,
@@ -194,14 +195,16 @@ def seed_layer1_audit_fixture(
         ),
         as_of_date,
     )
+    macro_frame = pd.concat(list(macro_by_key.values()), ignore_index=True)
     context_record = _single_record(
         context_features_to_records(
             compute_context_features(
                 fundamentals=fundamentals,
                 ohlcv=ohlcv,
-                macro=pd.concat(list(macro_by_key.values()), ignore_index=True),
+                macro=macro_frame,
                 ticker=ticker,
-                target_dates=[as_of_date],
+                macro_features=compute_macro_features(macro_frame, ohlcv["date"].tolist()),
+                target_dates=(as_of_date,),
             )
         ),
         as_of_date,

--- a/tests/integration/test_layer1_feature_audit_integration.py
+++ b/tests/integration/test_layer1_feature_audit_integration.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.features.audit import audit_layer1_features
+from tests.fixtures.layer1_audit_support import local_writer, seed_layer1_audit_fixture
+
+
+def test_layer1_feature_audit_passes_on_seeded_local_archives(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The audit recomputes deterministic branches from local Layer 0/1 archives."""
+    writer = local_writer(tmp_path, monkeypatch)
+    fixture = seed_layer1_audit_fixture(writer)
+
+    report = audit_layer1_features(
+        run_id="audit-integration",
+        as_of_date=str(fixture["as_of_date"]),
+        tickers=[str(fixture["ticker"])],
+        benchmark_ticker=str(fixture["benchmark_ticker"]),
+        writer=writer,
+    )
+
+    assert report.summary["fail"] == 0
+    assert report.summary["warn"] == 0
+    assert all(result["status"] == "pass" for result in report.branch_results)
+    assert any(
+        finding["category"] == "news" and finding["status"] == "pass"
+        for finding in report.findings
+    )
+    assert any(
+        finding["category"] == "leakage" and finding["status"] == "pass"
+        for finding in report.findings
+    )

--- a/tests/unit/test_feature_audit.py
+++ b/tests/unit/test_feature_audit.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from core.features.audit import (
+    audit_layer1_features,
+    render_audit_summary,
+    write_audit_report,
+)
+from core.features.io import feature_records_to_parquet_bytes
+from services.r2.paths import layer1_ticker_history_path
+from tests.fixtures.layer1_audit_support import local_writer, seed_layer1_audit_fixture
+
+
+def test_write_audit_report_writes_json_and_summary(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Audit reports persist both machine-readable and operator-readable outputs."""
+    writer = local_writer(tmp_path, monkeypatch)
+    fixture = seed_layer1_audit_fixture(writer)
+
+    report = audit_layer1_features(
+        run_id="audit-unit",
+        as_of_date=str(fixture["as_of_date"]),
+        tickers=[str(fixture["ticker"])],
+        benchmark_ticker=str(fixture["benchmark_ticker"]),
+        writer=writer,
+    )
+    output_paths = write_audit_report(report, output_dir=tmp_path / "reports")
+    summary = render_audit_summary(report)
+
+    assert output_paths.json_path.exists()
+    assert output_paths.summary_path.exists()
+    assert '"run_id": "audit-unit"' in output_paths.json_path.read_text(encoding="utf-8")
+    assert "Layer 1 Feature Audit" in summary
+    assert "AAPL" in summary
+
+
+def test_audit_layer1_features_flags_history_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stored history drift is surfaced as a failing branch comparison."""
+    writer = local_writer(tmp_path, monkeypatch)
+    fixture = seed_layer1_audit_fixture(writer)
+    history_record = fixture["history_record"].model_copy(
+        update={
+            "features": {
+                **fixture["history_record"].features,
+                "returns_1d": 9.99,
+            }
+        }
+    )
+    writer.put_object(
+        layer1_ticker_history_path(str(fixture["ticker"])),
+        feature_records_to_parquet_bytes([history_record]),
+    )
+
+    report = audit_layer1_features(
+        run_id="audit-mismatch",
+        as_of_date=str(fixture["as_of_date"]),
+        tickers=[str(fixture["ticker"])],
+        benchmark_ticker=str(fixture["benchmark_ticker"]),
+        writer=writer,
+    )
+
+    assert report.summary["fail"] > 0
+    market_result = next(
+        result for result in report.branch_results if result["branch"] == "market"
+    )
+    assert market_result["status"] == "fail"
+    assert any("returns_1d" in mismatch for mismatch in market_result["mismatches"])

--- a/tests/unit/test_feature_audit.py
+++ b/tests/unit/test_feature_audit.py
@@ -10,7 +10,7 @@ from core.features.audit import (
     write_audit_report,
 )
 from core.features.io import feature_records_to_parquet_bytes
-from services.r2.paths import layer1_ticker_history_path
+from services.r2.paths import layer1_ticker_history_path, raw_news_path
 from tests.fixtures.layer1_audit_support import local_writer, seed_layer1_audit_fixture
 
 
@@ -73,3 +73,116 @@ def test_audit_layer1_features_flags_history_mismatch(
     )
     assert market_result["status"] == "fail"
     assert any("returns_1d" in mismatch for mismatch in market_result["mismatches"])
+
+
+def test_audit_layer1_features_requires_non_empty_tickers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The audit rejects empty ticker inputs before attempting archive reads."""
+    writer = local_writer(tmp_path, monkeypatch)
+
+    with pytest.raises(ValueError, match="tickers must contain at least one non-empty ticker"):
+        audit_layer1_features(
+            run_id="audit-empty",
+            as_of_date="2024-05-06",
+            tickers=["", " "],
+            writer=writer,
+        )
+
+
+def test_audit_layer1_features_warns_when_raw_news_archive_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing Layer 0 news archives produce a warning instead of aborting the audit."""
+    writer = local_writer(tmp_path, monkeypatch)
+    fixture = seed_layer1_audit_fixture(writer)
+    writer.delete_object(raw_news_path(str(fixture["as_of_date"])))
+
+    report = audit_layer1_features(
+        run_id="audit-missing-news",
+        as_of_date=str(fixture["as_of_date"]),
+        tickers=[str(fixture["ticker"])],
+        benchmark_ticker=str(fixture["benchmark_ticker"]),
+        writer=writer,
+    )
+
+    assert report.summary["fail"] == 0
+    assert any(
+        finding["status"] == "warn"
+        and finding["category"] == "news"
+        and "Raw Layer 0 news archive missing" in finding["message"]
+        for finding in report.findings
+    )
+
+
+def test_audit_layer1_features_warns_and_skips_malformed_news_jsonl(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Malformed raw news JSONL rows are warned on and skipped during recomputation."""
+    writer = local_writer(tmp_path, monkeypatch)
+    fixture = seed_layer1_audit_fixture(writer)
+    news_key = raw_news_path(str(fixture["as_of_date"]))
+    writer.put_object(news_key, writer.get_object(news_key) + b"{malformed-json}\n")
+
+    report = audit_layer1_features(
+        run_id="audit-malformed-news",
+        as_of_date=str(fixture["as_of_date"]),
+        tickers=[str(fixture["ticker"])],
+        benchmark_ticker=str(fixture["benchmark_ticker"]),
+        writer=writer,
+    )
+
+    assert report.summary["fail"] == 0
+    assert any(
+        finding["status"] == "warn"
+        and finding["category"] == "news"
+        and "Skipped malformed JSON Lines rows" in finding["message"]
+        for finding in report.findings
+    )
+    assert any(
+        finding["status"] == "pass"
+        and finding["category"] == "news"
+        and "matches raw Layer 0 inputs" in finding["message"]
+        for finding in report.findings
+    )
+
+
+def test_audit_layer1_features_flags_nan_feature_values(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NaN values in stored feature histories fail catalog validation."""
+    writer = local_writer(tmp_path, monkeypatch)
+    fixture = seed_layer1_audit_fixture(writer)
+    history_record = fixture["history_record"].model_copy(
+        update={
+            "features": {
+                **fixture["history_record"].features,
+                "returns_1d": float("nan"),
+            }
+        }
+    )
+    writer.put_object(
+        layer1_ticker_history_path(str(fixture["ticker"])),
+        feature_records_to_parquet_bytes([history_record]),
+    )
+
+    report = audit_layer1_features(
+        run_id="audit-nan-history",
+        as_of_date=str(fixture["as_of_date"]),
+        tickers=[str(fixture["ticker"])],
+        benchmark_ticker=str(fixture["benchmark_ticker"]),
+        writer=writer,
+    )
+
+    assert report.summary["fail"] > 0
+    assert report.catalog_summary["value_failures"] > 0
+    assert any(
+        finding["status"] == "fail"
+        and finding["category"] == "catalog"
+        and "returns_1d" in str(finding["details"])
+        for finding in report.findings
+    )


### PR DESCRIPTION
## What this PR does
Adds a read-only Layer 1 feature correctness audit harness for Layer 0/1 validation. The new CLI reads existing Layer 0 and Layer 1 artifacts, recomputes deterministic market/context/topic/sentiment/regime branches, validates the stored FeatureRecord catalog and point-in-time boundaries, and writes a durable JSON report plus operator-facing text summary without mutating production feature histories.

## Closes
Closes #156

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Local audit output writes:
- `artifacts/reports/diagnostics/layer1_feature_audit_<run_id>_<as_of_date>.json`
- `artifacts/reports/diagnostics/layer1_feature_audit_<run_id>_<as_of_date>.txt`

## Notes for reviewer
Commands run:
- `./.venv/bin/pytest tests/unit/ -v --tb=short`
- `./.venv/bin/pytest tests/integration/test_layer1_feature_audit_integration.py -v --tb=short`

Test result summary:
- `484 passed` in the required unit suite
- `1 passed` in the new Layer 1 audit integration test

Manifest key(s):
- Local fixture manifests only in tests for `layer1_news_preprocessing`, `layer1_text_topics`, `layer1_finbert_sentiment`, and `layer1_5_regime`

Report path(s):
- Audit CLI writes local reports under `artifacts/reports/diagnostics/`
- Unit coverage verifies JSON and text report emission

R2 output prefix(es):
- None new; audit is read-only against production artifacts

Known skipped/missing data:
- The audit warns rather than mutates state when optional branch artifacts are absent for a sampled date
