### PR TITLE
Fetch Layer 1 benchmark prices in Layer 0

### DIFF
--- a/app/lab/data_pipelines/backfill_layer0.py
+++ b/app/lab/data_pipelines/backfill_layer0.py
@@ -105,6 +105,7 @@ def main() -> int:
         from_date=from_date,
         to_date=to_date,
         tickers=args.tickers,
+        benchmark_ticker=args.benchmark_ticker,
         fred_series_ids=args.series_ids or archive_config.series_ids,
         overwrite=args.overwrite,
         news_limit=args.news_limit,
@@ -138,6 +139,14 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--to-date", metavar="YYYY-MM-DD")
     parser.add_argument("--tickers", nargs="*", default=None)
+    parser.add_argument(
+        "--benchmark-ticker",
+        default="SPY",
+        help=(
+            "Benchmark ticker whose raw price archive must also be refreshed for Layer 1 "
+            "(default: SPY)."
+        ),
+    )
     parser.add_argument("--series-ids", nargs="*", default=None)
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--run-id", default=None)

--- a/app/pi/fetchers/layer0.py
+++ b/app/pi/fetchers/layer0.py
@@ -37,6 +37,7 @@ def run_layer0_incremental(
     *,
     as_of_date: date,
     tickers: Sequence[str],
+    benchmark_ticker: str = "SPY",
     series_ids: Sequence[str] | None = None,
     overwrite: bool = False,
     run_id: str | None = None,
@@ -52,6 +53,7 @@ def run_layer0_incremental(
     config = DailyLayer0Config(
         as_of_date=as_of_date,
         tickers=tickers,
+        benchmark_ticker=benchmark_ticker,
         fred_series_ids=series_ids or archive_config.series_ids,
         overwrite=overwrite,
         news_limit=news_limit,
@@ -81,6 +83,7 @@ def main() -> int:
     result = run_layer0_incremental(
         as_of_date=as_of_date,
         tickers=args.tickers,
+        benchmark_ticker=args.benchmark_ticker,
         series_ids=args.series_ids,
         overwrite=args.overwrite,
         run_id=args.run_id,
@@ -99,6 +102,14 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--config", default=str(DEFAULT_FRED_CONFIG_PATH))
     parser.add_argument("--as-of-date", required=True, metavar="YYYY-MM-DD")
     parser.add_argument("--tickers", nargs="+", required=True)
+    parser.add_argument(
+        "--benchmark-ticker",
+        default="SPY",
+        help=(
+            "Benchmark ticker whose raw price archive must also be refreshed for Layer 1 "
+            "(default: SPY)."
+        ),
+    )
     parser.add_argument("--series-ids", nargs="*", default=None)
     parser.add_argument("--overwrite", action="store_true")
     parser.add_argument("--run-id", default=None)

--- a/app/pi/run_daily.py
+++ b/app/pi/run_daily.py
@@ -42,7 +42,7 @@ class DailyRunDependencies:
     """Injected runtime surfaces for live or dry-run orchestration."""
 
     market_context_collector: Callable[[str], dict[str, object]]
-    layer0_runner: Callable[[date, Sequence[str]], Layer0RunSummary]
+    layer0_runner: Callable[[date, Sequence[str], str], Layer0RunSummary]
     modal_runtime_loader: Callable[[], PiModalRuntimeConfig]
     layer1_trigger: Callable[[Layer1TriggerConfig], Layer1DispatchResult]
     layer1_waiter: Callable[[Layer1WaitConfig], PipelineManifestRecord]
@@ -87,7 +87,7 @@ def run_daily(
     tickers = _context_tickers(context)
     manifests.append(_manifest(run_id, "collect_market_context", 0, {"tickers": len(tickers)}))
 
-    layer0_result = dependencies.layer0_runner(parsed_date, tickers)
+    layer0_result = dependencies.layer0_runner(parsed_date, tickers, benchmark_ticker)
     manifests.append(
         _manifest(
             run_id,
@@ -248,15 +248,28 @@ def _dry_run_dependencies() -> DailyRunDependencies:
     )
 
 
-def _run_live_layer0(as_of_date: date, tickers: Sequence[str]) -> Layer0RunSummary:
+def _run_live_layer0(
+    as_of_date: date,
+    tickers: Sequence[str],
+    benchmark_ticker: str,
+) -> Layer0RunSummary:
     """Run the production Layer 0 incremental pipeline and return its manifest identity."""
-    result = run_live_layer0_incremental(as_of_date=as_of_date, tickers=tickers)
+    result = run_live_layer0_incremental(
+        as_of_date=as_of_date,
+        tickers=tickers,
+        benchmark_ticker=benchmark_ticker,
+    )
     return Layer0RunSummary(run_id=result.run_id, manifest_key=result.manifest_key)
 
 
-def _run_dry_layer0(as_of_date: date, tickers: Sequence[str]) -> Layer0RunSummary:
+def _run_dry_layer0(
+    as_of_date: date,
+    tickers: Sequence[str],
+    benchmark_ticker: str,
+) -> Layer0RunSummary:
     """Return a deterministic Layer 0 completion record for dry-run orchestration."""
     _ = tickers
+    _ = benchmark_ticker
     run_id = f"layer0-daily-{as_of_date.isoformat()}"
     return Layer0RunSummary(
         run_id=run_id,

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -187,6 +187,7 @@ class HistoricalLayer0Config:
     from_date: date
     to_date: date
     tickers: Sequence[str] | None = None
+    benchmark_ticker: str = "SPY"
     fred_series_ids: Sequence[str] = ()
     simfin_statements: Sequence[str] = ("pl", "bs", "cf", "derived")
     simfin_periods: Sequence[str] = ("q1", "q2", "q3", "q4", "fy")
@@ -204,12 +205,15 @@ class HistoricalLayer0Config:
         _validate_positive_limit(self.news_limit, "news_limit")
         _validate_positive_limit(self.simfin_limit, "simfin_limit")
         _validate_positive_limit(self.fred_limit, "fred_limit")
+        if not self.benchmark_ticker.strip():
+            raise ValueError("benchmark_ticker cannot be empty")
         if not self.fred_series_ids:
             raise ValueError("fred_series_ids must contain at least one series")
         if not self.simfin_statements:
             raise ValueError("simfin_statements must contain at least one statement")
         if not self.simfin_periods:
             raise ValueError("simfin_periods must contain at least one period")
+        object.__setattr__(self, "benchmark_ticker", _canonicalize_ticker(self.benchmark_ticker))
 
 
 @dataclass(frozen=True)
@@ -219,6 +223,7 @@ class DailyLayer0Config:
     as_of_date: date
     tickers: Sequence[str]
     fred_series_ids: Sequence[str]
+    benchmark_ticker: str = "SPY"
     simfin_statements: Sequence[str] = ("pl", "bs", "cf", "derived")
     simfin_periods: Sequence[str] = ("q1", "q2", "q3", "q4", "fy")
     overwrite: bool = False
@@ -233,6 +238,8 @@ class DailyLayer0Config:
         """Validate daily ticker and vendor-fetch settings."""
         if not _normalize_tickers(self.tickers):
             raise ValueError("tickers must contain at least one ticker")
+        if not self.benchmark_ticker.strip():
+            raise ValueError("benchmark_ticker cannot be empty")
         if not self.fred_series_ids:
             raise ValueError("fred_series_ids must contain at least one series")
         if not self.simfin_statements:
@@ -242,6 +249,7 @@ class DailyLayer0Config:
         _validate_positive_limit(self.news_limit, "news_limit")
         _validate_positive_limit(self.simfin_limit, "simfin_limit")
         _validate_positive_limit(self.fred_limit, "fred_limit")
+        object.__setattr__(self, "benchmark_ticker", _canonicalize_ticker(self.benchmark_ticker))
 
 
 @dataclass(frozen=True)
@@ -292,7 +300,15 @@ def run_historical_layer0_backfill(
             config.to_date.isoformat(),
         )
         tickers = _resolve_backfill_tickers(config=config, universe_provider=universe_provider)
-        logger.info("Resolved {} tickers for backfill", len(tickers))
+        price_tickers = _scope_with_benchmark(
+            tickers=tickers,
+            benchmark_ticker=config.benchmark_ticker,
+        )
+        logger.info(
+            "Resolved {} universe tickers and {} price tickers for backfill",
+            len(tickers),
+            len(price_tickers),
+        )
         quality_window = _copy_ohlcv_window(config.quality_ohlcv_window)
 
         logger.info("Caching existence keys across R2 raw/ prefixes")
@@ -309,7 +325,7 @@ def run_historical_layer0_backfill(
         logger.info("Phase: prices")
         price_result = _backfill_historical_prices(
             config=config,
-            tickers=tickers,
+            tickers=price_tickers,
             price_fetcher=price_fetcher,
             security_master=security_master,
             writer=cached_writer,
@@ -452,6 +468,10 @@ def run_daily_layer0_incremental(
     started_at = datetime.now(UTC)
     as_of_date = config.as_of_date
     tickers = _normalize_tickers(config.tickers)
+    price_tickers = _scope_with_benchmark(
+        tickers=tickers,
+        benchmark_ticker=config.benchmark_ticker,
+    )
     output_keys: list[str] = []
     metadata: dict[str, object] = _base_metadata(
         mode="daily_incremental",
@@ -463,7 +483,7 @@ def run_daily_layer0_incremental(
     try:
         daily_records = _canonicalize_ohlcv_records(
             live_price_fetcher.fetch_live_daily_bars(
-                tickers=tickers,
+                tickers=price_tickers,
                 as_of_date=as_of_date.isoformat(),
             )
         )
@@ -480,9 +500,15 @@ def run_daily_layer0_incremental(
         quality_window = _copy_ohlcv_window(config.quality_ohlcv_window)
         _extend_quality_window_from_price_archives(
             writer=writer,
-            tickers=tickers,
+            tickers=price_tickers,
             deserializer=price_deserializer or _parquet_bytes_to_records,
             quality_window=quality_window,
+        )
+        _require_target_date_price_coverage(
+            as_of_date=as_of_date,
+            tickers=(config.benchmark_ticker,),
+            ohlcv_window=quality_window,
+            reason="benchmark_ticker",
         )
         universe_records = build_universe_mask_records(
             as_of_date=as_of_date,
@@ -612,6 +638,11 @@ def _resolve_backfill_tickers(
     if not tickers:
         raise ValueError("historical backfill ticker universe is empty")
     return list(tickers)
+
+
+def _scope_with_benchmark(*, tickers: Sequence[str], benchmark_ticker: str) -> list[str]:
+    """Return the price-fetch scope with the required Layer 1 benchmark included."""
+    return list(_normalize_tickers([*tickers, benchmark_ticker]))
 
 
 def _backfill_historical_prices(
@@ -1240,6 +1271,31 @@ def _require_price_coverage_for_eligible_universe(
         raise RuntimeError(
             "Layer 0 cannot mark the universe ready without raw target-date price coverage for: "
             + ", ".join(sorted(set(missing)))
+        )
+
+
+def _require_target_date_price_coverage(
+    *,
+    as_of_date: date,
+    tickers: Sequence[str],
+    ohlcv_window: Mapping[str, Sequence[OHLCVRecord]],
+    reason: str,
+) -> None:
+    """Require target-date coverage for explicitly required non-universe tickers."""
+    target_date = as_of_date.isoformat()
+    indexed_dates = {
+        _canonicalize_ticker(ticker): {record.date for record in rows}
+        for ticker, rows in ohlcv_window.items()
+    }
+    missing = [
+        ticker
+        for ticker in _normalize_tickers(tickers)
+        if target_date not in indexed_dates.get(_canonicalize_ticker(ticker), set())
+    ]
+    if missing:
+        raise RuntimeError(
+            f"Layer 0 missing raw target-date price coverage for {reason}: "
+            + ", ".join(missing)
         )
 
 

--- a/tests/integration/test_pi_layer1_orchestration.py
+++ b/tests/integration/test_pi_layer1_orchestration.py
@@ -39,8 +39,9 @@ def test_pi_runtime_waits_for_layer1_manifest_with_mocked_modal_trigger() -> Non
             "account": {"equity": 100_000.0, "cash": 25_000.0},
         }
 
-    def _layer0_runner(as_of_date: date, tickers) -> Layer0RunSummary:
+    def _layer0_runner(as_of_date: date, tickers, benchmark_ticker: str) -> Layer0RunSummary:
         _ = tickers
+        assert benchmark_ticker == "QQQ"
         run_id = f"layer0-daily-{as_of_date.isoformat()}"
         return Layer0RunSummary(
             run_id=run_id,
@@ -48,6 +49,7 @@ def test_pi_runtime_waits_for_layer1_manifest_with_mocked_modal_trigger() -> Non
         )
 
     def _layer1_trigger(config: Layer1TriggerConfig) -> Layer1DispatchResult:
+        assert config.benchmark_ticker == "QQQ"
         manifest = PipelineManifestRecord(
             run_id=config.run_id,
             stage="layer1",
@@ -100,7 +102,12 @@ def test_pi_runtime_waits_for_layer1_manifest_with_mocked_modal_trigger() -> Non
         },
     )
 
-    manifests = run_daily("2026-04-06", dependencies=dependencies, runtime_run_id="itest-run")
+    manifests = run_daily(
+        "2026-04-06",
+        dependencies=dependencies,
+        benchmark_ticker="QQQ",
+        runtime_run_id="itest-run",
+    )
 
     assert [row["stage"] for row in manifests][:4] == [
         "collect_market_context",

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -83,6 +83,8 @@ class _SecurityMaster:
             return [_Security(ticker="AAPL", security_id="perm-aapl", start_date="2020-01-01")]
         if ticker == "MSFT":
             return [_Security(ticker="MSFT", security_id="perm-msft", start_date="2020-01-01")]
+        if ticker == "SPY":
+            return [_Security(ticker="SPY", security_id="perm-spy", start_date="2020-01-01")]
         raise KeyError(ticker)
 
 
@@ -102,14 +104,16 @@ class _HistoricalPriceFetcher:
 
 class _LivePriceFetcher:
     def __init__(self, records: list[OHLCVRecord] | None = None) -> None:
-        self.records = records or [_bar(date_value="2024-01-02", ticker="AAPL")]
+        self.records = records
         self.calls: list[dict[str, Any]] = []
 
     def fetch_live_daily_bars(
         self, *, tickers: list[str] | tuple[str, ...], as_of_date: str
     ) -> list[OHLCVRecord]:
         self.calls.append({"tickers": tuple(tickers), "as_of_date": as_of_date})
-        return self.records
+        if self.records is not None:
+            return self.records
+        return [_bar(date_value=as_of_date, ticker=ticker) for ticker in tickers]
 
 
 class _NewsFetcher:
@@ -284,6 +288,7 @@ def test_historical_layer0_backfill_writes_all_raw_archives_and_manifest() -> No
         raw_security_master_path(date(2024, 1, 3)),
         raw_price_path("perm-aapl"),
         raw_price_path("perm-msft"),
+        raw_price_path("perm-spy"),
         raw_universe_path("2024-01-02"),
         raw_universe_path("2024-01-03"),
         raw_news_path("2024-01-02"),
@@ -316,10 +321,13 @@ def test_historical_backfill_reads_existing_prices_from_store_for_quality_masks(
     writer = _Writer()
     aapl_key = raw_price_path("perm-aapl")
     msft_key = raw_price_path("perm-msft")
+    spy_key = raw_price_path("perm-spy")
     writer.put_object(aapl_key, _bytes_serializer([_bar(date_value="2024-01-02", ticker="AAPL")]))
     writer.put_object(msft_key, _bytes_serializer([_bar(date_value="2024-01-02", ticker="MSFT")]))
+    writer.put_object(spy_key, _bytes_serializer([_bar(date_value="2024-01-02", ticker="SPY")]))
     writer.put_counts[aapl_key] = 0
     writer.put_counts[msft_key] = 0
+    writer.put_counts[spy_key] = 0
     price_fetcher = _HistoricalPriceFetcher()
 
     run_historical_layer0_backfill(
@@ -344,9 +352,14 @@ def test_historical_backfill_reads_existing_prices_from_store_for_quality_masks(
         macro_serializer=_bytes_serializer,
     )
 
-    assert {aapl_key: writer.put_counts[aapl_key], msft_key: writer.put_counts[msft_key]} == {
+    assert {
+        aapl_key: writer.put_counts[aapl_key],
+        msft_key: writer.put_counts[msft_key],
+        spy_key: writer.put_counts[spy_key],
+    } == {
         aapl_key: 0,
         msft_key: 0,
+        spy_key: 0,
     }
     assert price_fetcher.calls == []
     universe_rows = list(
@@ -384,8 +397,9 @@ def test_daily_layer0_incremental_uses_alpaca_shape_and_canonical_paths() -> Non
         macro_serializer=_bytes_serializer,
     )
 
-    assert live_fetcher.calls == [{"tickers": ("AAPL",), "as_of_date": "2024-01-02"}]
+    assert live_fetcher.calls == [{"tickers": ("AAPL", "SPY"), "as_of_date": "2024-01-02"}]
     assert raw_price_path("AAPL") in writer.objects
+    assert raw_price_path("SPY") in writer.objects
     assert raw_news_path("2024-01-02") in writer.objects
     assert raw_fundamentals_path("AAPL") in writer.objects
     assert raw_macro_path("2024-01-02") in writer.objects
@@ -400,7 +414,12 @@ def test_daily_layer0_incremental_uses_alpaca_shape_and_canonical_paths() -> Non
 
 def test_daily_layer0_incremental_canonicalizes_dot_tickers_across_outputs() -> None:
     writer = _Writer()
-    live_fetcher = _LivePriceFetcher(records=[_bar(date_value="2024-01-02", ticker="BRK.B")])
+    live_fetcher = _LivePriceFetcher(
+        records=[
+            _bar(date_value="2024-01-02", ticker="BRK.B"),
+            _bar(date_value="2024-01-02", ticker="SPY"),
+        ]
+    )
 
     run_daily_layer0_incremental(
         config=DailyLayer0Config(
@@ -422,8 +441,9 @@ def test_daily_layer0_incremental_canonicalizes_dot_tickers_across_outputs() -> 
         macro_serializer=_bytes_serializer,
     )
 
-    assert live_fetcher.calls == [{"tickers": ("BRK-B",), "as_of_date": "2024-01-02"}]
+    assert live_fetcher.calls == [{"tickers": ("BRK-B", "SPY"), "as_of_date": "2024-01-02"}]
     assert raw_price_path("BRK-B") in writer.objects
+    assert raw_price_path("SPY") in writer.objects
     price_payload = json.loads(writer.objects[raw_price_path("BRK-B")])
     assert price_payload[0]["ticker"] == "BRK-B"
 
@@ -437,9 +457,21 @@ def test_daily_layer0_incremental_canonicalizes_dot_tickers_across_outputs() -> 
 def test_daily_layer0_incremental_is_idempotent_for_existing_raw_outputs() -> None:
     writer = _Writer()
     price_key = raw_price_path("AAPL")
+    benchmark_key = raw_price_path("SPY")
     universe_key = raw_universe_path("2024-01-02")
-    keys = [price_key, raw_news_path("2024-01-02"), raw_fundamentals_path("AAPL"), raw_macro_path("2024-01-02"), universe_key]
+    keys = [
+        price_key,
+        benchmark_key,
+        raw_news_path("2024-01-02"),
+        raw_fundamentals_path("AAPL"),
+        raw_macro_path("2024-01-02"),
+        universe_key,
+    ]
     writer.put_object(price_key, _bytes_serializer([_bar(date_value="2024-01-02", ticker="AAPL")]))
+    writer.put_object(
+        benchmark_key,
+        _bytes_serializer([_bar(date_value="2024-01-02", ticker="SPY")]),
+    )
     writer.put_object(raw_news_path("2024-01-02"), b"existing")
     writer.put_object(raw_fundamentals_path("AAPL"), b"existing")
     writer.put_object(raw_macro_path("2024-01-02"), b"existing")
@@ -485,8 +517,13 @@ def test_daily_layer0_incremental_is_idempotent_for_existing_raw_outputs() -> No
 def test_daily_layer0_incremental_repairs_missing_target_date_and_rewrites_universe_mask() -> None:
     writer = _Writer()
     price_key = raw_price_path("AAPL")
+    benchmark_key = raw_price_path("SPY")
     universe_key = raw_universe_path("2024-01-03")
     writer.put_object(price_key, _bytes_serializer([_bar(date_value="2024-01-02", ticker="AAPL")]))
+    writer.put_object(
+        benchmark_key,
+        _bytes_serializer([_bar(date_value="2024-01-02", ticker="SPY")]),
+    )
     writer.put_object(
         universe_key,
         _universe_serializer(
@@ -505,6 +542,7 @@ def test_daily_layer0_incremental_repairs_missing_target_date_and_rewrites_unive
         ),
     )
     writer.put_counts[price_key] = 0
+    writer.put_counts[benchmark_key] = 0
     writer.put_counts[universe_key] = 0
 
     run_daily_layer0_incremental(
@@ -515,7 +553,12 @@ def test_daily_layer0_incremental_repairs_missing_target_date_and_rewrites_unive
             run_id="test-repair-daily",
             quality_config=QualityFilterConfig(rolling_window_days=2),
         ),
-        live_price_fetcher=_LivePriceFetcher(records=[_bar(date_value="2024-01-03", ticker="AAPL")]),
+        live_price_fetcher=_LivePriceFetcher(
+            records=[
+                _bar(date_value="2024-01-03", ticker="AAPL"),
+                _bar(date_value="2024-01-03", ticker="SPY"),
+            ]
+        ),
         news_fetcher=_NewsFetcher(),
         fundamentals_fetcher=_FundamentalsFetcher(),
         macro_fetcher=_MacroFetcher(),
@@ -530,7 +573,10 @@ def test_daily_layer0_incremental_repairs_missing_target_date_and_rewrites_unive
 
     price_payload = json.loads(writer.objects[price_key])
     assert [row["date"] for row in price_payload] == ["2024-01-02", "2024-01-03"]
+    benchmark_payload = json.loads(writer.objects[benchmark_key])
+    assert [row["date"] for row in benchmark_payload] == ["2024-01-02", "2024-01-03"]
     assert writer.put_counts[price_key] == 1
+    assert writer.put_counts[benchmark_key] == 1
     assert writer.put_counts[universe_key] == 1
     universe_rows = list(csv.DictReader(io.StringIO(writer.objects[universe_key].decode("utf-8"))))
     assert universe_rows[0]["data_quality_ok"] == "True"
@@ -577,8 +623,10 @@ def test_historical_backfill_skips_quality_reads_when_universe_masks_exist() -> 
     writer = _Writer()
     aapl_key = raw_price_path("perm-aapl")
     msft_key = raw_price_path("perm-msft")
+    spy_key = raw_price_path("perm-spy")
     writer.put_object(aapl_key, _bytes_serializer([_bar(date_value="2024-01-02", ticker="AAPL")]))
     writer.put_object(msft_key, _bytes_serializer([_bar(date_value="2024-01-02", ticker="MSFT")]))
+    writer.put_object(spy_key, _bytes_serializer([_bar(date_value="2024-01-02", ticker="SPY")]))
     # Pre-populate universe mask so _all_universe_masks_exist returns True
     writer.put_object(raw_universe_path("2024-01-02"), b"placeholder")
     # Pre-populate security master
@@ -684,13 +732,98 @@ def test_historical_backfill_repairs_existing_price_history_for_one_day_catch_up
         universe_serializer=_universe_serializer,
     )
 
-    assert price_fetcher.calls == [{"ticker": "AAPL", "from_date": "2024-01-03", "to_date": "2024-01-03"}]
+    assert price_fetcher.calls == [
+        {"ticker": "AAPL", "from_date": "2024-01-03", "to_date": "2024-01-03"},
+        {"ticker": "SPY", "from_date": "2024-01-03", "to_date": "2024-01-03"},
+    ]
     price_payload = json.loads(writer.objects[stale_price_key])
     assert [row["date"] for row in price_payload] == ["2024-01-02", "2024-01-03"]
     assert writer.put_counts[stale_price_key] == 1
     assert writer.put_counts[universe_key] == 1
     universe_rows = list(csv.DictReader(io.StringIO(writer.objects[universe_key].decode("utf-8"))))
     assert universe_rows[0]["data_quality_ok"] == "True"
+
+
+def test_historical_backfill_fetches_benchmark_prices_without_adding_benchmark_to_universe() -> None:
+    writer = _Writer()
+    price_fetcher = _HistoricalPriceFetcher()
+
+    run_historical_layer0_backfill(
+        config=HistoricalLayer0Config(
+            from_date=date(2024, 1, 2),
+            to_date=date(2024, 1, 2),
+            fred_series_ids=("DGS10",),
+            run_id="test-benchmark-historical",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        universe_provider=_UniverseProvider(),
+        price_fetcher=price_fetcher,
+        security_master=_SecurityMaster(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        price_deserializer=_bytes_deserializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+        universe_serializer=_universe_serializer,
+    )
+
+    assert raw_price_path("perm-spy") in writer.objects
+    assert {call["ticker"] for call in price_fetcher.calls} == {"AAPL", "MSFT", "SPY"}
+    universe_rows = list(
+        csv.DictReader(io.StringIO(writer.objects[raw_universe_path("2024-01-02")].decode()))
+    )
+    assert [row["ticker"] for row in universe_rows] == ["AAPL", "MSFT"]
+
+
+def test_historical_backfill_repairs_stale_benchmark_archive_missing_target_date() -> None:
+    writer = _Writer()
+    benchmark_key = raw_price_path("perm-spy")
+    writer.put_object(
+        benchmark_key,
+        _bytes_serializer([_bar(date_value="2024-01-02", ticker="SPY")]),
+    )
+    writer.put_counts[benchmark_key] = 0
+
+    class _SpyOnlyUniverseProvider:
+        def get_constituents(self, as_of_date: str) -> list[str]:
+            return ["AAPL", "MSFT"]
+
+        def get_historical_tickers(self, from_date: str, to_date: str) -> set[str]:
+            return {"AAPL", "MSFT"}
+
+    price_fetcher = _HistoricalPriceFetcher()
+
+    run_historical_layer0_backfill(
+        config=HistoricalLayer0Config(
+            from_date=date(2024, 1, 3),
+            to_date=date(2024, 1, 3),
+            fred_series_ids=("DGS10",),
+            run_id="test-benchmark-top-up",
+            quality_config=QualityFilterConfig(rolling_window_days=2),
+        ),
+        universe_provider=_SpyOnlyUniverseProvider(),
+        price_fetcher=price_fetcher,
+        security_master=_SecurityMaster(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        price_deserializer=_bytes_deserializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+        universe_serializer=_universe_serializer,
+    )
+
+    assert {"ticker": "SPY", "from_date": "2024-01-03", "to_date": "2024-01-03"} in price_fetcher.calls
+    benchmark_payload = json.loads(writer.objects[benchmark_key])
+    assert [row["date"] for row in benchmark_payload] == ["2024-01-02", "2024-01-03"]
+    assert writer.put_counts[benchmark_key] == 1
 
 
 def test_layer0_config_rejects_empty_inputs() -> None:

--- a/tests/unit/test_pi_layer0_runner.py
+++ b/tests/unit/test_pi_layer0_runner.py
@@ -73,6 +73,7 @@ def test_run_layer0_incremental_builds_daily_config_and_forwards_dependencies(
     result = run_layer0_incremental(
         as_of_date=date(2026, 4, 6),
         tickers=("AAPL", "MSFT"),
+        benchmark_ticker="QQQ",
         overwrite=True,
         run_id="layer0-daily-2026-04-06",
         news_limit=25,
@@ -86,6 +87,7 @@ def test_run_layer0_incremental_builds_daily_config_and_forwards_dependencies(
     config = captured["config"]
     assert config.as_of_date == date(2026, 4, 6)
     assert tuple(config.tickers) == ("AAPL", "MSFT")
+    assert config.benchmark_ticker == "QQQ"
     assert tuple(config.fred_series_ids) == ("FEDFUNDS", "DGS10")
     assert config.overwrite is True
     assert config.run_id == "layer0-daily-2026-04-06"


### PR DESCRIPTION
## What this PR does
Ensures Layer 0 historical and Pi daily/incremental price fetches include required Layer 1 benchmark price coverage, defaulting to `SPY`, even when the benchmark ETF is not part of the tradable universe. This prevents stale benchmark archives like `raw/prices/SPY.parquet` from being skipped when Layer 1 requires target-date benchmark coverage.

This is a follow-up to #164 / #162: #164 fixed the first idempotency gap, and this commit adds the missing benchmark-fetch path that the production `SPY` `2026-04-13` failure exposed.

## Closes
Follow-up to #162 and #164

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [ ] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover the benchmark-fetch regression, stale benchmark top-up, and universe mask exclusion behavior
- [x] No live API calls in unit tests — fixtures/mocks used

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring where applicable
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue #162 is already closed from #164; this is a follow-up PR
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Validation run locally:

```text
./.venv/bin/pytest tests/unit/test_layer0_pipeline.py tests/unit/test_pi_layer0_runner.py tests/unit/test_pi_runtime_skeleton.py tests/integration/test_pi_layer1_orchestration.py tests/unit/test_backfill_layer0.py -q
21 passed in 0.37s

./.venv/bin/python -m ruff check core/data/layer0_pipeline.py app/lab/data_pipelines/backfill_layer0.py app/pi/fetchers/layer0.py app/pi/run_daily.py tests/unit/test_layer0_pipeline.py tests/unit/test_pi_layer0_runner.py tests/integration/test_pi_layer1_orchestration.py
All checks passed!
```

Production repair already verified after applying the fix locally:
- `raw/prices/SPY.parquet` contains `2026-04-13`
- `SPY` close on `2026-04-13`: `686.1`
- Layer 1 benchmark coverage gate passed

## Notes for reviewer
Please focus on the distinction between benchmark price coverage and tradable universe membership: `SPY` should be fetched/written for Layer 1 benchmark readiness, but should not be inserted into the universe mask unless it is actually part of the requested universe scope.
