### PR TITLE
Add raw-vs-computed Layer 1 market spot checks

### DIFF
--- a/app/lab/data_pipelines/build_layer1_feature_audit_dashboard.py
+++ b/app/lab/data_pipelines/build_layer1_feature_audit_dashboard.py
@@ -80,7 +80,9 @@ def main(argv: list[str] | None = None) -> int:
     logger.info("Layer 1 audit dashboard JSON written: {}", output_paths.json_path)
     logger.info("Layer 1 audit dashboard summary written: {}", output_paths.summary_path)
     logger.info("\n{}", render_layer1_audit_dashboard_summary(report))
-    return 1 if report.summary.get("family_fail_count", 0) > 0 else 0
+    if report.summary.get("family_fail_count", 0) > 0:
+        return 1
+    return 1 if report.summary.get("spot_check_fail_count", 0) > 0 else 0
 
 
 if __name__ == "__main__":

--- a/core/features/dashboard_backend.py
+++ b/core/features/dashboard_backend.py
@@ -21,8 +21,9 @@ from core.features.catalog import (
 )
 from core.features.io import read_feature_history_window
 from core.features.market_spotchecks import (
-    _summarize_market_feature_spot_checks,
+    MarketFeatureSpotCheckRecord,
     build_market_feature_spot_checks,
+    summarize_market_feature_spot_checks,
 )
 from services.r2.paths import layer1_ticker_history_path
 from services.r2.writer import R2Writer
@@ -731,12 +732,12 @@ def _build_dashboard_summary(
     load_warnings: Sequence[DashboardLoadWarning],
     family_status_summaries: Sequence[FeatureFamilyStatus],
     outlier_records: Sequence[OutlierRecord],
-    spot_check_records: Sequence[object],
+    spot_check_records: Sequence[MarketFeatureSpotCheckRecord],
 ) -> dict[str, int]:
     counts = {"pass": 0, "warn": 0, "fail": 0}
     for item in family_status_summaries:
         counts[item.status] += 1
-    spot_check_counts = _summarize_market_feature_spot_checks(spot_check_records)
+    spot_check_counts = summarize_market_feature_spot_checks(spot_check_records)
     return {
         "rows_loaded": len(selection_rows),
         "load_warning_count": len(load_warnings),

--- a/core/features/dashboard_backend.py
+++ b/core/features/dashboard_backend.py
@@ -21,8 +21,8 @@ from core.features.catalog import (
 )
 from core.features.io import read_feature_history_window
 from core.features.market_spotchecks import (
+    _summarize_market_feature_spot_checks,
     build_market_feature_spot_checks,
-    summarize_market_feature_spot_checks,
 )
 from services.r2.paths import layer1_ticker_history_path
 from services.r2.writer import R2Writer
@@ -736,7 +736,7 @@ def _build_dashboard_summary(
     counts = {"pass": 0, "warn": 0, "fail": 0}
     for item in family_status_summaries:
         counts[item.status] += 1
-    spot_check_counts = summarize_market_feature_spot_checks(spot_check_records)
+    spot_check_counts = _summarize_market_feature_spot_checks(spot_check_records)
     return {
         "rows_loaded": len(selection_rows),
         "load_warning_count": len(load_warnings),

--- a/core/features/dashboard_backend.py
+++ b/core/features/dashboard_backend.py
@@ -20,6 +20,10 @@ from core.features.catalog import (
     validate_feature_value,
 )
 from core.features.io import read_feature_history_window
+from core.features.market_spotchecks import (
+    build_market_feature_spot_checks,
+    summarize_market_feature_spot_checks,
+)
 from services.r2.paths import layer1_ticker_history_path
 from services.r2.writer import R2Writer
 
@@ -171,6 +175,8 @@ class Layer1AuditDashboardReport:
     feature_null_summaries: list[dict[str, object]]
     family_status_summaries: list[dict[str, object]]
     outlier_records: list[dict[str, object]]
+    spot_check_records: list[dict[str, object]]
+    formula_audit_cards: list[dict[str, object]]
     summary: dict[str, int]
 
     def to_dict(self) -> dict[str, object]:
@@ -274,11 +280,16 @@ def build_layer1_audit_dashboard_report(
         feature_summaries=feature_null_summaries,
         outlier_records=outlier_records,
     )
+    spot_check_records, formula_audit_cards = build_market_feature_spot_checks(
+        records=sorted_rows,
+        writer=active_writer,
+    )
     summary = _build_dashboard_summary(
         selection_rows=selection_rows,
         load_warnings=load_warnings,
         family_status_summaries=family_status_summaries,
         outlier_records=outlier_records,
+        spot_check_records=spot_check_records,
     )
 
     return Layer1AuditDashboardReport(
@@ -304,6 +315,8 @@ def build_layer1_audit_dashboard_report(
         feature_null_summaries=[summary_item.to_dict() for summary_item in feature_null_summaries],
         family_status_summaries=[summary_item.to_dict() for summary_item in family_status_summaries],
         outlier_records=[record.to_dict() for record in outlier_records],
+        spot_check_records=[record.to_dict() for record in spot_check_records],
+        formula_audit_cards=[card.to_dict() for card in formula_audit_cards],
         summary=summary,
     )
 
@@ -355,6 +368,12 @@ def render_layer1_audit_dashboard_summary(report: Layer1AuditDashboardReport) ->
             f"FAIL={report.summary.get('family_fail_count', 0)}"
         ),
         f"Outlier records: {report.summary.get('outlier_count', 0)}",
+        (
+            "Market spot checks: "
+            f"PASS={report.summary.get('spot_check_pass_count', 0)} "
+            f"WARN={report.summary.get('spot_check_warn_count', 0)} "
+            f"FAIL={report.summary.get('spot_check_fail_count', 0)}"
+        ),
         "",
         "Family Status:",
     ]
@@ -378,6 +397,15 @@ def render_layer1_audit_dashboard_summary(report: Layer1AuditDashboardReport) ->
                 "  "
                 f"{item['ticker']} {item['date']} {item['feature_name']} "
                 f"{item['rule_type']} value={item['value']}"
+            )
+    if report.spot_check_records:
+        lines.extend(["", "Market Spot Check Samples:"])
+        for item in report.spot_check_records[:10]:
+            lines.append(
+                "  "
+                f"{item['ticker']} {item['date']} {item['feature_name']} "
+                f"{str(item['status']).upper()} stored={item['stored_value']} "
+                f"expected={item['expected_value']}"
             )
     return "\n".join(lines) + "\n"
 
@@ -703,10 +731,12 @@ def _build_dashboard_summary(
     load_warnings: Sequence[DashboardLoadWarning],
     family_status_summaries: Sequence[FeatureFamilyStatus],
     outlier_records: Sequence[OutlierRecord],
+    spot_check_records: Sequence[object],
 ) -> dict[str, int]:
     counts = {"pass": 0, "warn": 0, "fail": 0}
     for item in family_status_summaries:
         counts[item.status] += 1
+    spot_check_counts = summarize_market_feature_spot_checks(spot_check_records)
     return {
         "rows_loaded": len(selection_rows),
         "load_warning_count": len(load_warnings),
@@ -714,6 +744,9 @@ def _build_dashboard_summary(
         "family_warn_count": counts["warn"],
         "family_fail_count": counts["fail"],
         "outlier_count": len(outlier_records),
+        "spot_check_pass_count": spot_check_counts["pass"],
+        "spot_check_warn_count": spot_check_counts["warn"],
+        "spot_check_fail_count": spot_check_counts["fail"],
     }
 
 

--- a/core/features/market_spotchecks.py
+++ b/core/features/market_spotchecks.py
@@ -132,6 +132,20 @@ def build_market_feature_spot_checks(
                     checks.append(check)
                     cards.append(card)
             continue
+        except ValueError as exc:
+            reason = f"Raw Layer 0 OHLCV archive is invalid for this ticker: {exc}"
+            for record in ticker_records:
+                for feature_name in supported_features:
+                    check, card = _missing_source_artifact(
+                        record=record,
+                        feature_name=feature_name,
+                        absolute_tolerance=absolute_tolerance,
+                        relative_tolerance=relative_tolerance,
+                        reason=reason,
+                    )
+                    checks.append(check)
+                    cards.append(card)
+            continue
 
         for record in ticker_records:
             for feature_name in supported_features:
@@ -152,7 +166,7 @@ def build_market_feature_spot_checks(
     return checks, cards
 
 
-def _summarize_market_feature_spot_checks(
+def summarize_market_feature_spot_checks(
     checks: Sequence[MarketFeatureSpotCheckRecord],
 ) -> dict[str, int]:
     """Return PASS/WARN/FAIL counts for the supplied spot-check records."""
@@ -175,6 +189,8 @@ def _normalize_feature_names(feature_names: Sequence[str]) -> list[str]:
 
 
 def _prepare_bars(bars: pd.DataFrame) -> pd.DataFrame:
+    if "date" not in bars.columns:
+        raise ValueError("missing required columns: date")
     frame = bars.copy()
     frame["date"] = frame["date"].astype(str)
     return frame.sort_values("date").drop_duplicates("date").reset_index(drop=True)
@@ -319,6 +335,22 @@ def _recompute_feature(
     feature_date: str,
     feature_name: str,
 ) -> _RecomputedFeature:
+    formula = _formula_template(feature_name)
+    missing_columns = sorted(_required_columns_for_feature(feature_name) - set(bars.columns))
+    if missing_columns:
+        return _missing_recompute(
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=formula,
+            reason=(
+                "Raw Layer 0 OHLCV archive is missing required columns for "
+                f"{feature_name}: {', '.join(missing_columns)}."
+            ),
+            raw_inputs={
+                "feature_date": feature_date,
+                "available_columns": [str(column) for column in bars.columns],
+            },
+        )
     if feature_name == "returns_1d":
         return _recompute_returns(bars=bars, feature_date=feature_date, periods=1)
     if feature_name == "returns_5d":
@@ -359,8 +391,19 @@ def _recompute_returns(
         )
 
     source_rows = bars.iloc[row_index - (periods + 1) : row_index]
-    start_close = float(source_rows.iloc[0]["adj_close"])
-    end_close = float(source_rows.iloc[-1]["adj_close"])
+    adj_close_values, invalid_recompute = _coerce_finite_values(
+        source_rows,
+        column="adj_close",
+        feature_name=feature_name,
+        feature_date=feature_date,
+        formula=_formula_template(feature_name),
+    )
+    if invalid_recompute is not None:
+        return invalid_recompute
+    if adj_close_values is None:
+        raise ValueError("adj_close_values must be set when invalid_recompute is absent")
+    start_close = adj_close_values[0]
+    end_close = adj_close_values[-1]
     expected_value = end_close / start_close - 1.0
     source_dates = source_rows["date"].tolist()
     raw_inputs = {
@@ -410,7 +453,17 @@ def _recompute_realized_vol_21d(
         )
 
     source_rows = bars.iloc[row_index - 22 : row_index]
-    adj_close = [float(value) for value in source_rows["adj_close"].tolist()]
+    adj_close, invalid_recompute = _coerce_finite_values(
+        source_rows,
+        column="adj_close",
+        feature_name=feature_name,
+        feature_date=feature_date,
+        formula=_formula_template(feature_name),
+    )
+    if invalid_recompute is not None:
+        return invalid_recompute
+    if adj_close is None:
+        raise ValueError("adj_close must be set when invalid_recompute is absent")
     daily_returns = [
         adj_close[index] / adj_close[index - 1] - 1.0 for index in range(1, len(adj_close))
     ]
@@ -464,10 +517,19 @@ def _recompute_volume_ratio_20(
         )
 
     source_rows = bars.iloc[row_index - 20 : row_index]
-    volumes = [float(value) for value in source_rows["volume"].tolist()]
+    volumes, invalid_recompute = _coerce_finite_values(
+        source_rows,
+        column="volume",
+        feature_name=feature_name,
+        feature_date=feature_date,
+        formula=_formula_template(feature_name),
+    )
+    if invalid_recompute is not None:
+        return invalid_recompute
+    if volumes is None:
+        raise ValueError("volumes must be set when invalid_recompute is absent")
     current_volume = volumes[-1]
     mean_volume = statistics.fmean(volumes)
-    expected_value = current_volume / mean_volume if mean_volume != 0.0 else math.nan
     source_dates = source_rows["date"].tolist()
     raw_inputs = {
         "feature_date": feature_date,
@@ -475,6 +537,15 @@ def _recompute_volume_ratio_20(
         "window_rows": _rows_to_dicts(source_rows, columns=("date", "volume")),
         "mean_volume_20": _round_float(mean_volume),
     }
+    if mean_volume == 0.0:
+        return _missing_recompute(
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            reason="Volume ratio is undefined because the 20-bar mean volume is zero.",
+            raw_inputs=raw_inputs,
+        )
+    expected_value = current_volume / mean_volume
     calculation = (
         f"{feature_name}({feature_date}) = volume({source_dates[-1]}) / "
         f"mean(volume[{source_dates[0]}..{source_dates[-1]}]) = "
@@ -517,7 +588,17 @@ def _recompute_rsi_14(
         )
 
     source_rows = bars.iloc[row_index - 15 : row_index]
-    closes = [float(value) for value in source_rows["adj_close"].tolist()]
+    closes, invalid_recompute = _coerce_finite_values(
+        source_rows,
+        column="adj_close",
+        feature_name=feature_name,
+        feature_date=feature_date,
+        formula=_formula_template(feature_name),
+    )
+    if invalid_recompute is not None:
+        return invalid_recompute
+    if closes is None:
+        raise ValueError("closes must be set when invalid_recompute is absent")
     deltas = [closes[index] - closes[index - 1] for index in range(1, len(closes))]
     gains = [max(delta, 0.0) for delta in deltas]
     losses = [max(-delta, 0.0) for delta in deltas]
@@ -578,6 +659,56 @@ def _feature_row_index(*, bars: pd.DataFrame, feature_date: str) -> int | None:
     if not matches:
         return None
     return int(matches[0])
+
+
+def _required_columns_for_feature(feature_name: str) -> frozenset[str]:
+    columns_by_feature: Mapping[str, frozenset[str]] = {
+        "returns_1d": frozenset({"adj_close"}),
+        "returns_5d": frozenset({"adj_close"}),
+        "realized_vol_21d": frozenset({"adj_close"}),
+        "volume_ratio_20": frozenset({"volume"}),
+        "rsi_14": frozenset({"adj_close"}),
+    }
+    return columns_by_feature.get(feature_name, frozenset())
+
+
+def _coerce_finite_values(
+    source_rows: pd.DataFrame,
+    *,
+    column: str,
+    feature_name: str,
+    feature_date: str,
+    formula: str,
+) -> tuple[list[float] | None, _RecomputedFeature | None]:
+    values: list[float] = []
+    invalid_rows: list[dict[str, object]] = []
+    for row in source_rows.loc[:, ["date", column]].to_dict(orient="records"):
+        try:
+            numeric_value = float(row[column])
+        except (TypeError, ValueError):
+            invalid_rows.append({"date": str(row["date"]), column: row[column]})
+            continue
+        if math.isnan(numeric_value) or math.isinf(numeric_value):
+            invalid_rows.append({"date": str(row["date"]), column: row[column]})
+            continue
+        values.append(numeric_value)
+    if invalid_rows:
+        return None, _missing_recompute(
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=formula,
+            reason=(
+                f"Raw Layer 0 OHLCV archive has non-finite {column} values inside the "
+                "source window."
+            ),
+            raw_inputs={
+                "feature_date": feature_date,
+                "window_dates": [str(value) for value in source_rows["date"].tolist()],
+                "window_rows": _rows_to_dicts(source_rows, columns=("date", column)),
+                "invalid_rows": invalid_rows,
+            },
+        )
+    return values, None
 
 
 def _missing_recompute(
@@ -674,12 +805,22 @@ def _rows_to_dicts(frame: pd.DataFrame, *, columns: Sequence[str]) -> list[dict[
         for key, value in row.items():
             if key == "date":
                 normalized[key] = str(value)
+            elif value is None:
+                normalized[key] = None
             elif isinstance(value, bool):
                 normalized[key] = value
             elif isinstance(value, int):
                 normalized[key] = value
             else:
-                normalized[key] = _round_float(float(value))
+                try:
+                    numeric_value = float(value)
+                except (TypeError, ValueError):
+                    normalized[key] = value
+                    continue
+                if math.isnan(numeric_value) or math.isinf(numeric_value):
+                    normalized[key] = None
+                    continue
+                normalized[key] = _round_float(numeric_value)
         rows.append(normalized)
     return rows
 

--- a/core/features/market_spotchecks.py
+++ b/core/features/market_spotchecks.py
@@ -1,0 +1,719 @@
+"""Point-in-time-safe raw-vs-stored spot checks for deterministic market features."""
+from __future__ import annotations
+
+import math
+import statistics
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Literal
+
+from core.contracts.schemas import FeatureRecord
+from core.features.loaders import load_ohlcv_frame
+from services.r2.writer import R2Writer
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+SpotCheckStatus = Literal["pass", "warn", "fail"]
+MARKET_SPOTCHECK_FEATURES: tuple[str, ...] = (
+    "returns_1d",
+    "returns_5d",
+    "realized_vol_21d",
+    "volume_ratio_20",
+    "rsi_14",
+)
+DEFAULT_ABSOLUTE_TOLERANCE = 1e-9
+DEFAULT_RELATIVE_TOLERANCE = 1e-7
+_TRADING_DAYS_PER_YEAR = 252
+
+
+@dataclass(frozen=True)
+class MarketFeatureSpotCheckRecord:
+    """One raw-vs-stored comparison for a deterministic market feature."""
+
+    row_key: str
+    date: str
+    ticker: str
+    feature_name: str
+    status: SpotCheckStatus
+    point_in_time_safe: bool
+    source_window_start: str | None
+    source_window_end: str | None
+    source_bar_count: int
+    stored_value: float | int | str | bool | None
+    expected_value: float | None
+    absolute_difference: float | None
+    relative_difference: float | None
+    tolerance_absolute: float
+    tolerance_relative: float
+    raw_inputs: dict[str, object]
+    message: str
+    missing_reason: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class MarketFeatureFormulaAuditCard:
+    """Human-readable formula payload for one deterministic feature spot check."""
+
+    row_key: str
+    date: str
+    ticker: str
+    feature_name: str
+    status: SpotCheckStatus
+    title: str
+    formula: str
+    calculation: str
+    point_in_time_note: str
+    expected_value: float | None
+    stored_value: float | int | str | bool | None
+    raw_inputs: dict[str, object]
+    message: str
+    missing_reason: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class _RecomputedFeature:
+    """Internal recomputation payload before stored-value comparison."""
+
+    feature_name: str
+    expected_value: float | None
+    raw_inputs: dict[str, object]
+    formula: str
+    calculation: str
+    point_in_time_safe: bool
+    point_in_time_note: str
+    source_window_start: str | None
+    source_window_end: str | None
+    source_bar_count: int
+    missing_reason: str | None = None
+
+
+def build_market_feature_spot_checks(
+    *,
+    records: Sequence[FeatureRecord],
+    writer: R2Writer | None = None,
+    feature_names: Sequence[str] = MARKET_SPOTCHECK_FEATURES,
+    absolute_tolerance: float = DEFAULT_ABSOLUTE_TOLERANCE,
+    relative_tolerance: float = DEFAULT_RELATIVE_TOLERANCE,
+) -> tuple[list[MarketFeatureSpotCheckRecord], list[MarketFeatureFormulaAuditCard]]:
+    """Build raw-vs-stored spot checks and formula cards for selected Layer 1 rows."""
+    active_writer = writer or R2Writer()
+    supported_features = tuple(_normalize_feature_names(feature_names))
+    checks: list[MarketFeatureSpotCheckRecord] = []
+    cards: list[MarketFeatureFormulaAuditCard] = []
+
+    by_ticker: dict[str, list[FeatureRecord]] = defaultdict(list)
+    for record in records:
+        by_ticker[record.ticker].append(record)
+
+    for ticker in sorted(by_ticker):
+        ticker_records = sorted(by_ticker[ticker], key=lambda item: item.date)
+        try:
+            bars = _prepare_bars(load_ohlcv_frame(ticker, writer=active_writer))
+        except FileNotFoundError:
+            for record in ticker_records:
+                for feature_name in supported_features:
+                    check, card = _missing_source_artifact(
+                        record=record,
+                        feature_name=feature_name,
+                        absolute_tolerance=absolute_tolerance,
+                        relative_tolerance=relative_tolerance,
+                        reason="Raw Layer 0 OHLCV archive is missing for this ticker.",
+                    )
+                    checks.append(check)
+                    cards.append(card)
+            continue
+
+        for record in ticker_records:
+            for feature_name in supported_features:
+                recomputed = _recompute_feature(
+                    bars=bars,
+                    feature_date=record.date,
+                    feature_name=feature_name,
+                )
+                check, card = _build_spot_check_outputs(
+                    record=record,
+                    recomputed=recomputed,
+                    absolute_tolerance=absolute_tolerance,
+                    relative_tolerance=relative_tolerance,
+                )
+                checks.append(check)
+                cards.append(card)
+
+    return checks, cards
+
+
+def summarize_market_feature_spot_checks(
+    checks: Sequence[MarketFeatureSpotCheckRecord],
+) -> dict[str, int]:
+    """Return PASS/WARN/FAIL counts for the supplied spot-check records."""
+    counts = {"pass": 0, "warn": 0, "fail": 0}
+    for check in checks:
+        counts[check.status] += 1
+    return counts
+
+
+def _normalize_feature_names(feature_names: Sequence[str]) -> list[str]:
+    unique: list[str] = []
+    seen: set[str] = set()
+    for feature_name in feature_names:
+        normalized = str(feature_name).strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        unique.append(normalized)
+    return unique
+
+
+def _prepare_bars(bars: pd.DataFrame) -> pd.DataFrame:
+    frame = bars.copy()
+    frame["date"] = frame["date"].astype(str)
+    return frame.sort_values("date").drop_duplicates("date").reset_index(drop=True)
+
+
+def _missing_source_artifact(
+    *,
+    record: FeatureRecord,
+    feature_name: str,
+    absolute_tolerance: float,
+    relative_tolerance: float,
+    reason: str,
+) -> tuple[MarketFeatureSpotCheckRecord, MarketFeatureFormulaAuditCard]:
+    row_key = _row_key(record)
+    formula = _formula_template(feature_name)
+    note = f"Spot check skipped for {record.date}; {reason}"
+    check = MarketFeatureSpotCheckRecord(
+        row_key=row_key,
+        date=record.date,
+        ticker=record.ticker,
+        feature_name=feature_name,
+        status="warn",
+        point_in_time_safe=True,
+        source_window_start=None,
+        source_window_end=None,
+        source_bar_count=0,
+        stored_value=record.features.get(feature_name),
+        expected_value=None,
+        absolute_difference=None,
+        relative_difference=None,
+        tolerance_absolute=absolute_tolerance,
+        tolerance_relative=relative_tolerance,
+        raw_inputs={},
+        message=reason,
+        missing_reason=reason,
+    )
+    card = MarketFeatureFormulaAuditCard(
+        row_key=row_key,
+        date=record.date,
+        ticker=record.ticker,
+        feature_name=feature_name,
+        status="warn",
+        title=f"{record.ticker} {feature_name} on {record.date}",
+        formula=formula,
+        calculation=reason,
+        point_in_time_note=note,
+        expected_value=None,
+        stored_value=record.features.get(feature_name),
+        raw_inputs={},
+        message=reason,
+        missing_reason=reason,
+    )
+    return check, card
+
+
+def _build_spot_check_outputs(
+    *,
+    record: FeatureRecord,
+    recomputed: _RecomputedFeature,
+    absolute_tolerance: float,
+    relative_tolerance: float,
+) -> tuple[MarketFeatureSpotCheckRecord, MarketFeatureFormulaAuditCard]:
+    row_key = _row_key(record)
+    stored_value = record.features.get(recomputed.feature_name)
+    stored_numeric = _to_float_or_none(stored_value)
+
+    if recomputed.missing_reason is not None:
+        status: SpotCheckStatus = "warn"
+        message = recomputed.missing_reason
+        absolute_difference = None
+        relative_difference = None
+    elif stored_value is None:
+        status = "fail"
+        message = "Stored Layer 1 value is missing for a recomputable market feature."
+        absolute_difference = None
+        relative_difference = None
+    elif stored_numeric is None:
+        status = "fail"
+        message = "Stored Layer 1 value is not numeric for a recomputable market feature."
+        absolute_difference = None
+        relative_difference = None
+    else:
+        expected_value = recomputed.expected_value
+        if expected_value is None:
+            raise ValueError("expected_value must be set when missing_reason is absent")
+        absolute_difference = abs(stored_numeric - expected_value)
+        denominator = max(abs(expected_value), absolute_tolerance)
+        relative_difference = absolute_difference / denominator
+        matches = (
+            absolute_difference <= absolute_tolerance
+            or relative_difference <= relative_tolerance
+        )
+        status = "pass" if matches else "fail"
+        message = (
+            "Stored Layer 1 value matches recomputation within tolerance."
+            if matches
+            else "Stored Layer 1 value differs from recomputation beyond tolerance."
+        )
+
+    check = MarketFeatureSpotCheckRecord(
+        row_key=row_key,
+        date=record.date,
+        ticker=record.ticker,
+        feature_name=recomputed.feature_name,
+        status=status,
+        point_in_time_safe=recomputed.point_in_time_safe,
+        source_window_start=recomputed.source_window_start,
+        source_window_end=recomputed.source_window_end,
+        source_bar_count=recomputed.source_bar_count,
+        stored_value=stored_value,
+        expected_value=recomputed.expected_value,
+        absolute_difference=absolute_difference,
+        relative_difference=relative_difference,
+        tolerance_absolute=absolute_tolerance,
+        tolerance_relative=relative_tolerance,
+        raw_inputs=recomputed.raw_inputs,
+        message=message,
+        missing_reason=recomputed.missing_reason,
+    )
+    card = MarketFeatureFormulaAuditCard(
+        row_key=row_key,
+        date=record.date,
+        ticker=record.ticker,
+        feature_name=recomputed.feature_name,
+        status=status,
+        title=f"{record.ticker} {recomputed.feature_name} on {record.date}",
+        formula=recomputed.formula,
+        calculation=recomputed.calculation,
+        point_in_time_note=recomputed.point_in_time_note,
+        expected_value=recomputed.expected_value,
+        stored_value=stored_value,
+        raw_inputs=recomputed.raw_inputs,
+        message=message,
+        missing_reason=recomputed.missing_reason,
+    )
+    return check, card
+
+
+def _recompute_feature(
+    *,
+    bars: pd.DataFrame,
+    feature_date: str,
+    feature_name: str,
+) -> _RecomputedFeature:
+    if feature_name == "returns_1d":
+        return _recompute_returns(bars=bars, feature_date=feature_date, periods=1)
+    if feature_name == "returns_5d":
+        return _recompute_returns(bars=bars, feature_date=feature_date, periods=5)
+    if feature_name == "realized_vol_21d":
+        return _recompute_realized_vol_21d(bars=bars, feature_date=feature_date)
+    if feature_name == "volume_ratio_20":
+        return _recompute_volume_ratio_20(bars=bars, feature_date=feature_date)
+    if feature_name == "rsi_14":
+        return _recompute_rsi_14(bars=bars, feature_date=feature_date)
+    raise ValueError(f"Unsupported market spot-check feature: {feature_name}")
+
+
+def _recompute_returns(
+    *,
+    bars: pd.DataFrame,
+    feature_date: str,
+    periods: int,
+) -> _RecomputedFeature:
+    feature_name = f"returns_{periods}d"
+    row_index = _feature_row_index(bars=bars, feature_date=feature_date)
+    if row_index is None:
+        return _missing_recompute(
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            reason="Feature date is missing from the raw Layer 0 OHLCV archive.",
+        )
+    required_index = periods + 1
+    if row_index < required_index:
+        return _insufficient_history(
+            bars=bars,
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            available_bars=row_index,
+            required_bars=required_index,
+        )
+
+    source_rows = bars.iloc[row_index - (periods + 1) : row_index]
+    start_close = float(source_rows.iloc[0]["adj_close"])
+    end_close = float(source_rows.iloc[-1]["adj_close"])
+    expected_value = end_close / start_close - 1.0
+    source_dates = source_rows["date"].tolist()
+    raw_inputs = {
+        "feature_date": feature_date,
+        "window_dates": source_dates,
+        "window_rows": _rows_to_dicts(source_rows, columns=("date", "adj_close")),
+        "lookback_periods": periods,
+    }
+    calculation = (
+        f"{feature_name}({feature_date}) = adj_close({source_dates[-1]}) / "
+        f"adj_close({source_dates[0]}) - 1 = {_format_number(end_close)} / "
+        f"{_format_number(start_close)} - 1 = {_format_number(expected_value)}"
+    )
+    return _complete_recompute(
+        feature_name=feature_name,
+        feature_date=feature_date,
+        expected_value=expected_value,
+        raw_inputs=raw_inputs,
+        formula=_formula_template(feature_name),
+        calculation=calculation,
+        source_dates=source_dates,
+    )
+
+
+def _recompute_realized_vol_21d(
+    *,
+    bars: pd.DataFrame,
+    feature_date: str,
+) -> _RecomputedFeature:
+    feature_name = "realized_vol_21d"
+    row_index = _feature_row_index(bars=bars, feature_date=feature_date)
+    if row_index is None:
+        return _missing_recompute(
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            reason="Feature date is missing from the raw Layer 0 OHLCV archive.",
+        )
+    if row_index < 22:
+        return _insufficient_history(
+            bars=bars,
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            available_bars=row_index,
+            required_bars=22,
+        )
+
+    source_rows = bars.iloc[row_index - 22 : row_index]
+    adj_close = [float(value) for value in source_rows["adj_close"].tolist()]
+    daily_returns = [
+        adj_close[index] / adj_close[index - 1] - 1.0 for index in range(1, len(adj_close))
+    ]
+    expected_value = statistics.stdev(daily_returns) * math.sqrt(_TRADING_DAYS_PER_YEAR)
+    source_dates = source_rows["date"].tolist()
+    raw_inputs = {
+        "feature_date": feature_date,
+        "window_dates": source_dates,
+        "window_rows": _rows_to_dicts(source_rows, columns=("date", "adj_close")),
+        "daily_returns": [_round_float(value) for value in daily_returns],
+        "annualization_factor": _TRADING_DAYS_PER_YEAR,
+    }
+    calculation = (
+        f"{feature_name}({feature_date}) = sqrt(252) * stdev("
+        f"[{', '.join(_format_number(value) for value in daily_returns)}]) = "
+        f"{_format_number(expected_value)}"
+    )
+    return _complete_recompute(
+        feature_name=feature_name,
+        feature_date=feature_date,
+        expected_value=expected_value,
+        raw_inputs=raw_inputs,
+        formula=_formula_template(feature_name),
+        calculation=calculation,
+        source_dates=source_dates,
+    )
+
+
+def _recompute_volume_ratio_20(
+    *,
+    bars: pd.DataFrame,
+    feature_date: str,
+) -> _RecomputedFeature:
+    feature_name = "volume_ratio_20"
+    row_index = _feature_row_index(bars=bars, feature_date=feature_date)
+    if row_index is None:
+        return _missing_recompute(
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            reason="Feature date is missing from the raw Layer 0 OHLCV archive.",
+        )
+    if row_index < 20:
+        return _insufficient_history(
+            bars=bars,
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            available_bars=row_index,
+            required_bars=20,
+        )
+
+    source_rows = bars.iloc[row_index - 20 : row_index]
+    volumes = [float(value) for value in source_rows["volume"].tolist()]
+    current_volume = volumes[-1]
+    mean_volume = statistics.fmean(volumes)
+    expected_value = current_volume / mean_volume if mean_volume != 0.0 else math.nan
+    source_dates = source_rows["date"].tolist()
+    raw_inputs = {
+        "feature_date": feature_date,
+        "window_dates": source_dates,
+        "window_rows": _rows_to_dicts(source_rows, columns=("date", "volume")),
+        "mean_volume_20": _round_float(mean_volume),
+    }
+    calculation = (
+        f"{feature_name}({feature_date}) = volume({source_dates[-1]}) / "
+        f"mean(volume[{source_dates[0]}..{source_dates[-1]}]) = "
+        f"{_format_number(current_volume)} / {_format_number(mean_volume)} = "
+        f"{_format_number(expected_value)}"
+    )
+    return _complete_recompute(
+        feature_name=feature_name,
+        feature_date=feature_date,
+        expected_value=expected_value,
+        raw_inputs=raw_inputs,
+        formula=_formula_template(feature_name),
+        calculation=calculation,
+        source_dates=source_dates,
+    )
+
+
+def _recompute_rsi_14(
+    *,
+    bars: pd.DataFrame,
+    feature_date: str,
+) -> _RecomputedFeature:
+    feature_name = "rsi_14"
+    row_index = _feature_row_index(bars=bars, feature_date=feature_date)
+    if row_index is None:
+        return _missing_recompute(
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            reason="Feature date is missing from the raw Layer 0 OHLCV archive.",
+        )
+    if row_index < 15:
+        return _insufficient_history(
+            bars=bars,
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            available_bars=row_index,
+            required_bars=15,
+        )
+
+    source_rows = bars.iloc[row_index - 15 : row_index]
+    closes = [float(value) for value in source_rows["adj_close"].tolist()]
+    deltas = [closes[index] - closes[index - 1] for index in range(1, len(closes))]
+    gains = [max(delta, 0.0) for delta in deltas]
+    losses = [max(-delta, 0.0) for delta in deltas]
+    avg_gain = statistics.fmean(gains)
+    avg_loss = statistics.fmean(losses)
+    if avg_loss == 0.0 and avg_gain == 0.0:
+        return _missing_recompute(
+            feature_name=feature_name,
+            feature_date=feature_date,
+            formula=_formula_template(feature_name),
+            reason="RSI is undefined because both average gain and average loss are zero.",
+            raw_inputs={
+                "feature_date": feature_date,
+                "window_dates": source_rows["date"].tolist(),
+                "window_rows": _rows_to_dicts(source_rows, columns=("date", "adj_close")),
+                "deltas": [_round_float(value) for value in deltas],
+                "gains": [_round_float(value) for value in gains],
+                "losses": [_round_float(value) for value in losses],
+            },
+        )
+    if avg_loss == 0.0:
+        expected_value = 100.0
+        rs_text = "infinity"
+    else:
+        rs = avg_gain / avg_loss
+        expected_value = 100.0 - 100.0 / (1.0 + rs)
+        rs_text = _format_number(rs)
+
+    source_dates = source_rows["date"].tolist()
+    raw_inputs = {
+        "feature_date": feature_date,
+        "window_dates": source_dates,
+        "window_rows": _rows_to_dicts(source_rows, columns=("date", "adj_close")),
+        "deltas": [_round_float(value) for value in deltas],
+        "gains": [_round_float(value) for value in gains],
+        "losses": [_round_float(value) for value in losses],
+        "average_gain_14": _round_float(avg_gain),
+        "average_loss_14": _round_float(avg_loss),
+    }
+    calculation = (
+        f"{feature_name}({feature_date}) = 100 - 100 / (1 + "
+        f"avg_gain_14 / avg_loss_14) = 100 - 100 / (1 + {rs_text}) = "
+        f"{_format_number(expected_value)}"
+    )
+    return _complete_recompute(
+        feature_name=feature_name,
+        feature_date=feature_date,
+        expected_value=expected_value,
+        raw_inputs=raw_inputs,
+        formula=_formula_template(feature_name),
+        calculation=calculation,
+        source_dates=source_dates,
+    )
+
+
+def _feature_row_index(*, bars: pd.DataFrame, feature_date: str) -> int | None:
+    matches = bars.index[bars["date"] == feature_date].tolist()
+    if not matches:
+        return None
+    return int(matches[0])
+
+
+def _missing_recompute(
+    *,
+    feature_name: str,
+    feature_date: str,
+    formula: str,
+    reason: str,
+    raw_inputs: dict[str, object] | None = None,
+) -> _RecomputedFeature:
+    note = f"Spot check skipped for {feature_date}; {reason}"
+    return _RecomputedFeature(
+        feature_name=feature_name,
+        expected_value=None,
+        raw_inputs={} if raw_inputs is None else raw_inputs,
+        formula=formula,
+        calculation=reason,
+        point_in_time_safe=True,
+        point_in_time_note=note,
+        source_window_start=None,
+        source_window_end=None,
+        source_bar_count=0,
+        missing_reason=reason,
+    )
+
+
+def _insufficient_history(
+    *,
+    bars: pd.DataFrame,
+    feature_name: str,
+    feature_date: str,
+    formula: str,
+    available_bars: int,
+    required_bars: int,
+) -> _RecomputedFeature:
+    available_rows = bars.iloc[:available_bars]
+    return _missing_recompute(
+        feature_name=feature_name,
+        feature_date=feature_date,
+        formula=formula,
+        reason=(
+            "Insufficient prior OHLCV history for deterministic recomputation: "
+            f"requires {required_bars} prior bars, found {available_bars}."
+        ),
+        raw_inputs={
+            "feature_date": feature_date,
+            "available_window_dates": available_rows["date"].tolist(),
+            "available_window_rows": _rows_to_dicts(
+                available_rows,
+                columns=("date", "adj_close", "volume"),
+            ),
+            "required_prior_bars": required_bars,
+            "available_prior_bars": available_bars,
+        },
+    )
+
+
+def _complete_recompute(
+    *,
+    feature_name: str,
+    feature_date: str,
+    expected_value: float,
+    raw_inputs: dict[str, object],
+    formula: str,
+    calculation: str,
+    source_dates: Sequence[str],
+) -> _RecomputedFeature:
+    latest_source_date = source_dates[-1] if source_dates else None
+    point_in_time_safe = all(source_date < feature_date for source_date in source_dates)
+    note = (
+        f"Only source rows strictly before {feature_date} were used; latest source date was "
+        f"{latest_source_date}."
+        if latest_source_date is not None
+        else f"No source rows were used for {feature_date}."
+    )
+    return _RecomputedFeature(
+        feature_name=feature_name,
+        expected_value=expected_value,
+        raw_inputs=raw_inputs,
+        formula=formula,
+        calculation=calculation,
+        point_in_time_safe=point_in_time_safe,
+        point_in_time_note=note,
+        source_window_start=source_dates[0] if source_dates else None,
+        source_window_end=latest_source_date,
+        source_bar_count=len(source_dates),
+    )
+
+
+def _rows_to_dicts(frame: pd.DataFrame, *, columns: Sequence[str]) -> list[dict[str, object]]:
+    rows: list[dict[str, object]] = []
+    for row in frame.loc[:, list(columns)].to_dict(orient="records"):
+        normalized: dict[str, object] = {}
+        for key, value in row.items():
+            if key == "date":
+                normalized[key] = str(value)
+            elif isinstance(value, bool):
+                normalized[key] = value
+            elif isinstance(value, int):
+                normalized[key] = value
+            else:
+                normalized[key] = _round_float(float(value))
+        rows.append(normalized)
+    return rows
+
+
+def _row_key(record: FeatureRecord) -> str:
+    return f"{record.date}|{record.ticker}"
+
+
+def _to_float_or_none(value: float | int | str | bool | None) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
+
+
+def _formula_template(feature_name: str) -> str:
+    formulas: Mapping[str, str] = {
+        "returns_1d": "adj_close(t-1) / adj_close(t-2) - 1",
+        "returns_5d": "adj_close(t-1) / adj_close(t-6) - 1",
+        "realized_vol_21d": "sqrt(252) * stdev(returns_1d[t-21..t-1])",
+        "volume_ratio_20": "volume(t-1) / mean(volume[t-20..t-1])",
+        "rsi_14": "100 - 100 / (1 + avg_gain_14 / avg_loss_14)",
+    }
+    return formulas.get(feature_name, feature_name)
+
+
+def _format_number(value: float) -> str:
+    return f"{value:.6f}"
+
+
+def _round_float(value: float) -> float:
+    return float(f"{value:.10f}")

--- a/core/features/market_spotchecks.py
+++ b/core/features/market_spotchecks.py
@@ -152,7 +152,7 @@ def build_market_feature_spot_checks(
     return checks, cards
 
 
-def summarize_market_feature_spot_checks(
+def _summarize_market_feature_spot_checks(
     checks: Sequence[MarketFeatureSpotCheckRecord],
 ) -> dict[str, int]:
     """Return PASS/WARN/FAIL counts for the supplied spot-check records."""

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -167,7 +167,8 @@ For the read-only dashboard backend payload used by the Layer 0/1 audit UI, run:
 This command reads stored `features/layer1/{TICKER}.parquet` histories and writes
 local JSON/text report artifacts only. It does not modify R2 objects. See
 `docs/layer1_feature_audit_dashboard.md` for the heatmap, family-status,
-null-rate, and outlier payload details.
+raw-vs-computed spot-check, formula-card, null-rate, and outlier payload
+details.
 
 Operational notes for the readiness report:
 - The local validator writes

--- a/docs/layer1_feature_audit_dashboard.md
+++ b/docs/layer1_feature_audit_dashboard.md
@@ -11,6 +11,8 @@ writes local report artifacts under `artifacts/reports/diagnostics/` by default.
 This backend is intentionally scoped to Layer 0/1 audit visibility only:
 - feature completeness heatmap cells
 - feature-family status cards
+- raw-vs-computed market feature spot checks from Layer 0 OHLCV
+- formula audit cards for selected deterministic market features
 - null-rate summaries by feature and family
 - numeric outlier and range-violation records
 
@@ -59,8 +61,19 @@ text file is a compact operator summary.
   - `distribution_outlier`: the value fell outside the dashboard's
     `Q1 - 3*IQR` / `Q3 + 3*IQR` fence, computed only when at least four valid
     observations exist for that feature in the selected window
+- `spot_check_records`: point-in-time-safe raw-vs-stored comparisons for
+  deterministic market features currently including `returns_1d`,
+  `returns_5d`, `realized_vol_21d`, `volume_ratio_20`, and `rsi_14`. Each
+  record includes the raw OHLCV inputs used, recomputed value, stored Layer 1
+  value, absolute/relative difference, tolerance, status, and explicit missing
+  reason when the feature could not be recomputed.
+- `formula_audit_cards`: human-readable calculation payloads for the same
+  deterministic market features. These cards show the exact formula text, the
+  concrete numbers substituted for the selected `(date, ticker)`, and the
+  point-in-time note describing the latest source bar used.
 
 ## Exit Code
 
-- `0` when no family status resolved to `fail`
-- `1` when at least one family status resolved to `fail`
+- `0` when no family status resolved to `fail` and no market spot check
+  resolved to `fail`
+- `1` when at least one family status or market spot check resolved to `fail`

--- a/tests/fixtures/layer1_dashboard_support.py
+++ b/tests/fixtures/layer1_dashboard_support.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
+
 from core.contracts.schemas import FeatureRecord
 from core.features.io import feature_records_to_parquet_bytes
+from core.features.loaders import load_ohlcv_frame
+from core.features.market_features import compute_market_features, market_features_to_records
 from services.r2.paths import layer1_ticker_history_path
 from services.r2.writer import R2Writer
 from tests.fixtures.layer1_audit_support import seed_layer1_audit_fixture
@@ -9,19 +13,37 @@ from tests.fixtures.layer1_audit_support import seed_layer1_audit_fixture
 
 def seed_layer1_dashboard_fixture(writer: R2Writer) -> dict[str, object]:
     """Seed multi-row Layer 1 histories for dashboard backend tests."""
-    audit_fixture = seed_layer1_audit_fixture(writer)
+    audit_fixture = seed_layer1_audit_fixture(writer, as_of_date="2024-05-08")
     base_features = dict(audit_fixture["history_record"].features)
+    aapl_market_by_date = _market_features_by_date("AAPL", writer)
 
     aapl_records = [
-        _record("2024-05-06", "AAPL", base_features, returns_1d=0.010),
+        _record(
+            "2024-05-06",
+            "AAPL",
+            {
+                **base_features,
+                **aapl_market_by_date["2024-05-06"],
+            },
+        ),
         _record(
             "2024-05-07",
             "AAPL",
-            base_features,
-            returns_1d=0.011,
+            {
+                **base_features,
+                **aapl_market_by_date["2024-05-07"],
+            },
             nlp_sentiment_score=None,
         ),
-        _record("2024-05-08", "AAPL", base_features, returns_1d=0.750),
+        _record(
+            "2024-05-08",
+            "AAPL",
+            {
+                **base_features,
+                **aapl_market_by_date["2024-05-08"],
+            },
+            returns_1d=0.750,
+        ),
     ]
     msft_records = [
         _record("2024-05-06", "MSFT", base_features, returns_1d=0.012, rsi_14=120.0),
@@ -47,6 +69,12 @@ def seed_layer1_dashboard_fixture(writer: R2Writer) -> dict[str, object]:
         "to_date": "2024-05-08",
         "tickers": ("AAPL", "MSFT"),
     }
+
+
+def _market_features_by_date(ticker: str, writer: R2Writer) -> dict[str, Mapping[str, object]]:
+    """Return market feature dictionaries keyed by date for one ticker archive."""
+    records = market_features_to_records(compute_market_features(load_ohlcv_frame(ticker, writer), ticker))
+    return {record.date: dict(record.features) for record in records}
 
 
 def _record(

--- a/tests/unit/test_feature_dashboard_backend.py
+++ b/tests/unit/test_feature_dashboard_backend.py
@@ -17,7 +17,7 @@ def test_build_layer1_audit_dashboard_report_builds_visualization_inputs(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Dashboard backend emits heatmap, family, null-rate, and outlier datasets."""
+    """Dashboard backend emits visualization payloads including market spot checks."""
     writer = local_writer(tmp_path, monkeypatch)
     fixture = seed_layer1_dashboard_fixture(writer)
 
@@ -33,6 +33,11 @@ def test_build_layer1_audit_dashboard_report_builds_visualization_inputs(
     assert report.summary["family_fail_count"] >= 1
     assert report.summary["outlier_count"] >= 2
     assert len(report.heatmap_cells) == report.rows_loaded * report.catalog_feature_count
+    assert len(report.spot_check_records) == report.rows_loaded * 5
+    assert len(report.formula_audit_cards) == len(report.spot_check_records)
+    assert report.summary["spot_check_pass_count"] == 14
+    assert report.summary["spot_check_warn_count"] == 15
+    assert report.summary["spot_check_fail_count"] == 1
 
     family_by_key = {
         item["family"]: item
@@ -59,6 +64,26 @@ def test_build_layer1_audit_dashboard_report_builds_visualization_inputs(
     assert ("rsi_14", "range_violation") in outlier_keys
     assert ("returns_1d", "distribution_outlier") in outlier_keys
 
+    spot_checks = {
+        (item["ticker"], item["date"], item["feature_name"]): item
+        for item in report.spot_check_records
+    }
+    assert spot_checks[("AAPL", "2024-05-08", "returns_1d")]["status"] == "fail"
+    assert spot_checks[("MSFT", "2024-05-06", "returns_1d")]["status"] == "warn"
+    assert (
+        spot_checks[("MSFT", "2024-05-06", "returns_1d")]["missing_reason"]
+        == "Raw Layer 0 OHLCV archive is missing for this ticker."
+    )
+
+    formula_cards = {
+        (item["ticker"], item["date"], item["feature_name"]): item
+        for item in report.formula_audit_cards
+    }
+    assert "adj_close" in formula_cards[("AAPL", "2024-05-06", "returns_1d")]["calculation"]
+    assert (
+        formula_cards[("MSFT", "2024-05-06", "returns_1d")]["status"] == "warn"
+    )
+
 
 def test_write_layer1_audit_dashboard_report_writes_json_and_summary(
     tmp_path: Path,
@@ -83,3 +108,4 @@ def test_write_layer1_audit_dashboard_report_writes_json_and_summary(
     assert '"run_id": "dashboard-write"' in output_paths.json_path.read_text(encoding="utf-8")
     assert "Layer 1 Audit Dashboard Backend" in summary
     assert "Family Status" in output_paths.summary_path.read_text(encoding="utf-8")
+    assert "Market spot checks" in summary

--- a/tests/unit/test_market_spotchecks.py
+++ b/tests/unit/test_market_spotchecks.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import io
+import math
+import statistics
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.contracts.schemas import FeatureRecord
+from core.features.market_spotchecks import build_market_feature_spot_checks
+from services.r2.paths import raw_price_path
+from tests.fixtures.layer1_audit_support import local_writer
+
+
+def test_build_market_feature_spot_checks_recomputes_with_prior_bars_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Spot checks use only bars strictly before the feature date and emit formula cards."""
+    writer = local_writer(tmp_path, monkeypatch)
+    bars = _hand_computable_bars()
+    writer.put_object(raw_price_path("AAPL"), _parquet_bytes(bars))
+
+    feature_date = str(bars.iloc[27]["date"])
+    expected_values = _expected_market_values(bars, feature_date=feature_date)
+    record = FeatureRecord(
+        date=feature_date,
+        ticker="AAPL",
+        features=expected_values,
+    )
+
+    checks, cards = build_market_feature_spot_checks(records=[record], writer=writer)
+
+    assert len(checks) == 5
+    assert len(cards) == 5
+    assert all(check.status == "pass" for check in checks)
+
+    by_name = {check.feature_name: check for check in checks}
+    assert by_name["returns_1d"].expected_value == pytest.approx(expected_values["returns_1d"])
+    assert by_name["returns_5d"].expected_value == pytest.approx(expected_values["returns_5d"])
+    assert by_name["realized_vol_21d"].expected_value == pytest.approx(
+        expected_values["realized_vol_21d"]
+    )
+    assert by_name["volume_ratio_20"].expected_value == pytest.approx(
+        expected_values["volume_ratio_20"]
+    )
+    assert by_name["rsi_14"].expected_value == pytest.approx(expected_values["rsi_14"])
+    assert by_name["returns_1d"].point_in_time_safe is True
+    assert by_name["returns_1d"].source_window_end < feature_date
+    assert by_name["returns_1d"].raw_inputs["window_dates"][-1] == by_name["returns_1d"].source_window_end
+    assert str(bars.iloc[-1]["date"]) not in by_name["returns_1d"].raw_inputs["window_dates"]
+
+    card_by_name = {card.feature_name: card for card in cards}
+    assert "adj_close" in card_by_name["returns_1d"].calculation
+    assert "sqrt(252)" in card_by_name["realized_vol_21d"].calculation
+    assert "avg_gain_14 / avg_loss_14" in card_by_name["rsi_14"].calculation
+
+
+def test_build_market_feature_spot_checks_warns_on_missing_raw_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing raw OHLCV archives are surfaced as explicit WARN spot checks."""
+    writer = local_writer(tmp_path, monkeypatch)
+    record = FeatureRecord(
+        date="2024-02-08",
+        ticker="MSFT",
+        features={"returns_1d": 0.01},
+    )
+
+    checks, cards = build_market_feature_spot_checks(
+        records=[record],
+        writer=writer,
+        feature_names=("returns_1d",),
+    )
+
+    assert len(checks) == 1
+    assert checks[0].status == "warn"
+    assert checks[0].missing_reason == "Raw Layer 0 OHLCV archive is missing for this ticker."
+    assert cards[0].status == "warn"
+    assert cards[0].calculation == "Raw Layer 0 OHLCV archive is missing for this ticker."
+
+
+def test_build_market_feature_spot_checks_fails_on_stored_mismatch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Stored values outside tolerance fail the spot-check comparison."""
+    writer = local_writer(tmp_path, monkeypatch)
+    bars = _hand_computable_bars()
+    writer.put_object(raw_price_path("AAPL"), _parquet_bytes(bars))
+
+    feature_date = str(bars.iloc[27]["date"])
+    expected_values = _expected_market_values(bars, feature_date=feature_date)
+    record = FeatureRecord(
+        date=feature_date,
+        ticker="AAPL",
+        features={"returns_1d": float(expected_values["returns_1d"]) + 0.5},
+    )
+
+    checks, cards = build_market_feature_spot_checks(
+        records=[record],
+        writer=writer,
+        feature_names=("returns_1d",),
+    )
+
+    assert checks[0].status == "fail"
+    assert checks[0].absolute_difference is not None
+    assert checks[0].absolute_difference > 0.1
+    assert cards[0].status == "fail"
+    assert "differs from recomputation" in cards[0].message
+
+
+def _hand_computable_bars() -> pd.DataFrame:
+    """Return a deterministic OHLCV history with extra future bars after the feature date."""
+    dates = pd.bdate_range("2024-01-02", periods=32)
+    rows: list[dict[str, object]] = []
+    for index, date_value in enumerate(dates):
+        close = 100.0 + index * 1.2 + (index % 3) * 0.35
+        if index >= 30:
+            close += 25.0 * (index - 29)
+        volume = 1_000_000 + index * 25_000 + (index % 4) * 5_000
+        rows.append(
+            {
+                "date": date_value.date().isoformat(),
+                "ticker": "AAPL",
+                "open": close - 0.4,
+                "high": close + 0.8,
+                "low": close - 0.9,
+                "close": close,
+                "adj_close": close,
+                "volume": volume,
+                "dollar_volume": close * volume,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _expected_market_values(bars: pd.DataFrame, *, feature_date: str) -> dict[str, float]:
+    """Return manual deterministic spot-check values for one feature date."""
+    row_index = int(bars.index[bars["date"] == feature_date][0])
+    closes = [float(value) for value in bars["adj_close"].tolist()]
+    volumes = [float(value) for value in bars["volume"].tolist()]
+
+    returns_1d = closes[row_index - 1] / closes[row_index - 2] - 1.0
+    returns_5d = closes[row_index - 1] / closes[row_index - 6] - 1.0
+
+    vol_window = closes[row_index - 22 : row_index]
+    daily_returns = [
+        vol_window[index] / vol_window[index - 1] - 1.0 for index in range(1, len(vol_window))
+    ]
+    realized_vol_21d = statistics.stdev(daily_returns) * math.sqrt(252)
+
+    volume_window = volumes[row_index - 20 : row_index]
+    volume_ratio_20 = volume_window[-1] / statistics.fmean(volume_window)
+
+    rsi_window = closes[row_index - 15 : row_index]
+    deltas = [rsi_window[index] - rsi_window[index - 1] for index in range(1, len(rsi_window))]
+    gains = [max(delta, 0.0) for delta in deltas]
+    losses = [max(-delta, 0.0) for delta in deltas]
+    avg_gain = statistics.fmean(gains)
+    avg_loss = statistics.fmean(losses)
+    rsi_14 = 100.0 if avg_loss == 0.0 else 100.0 - 100.0 / (1.0 + avg_gain / avg_loss)
+
+    return {
+        "returns_1d": returns_1d,
+        "returns_5d": returns_5d,
+        "realized_vol_21d": realized_vol_21d,
+        "volume_ratio_20": volume_ratio_20,
+        "rsi_14": rsi_14,
+    }
+
+
+def _parquet_bytes(frame: pd.DataFrame) -> bytes:
+    """Serialize a DataFrame to Parquet bytes for the local mock R2 writer."""
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    return buffer.getvalue()

--- a/tests/unit/test_market_spotchecks.py
+++ b/tests/unit/test_market_spotchecks.py
@@ -14,6 +14,19 @@ from services.r2.paths import raw_price_path
 from tests.fixtures.layer1_audit_support import local_writer
 
 
+def test_build_market_feature_spot_checks_returns_empty_payloads_for_empty_records(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Empty input should produce empty comparison and formula-card payloads."""
+    writer = local_writer(tmp_path, monkeypatch)
+
+    checks, cards = build_market_feature_spot_checks(records=[], writer=writer)
+
+    assert checks == []
+    assert cards == []
+
+
 def test_build_market_feature_spot_checks_recomputes_with_prior_bars_only(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -83,6 +96,35 @@ def test_build_market_feature_spot_checks_warns_on_missing_raw_archive(
     assert cards[0].calculation == "Raw Layer 0 OHLCV archive is missing for this ticker."
 
 
+def test_build_market_feature_spot_checks_warns_on_insufficient_history(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Too little prior OHLCV history should yield an explicit WARN record."""
+    writer = local_writer(tmp_path, monkeypatch)
+    bars = _hand_computable_bars().iloc[:5].copy()
+    writer.put_object(raw_price_path("AAPL"), _parquet_bytes(bars))
+
+    record = FeatureRecord(
+        date=str(bars.iloc[2]["date"]),
+        ticker="AAPL",
+        features={"returns_5d": 0.0},
+    )
+
+    checks, cards = build_market_feature_spot_checks(
+        records=[record],
+        writer=writer,
+        feature_names=("returns_5d",),
+    )
+
+    assert checks[0].status == "warn"
+    assert checks[0].missing_reason == (
+        "Insufficient prior OHLCV history for deterministic recomputation: "
+        "requires 6 prior bars, found 2."
+    )
+    assert cards[0].status == "warn"
+
+
 def test_build_market_feature_spot_checks_fails_on_stored_mismatch(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -111,6 +153,97 @@ def test_build_market_feature_spot_checks_fails_on_stored_mismatch(
     assert checks[0].absolute_difference > 0.1
     assert cards[0].status == "fail"
     assert "differs from recomputation" in cards[0].message
+
+
+def test_build_market_feature_spot_checks_warns_on_nan_adj_close(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """NaN source OHLCV values should surface as explicit WARN records."""
+    writer = local_writer(tmp_path, monkeypatch)
+    bars = _hand_computable_bars()
+    feature_date = str(bars.iloc[27]["date"])
+    bars.loc[26, "adj_close"] = math.nan
+    writer.put_object(raw_price_path("AAPL"), _parquet_bytes(bars))
+
+    record = FeatureRecord(
+        date=feature_date,
+        ticker="AAPL",
+        features={"returns_1d": 0.0},
+    )
+
+    checks, cards = build_market_feature_spot_checks(
+        records=[record],
+        writer=writer,
+        feature_names=("returns_1d",),
+    )
+
+    assert checks[0].status == "warn"
+    assert checks[0].missing_reason == (
+        "Raw Layer 0 OHLCV archive has non-finite adj_close values inside the source window."
+    )
+    assert cards[0].status == "warn"
+
+
+def test_build_market_feature_spot_checks_warns_on_missing_required_column(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing OHLCV columns should produce explicit WARN records instead of exceptions."""
+    writer = local_writer(tmp_path, monkeypatch)
+    bars = _hand_computable_bars().drop(columns=["adj_close"])
+    feature_date = str(bars.iloc[27]["date"])
+    writer.put_object(raw_price_path("AAPL"), _parquet_bytes(bars))
+
+    record = FeatureRecord(
+        date=feature_date,
+        ticker="AAPL",
+        features={"returns_1d": 0.0},
+    )
+
+    checks, cards = build_market_feature_spot_checks(
+        records=[record],
+        writer=writer,
+        feature_names=("returns_1d",),
+    )
+
+    assert checks[0].status == "warn"
+    assert checks[0].missing_reason == (
+        "Raw Layer 0 OHLCV archive is missing required columns for returns_1d: adj_close."
+    )
+    assert cards[0].status == "warn"
+
+
+def test_build_market_feature_spot_checks_warns_on_zero_mean_volume(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero mean volume should be classified as a missing-data WARN, not a FAIL."""
+    writer = local_writer(tmp_path, monkeypatch)
+    bars = _hand_computable_bars()
+    bars.loc[:19, "volume"] = 0
+    bars.loc[:19, "dollar_volume"] = 0.0
+    feature_date = str(bars.iloc[20]["date"])
+    writer.put_object(raw_price_path("AAPL"), _parquet_bytes(bars))
+
+    record = FeatureRecord(
+        date=feature_date,
+        ticker="AAPL",
+        features={"volume_ratio_20": 0.0},
+    )
+
+    checks, cards = build_market_feature_spot_checks(
+        records=[record],
+        writer=writer,
+        feature_names=("volume_ratio_20",),
+    )
+
+    assert checks[0].status == "warn"
+    assert checks[0].expected_value is None
+    assert checks[0].missing_reason == (
+        "Volume ratio is undefined because the 20-bar mean volume is zero."
+    )
+    assert cards[0].status == "warn"
 
 
 def _hand_computable_bars() -> pd.DataFrame:


### PR DESCRIPTION
## What this PR does
Adds read-only raw-vs-computed spot checks and formula audit card payloads to the Layer 1 audit dashboard backend. The dashboard now recomputes a documented set of deterministic market features directly from Layer 0 OHLCV (`returns_1d`, `returns_5d`, `realized_vol_21d`, `volume_ratio_20`, and `rsi_14`), compares those values to stored Layer 1 histories with explicit tolerances, records PASS/WARN/FAIL status plus missing-data reasons, and emits human-readable formula cards for the same rows. The new logic is point-in-time safe by construction and only uses source bars strictly before the feature date.

This update also addresses Claude review feedback by making malformed OHLCV input explicit WARN/skip output instead of uncaught exceptions or spurious FAILs, promoting the cross-module spot-check summary helper to a public import, tightening the dashboard summary type annotation, and adding AGENTS.md-required edge-case tests for empty input, insufficient history, missing columns, NaN source data, and zero-mean volume.

## Closes
Closes #159

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [ ] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
- `spot_check_records`: emits 30 records in the seeded dashboard fixture (`14 pass`, `15 warn`, `1 fail`)
- `formula_audit_cards`: one human-readable calculation payload per spot-check row

## Notes for reviewer
Commands run:
- `./.venv/bin/python -m ruff check core/features/market_spotchecks.py core/features/dashboard_backend.py tests/unit/test_market_spotchecks.py tests/unit/test_feature_dashboard_backend.py`
- `./.venv/bin/pytest tests/unit/test_market_spotchecks.py tests/unit/test_feature_dashboard_backend.py -v --tb=short`
- `./.venv/bin/pytest tests/unit/ -v --tb=short`

Test result summary:
- `ruff check`: passed
- `pytest tests/unit/test_market_spotchecks.py tests/unit/test_feature_dashboard_backend.py -v --tb=short`: `10 passed`
- `pytest tests/unit/ -v --tb=short`: `506 passed in 45.69s`

Manifest key(s):
- None. This change is read-only against existing Layer 0/1 artifacts and does not write manifests.

Report path(s):
- Read-only local dashboard outputs remain under `artifacts/reports/diagnostics/` via `app/lab/data_pipelines/build_layer1_feature_audit_dashboard.py`

R2 output prefix(es):
- None. The new logic reads `raw/prices/{ticker}.parquet` and `features/layer1/{ticker}.parquet` only.

Known skipped/missing data:
- The seeded dashboard fixture intentionally leaves `MSFT` raw OHLCV absent so the report exercises explicit WARN/skip behavior for missing Layer 0 source data.
- Spot checks now also emit explicit WARN records when the source OHLCV archive is malformed, missing required columns, contains non-finite source values, or cannot define `volume_ratio_20` because the 20-bar mean volume is zero.
- Human review is still pending; this PR is intentionally left open for Claude review.
