### PR TITLE
Add batched Layer 1 Modal timeout guard

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -267,6 +267,7 @@ class ModalRuntimeConfig:
     app_name: str
     r2_secret_name: str
     timeout_seconds: int
+    batch_timeout_seconds: int
     python_version: str
     requirements_path: str
 
@@ -525,10 +526,14 @@ def run_daily_layer1(
 def load_modal_runtime_config(path: Path = MODAL_CONFIG_PATH) -> ModalRuntimeConfig:
     """Load Modal app and image settings from repository config."""
     payload = json.loads(path.read_text(encoding="utf-8"))
+    timeout_seconds = int(payload["timeout_seconds"])
     return ModalRuntimeConfig(
         app_name=str(payload["layer1_daily_app_name"]),
         r2_secret_name=str(payload["r2_secret_name"]),
-        timeout_seconds=int(payload["timeout_seconds"]),
+        timeout_seconds=timeout_seconds,
+        batch_timeout_seconds=int(
+            payload.get("layer1_batch_timeout_seconds", timeout_seconds)
+        ),
         python_version=str(payload.get("python_version", "3.11")),
         requirements_path=str(payload.get("requirements_path", "requirements/modal.txt")),
     )
@@ -1356,12 +1361,12 @@ def modal_range_main(
     hmm_max_iterations: int = 100,
     hmm_min_training_rows: int = 30,
 ) -> None:
-    """Submit one multi-date Layer 1 readiness run through the batched Modal path."""
+    """Submit one multi-date Layer 1 readiness run via the Python entrypoint only."""
     if _modal_run_batched_layer1 is None:
         raise RuntimeError(
             "Batched Modal app is unavailable because the modal package is not installed"
         )
-    _run_modal_remote_function(
+    result = _run_modal_remote_function(
         _modal_run_batched_layer1,
         owning_app=app,
         run_id=run_id,
@@ -1375,6 +1380,14 @@ def modal_range_main(
         hmm_max_iterations=hmm_max_iterations,
         hmm_min_training_rows=hmm_min_training_rows,
     )
+    manifest_key = result.get("manifest_key")
+    ready_for_layer2 = result.get("ready_for_layer2")
+    if isinstance(manifest_key, str) and isinstance(ready_for_layer2, bool):
+        logger.info(
+            "Layer 1 batched Modal run complete manifest={} ready_for_layer2={}",
+            manifest_key,
+            ready_for_layer2,
+        )
 
 
 def modal_main(
@@ -1611,7 +1624,7 @@ def _define_modal_app() -> object | None:
     modal_run_batched_layer1 = app.function(
         image=image,
         secrets=[modal.Secret.from_name(runtime.r2_secret_name)],
-        timeout=runtime.timeout_seconds,
+        timeout=runtime.batch_timeout_seconds,
     )(_modal_run_batched_layer1_entry)
     app.local_entrypoint()(modal_main)
     _modal_run_batched_layer1 = modal_run_batched_layer1

--- a/config/modal.json
+++ b/config/modal.json
@@ -4,6 +4,7 @@
   "hmm_regime_app_name": "ai-stock-trader-hmm-regime-detection",
   "r2_secret_name": "ai-stock-trader-r2",
   "timeout_seconds": 7200,
+  "layer1_batch_timeout_seconds": 18000,
   "layer1_poll_interval_seconds": 5,
   "layer1_poll_timeout_seconds": 7200,
   "layer1_backfill_timeout_seconds": 5400,

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,8 +113,8 @@ Config ownership:
 - `config/finbert_sentiment.json` owns the FinBERT app name, R2 secret, timeout, and
   Modal image settings.
 - `config/modal.json` owns the Pi-triggered daily Layer 1 app name and poll settings, the
-  Layer 1 backfill and HMM regime app names, their timeouts, and shared Modal image
-  settings.
+  single-date Layer 1 timeout, dedicated batched Layer 1 timeout, Layer 1 backfill and
+  HMM regime app names, their timeouts, and shared Modal image settings.
 
 Production readiness command and inspection:
 

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -831,7 +831,8 @@ def test_load_modal_runtime_config_reads_repo_config() -> None:
 
     assert config.app_name
     assert config.r2_secret_name
-    assert config.timeout_seconds > 0
+    assert config.timeout_seconds == 7200
+    assert config.batch_timeout_seconds == 18000
 
 
 def _write_completed_stage_manifest(

--- a/tests/unit/test_modal_runner_entrypoints.py
+++ b/tests/unit/test_modal_runner_entrypoints.py
@@ -335,7 +335,7 @@ def test_daily_layer1_modal_app_builds_workspace_image(
     assert registered.options["timeout"] == runtime.timeout_seconds
     assert registered.options["secrets"][0].name == runtime.r2_secret_name
     assert batched_registered.options["image"] is image
-    assert batched_registered.options["timeout"] == runtime.timeout_seconds
+    assert batched_registered.options["timeout"] == runtime.batch_timeout_seconds
     assert batched_registered.options["secrets"][0].name == runtime.r2_secret_name
 
 
@@ -461,8 +461,25 @@ def test_daily_layer1_modal_range_main_dispatches_batched_remote_call(
 ) -> None:
     """The range entrypoint submits one batched Modal job for a multi-date window."""
     final_remote = _FakeRegisteredFunction(name="modal_run_batched_layer1", options={})
+    logged_messages: list[tuple[str, bool]] = []
 
     monkeypatch.setattr(run_daily_layer1, "_modal_run_batched_layer1", final_remote)
+    monkeypatch.setattr(
+        run_daily_layer1.logger,
+        "info",
+        lambda message, manifest_key, ready_for_layer2: logged_messages.append(
+            (manifest_key, ready_for_layer2)
+        )
+        if message == "Layer 1 batched Modal run complete manifest={} ready_for_layer2={}"
+        else None,
+    )
+    final_remote.remote = lambda **kwargs: (
+        final_remote.remote_calls.append(kwargs)
+        or {
+            "manifest_key": "artifacts/manifests/layer1/smoke-range.json",
+            "ready_for_layer2": True,
+        }
+    )
 
     run_daily_layer1.modal_range_main(
         run_id="smoke-range",
@@ -490,4 +507,7 @@ def test_daily_layer1_modal_range_main_dispatches_batched_remote_call(
             "hmm_max_iterations": 61,
             "hmm_min_training_rows": 12,
         }
+    ]
+    assert logged_messages == [
+        ("artifacts/manifests/layer1/smoke-range.json", True)
     ]


### PR DESCRIPTION
## What this PR does
Adds a dedicated `layer1_batch_timeout_seconds` guard for the batched Layer 1 Modal registration, keeping the single-date Layer 1 timeout unchanged at 7200 seconds while raising the batched readiness window timeout to 18000 seconds. It also logs the batched remote result's `manifest_key` and `ready_for_layer2` in `modal_range_main`, updates the focused unit tests, and documents the new config ownership in `docs/deployment.md`.

## Closes
Closes #170

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
None

## Notes for reviewer
- Batched Layer 1 Modal registration now uses `layer1_batch_timeout_seconds=18000`, which stays within the requested 14400–18000 second guard band and gives the `2026-04-14..2026-05-12` readiness window materially more headroom than the shared 7200-second single-date timeout.
- Single-date Layer 1 registration still uses `timeout_seconds=7200`.
- `modal_range_main` now logs `manifest_key` and `ready_for_layer2` from the completed batched remote result without exposing secrets.
- Run the `#143` resume command only after this PR merges.

Resume command for #143 after this PR merges:
```bash
HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/run_daily_layer1.py \
    --run-id layer1-readiness-2026-04-14-to-2026-05-12-batch-v5 \
    --from-date 2026-04-14 \
    --to-date 2026-05-12 \
    --layer0-run-id layer0-readiness-2026-04-14-to-2026-05-12-batch-v1 \
    --allow-layer0-manifest-date-range
```

Verification artifacts:
- Commands run:
  - `./.venv/bin/python -m ruff check app/lab/data_pipelines/run_daily_layer1.py tests/unit/test_modal_runner_entrypoints.py tests/unit/test_daily_layer1_runner.py`
  - `./.venv/bin/pytest tests/unit/test_modal_runner_entrypoints.py tests/unit/test_daily_layer1_runner.py -v --tb=short`
  - `./.venv/bin/pytest tests/unit/ -v --tb=short`
- Test result summary:
  - `tests/unit/test_modal_runner_entrypoints.py tests/unit/test_daily_layer1_runner.py`: 25 passed
  - `tests/unit/`: 515 passed
- Manifest key(s): N/A
- Report path(s): N/A
- R2 output prefix(es): N/A
- Known skipped/missing data:
  - No live Modal or R2 smoke run was performed in this task; verification is limited to config wiring, logging, and unit coverage.
