### PR TITLE
Fix daily macro run-date snapshots for Layer 1 readiness

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -31,11 +31,10 @@
   persisted, failures recover batch-by-batch, and incremental updates don't require
   refetching the full range. Requires updating `raw_fundamentals_path`,
   `_write_fundamentals_archive`, `validate_layer0_archive.py`, and Layer 1 consumers.
-- [ ] Macro archive is written as a single `raw/macro/{from}_to_{to}.parquet` file. Shard
-  to per-day (`raw/macro/{YYYY-MM-DD}.parquet`) so FRED backfills match the per-day
-  cadence used by news/universe and partial progress is persisted. Requires updating
-  `raw_macro_path`, `_write_macro_archive`, `validate_layer0_archive.py`, and Layer 1
-  consumers.
+- [ ] Macro archive layout still mixes legacy observation-date shards with run-date
+  readiness snapshots under `raw/macro/{YYYY-MM-DD}.parquet`. Issue `#148` should
+  consolidate the convention and document/migrate any backward-compatibility cleanup
+  needed across backfill, validation, and Layer 1 consumers.
 
 ## Discovered during development
 <!-- Codex adds here when it notices something out of scope for the current task -->

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -168,6 +168,15 @@ class MacroFetcher(Protocol):
     ) -> list[dict[str, object]]:
         """Fetch raw macro observations for configured series/date ranges."""
 
+    def fetch_latest_available_macro_observations(
+        self,
+        *,
+        series_ids: Sequence[str],
+        as_of_date: str,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        """Fetch the latest raw macro observation per series available as of one date."""
+
 
 RecordSerializer = Callable[[list[OHLCVRecord]], bytes]
 RecordDeserializer = Callable[[bytes], list[OHLCVRecord]]
@@ -558,9 +567,8 @@ def run_daily_layer0_incremental(
         output_keys.extend(fundamentals_result.output_keys)
         metadata["fundamentals"] = fundamentals_result.metadata
 
-        macro_result = _write_macro_archive(
-            from_date=as_of_date,
-            to_date=as_of_date,
+        macro_result = _write_daily_macro_snapshot(
+            as_of_date=as_of_date,
             series_ids=config.fred_series_ids,
             limit=config.fred_limit,
             overwrite=config.overwrite,
@@ -1079,6 +1087,74 @@ def _write_macro_archive(
             "empty": empty,
             "total_rows": total_rows,
             "output_keys": output_keys,
+        },
+    )
+
+
+def _write_daily_macro_snapshot(
+    *,
+    as_of_date: date,
+    series_ids: Sequence[str],
+    limit: int,
+    overwrite: bool,
+    fetcher: MacroFetcher,
+    writer: ObjectWriter,
+    serializer: RawRowSerializer,
+) -> _WriteResult:
+    """Fetch and persist one run-date macro snapshot using latest available observations."""
+    normalized_series = _normalize_tokens(series_ids)
+    key = raw_macro_path(as_of_date)
+    if not overwrite and writer.exists(key):
+        logger.info(
+            "Daily macro snapshot already exists for {}; skipping FRED fetch",
+            as_of_date.isoformat(),
+        )
+        return _WriteResult(
+            output_keys=[],
+            metadata={
+                "requested_series": len(normalized_series),
+                "written": 0,
+                "skipped": 1,
+                "empty": 0,
+                "total_rows": 0,
+                "output_keys": [],
+                "snapshot_date": as_of_date.isoformat(),
+            },
+        )
+
+    rows = _sort_raw_rows(
+        fetcher.fetch_latest_available_macro_observations(
+            series_ids=normalized_series,
+            as_of_date=as_of_date.isoformat(),
+            limit=limit,
+        ),
+        ("series_id", "observation_date", "realtime_start", "realtime_end"),
+    )
+    if not rows:
+        return _WriteResult(
+            output_keys=[],
+            metadata={
+                "requested_series": len(normalized_series),
+                "written": 0,
+                "skipped": 0,
+                "empty": 1,
+                "total_rows": 0,
+                "output_keys": [],
+                "snapshot_date": as_of_date.isoformat(),
+            },
+        )
+
+    writer.put_object(key, serializer(rows))
+    return _WriteResult(
+        output_keys=[key],
+        metadata={
+            "requested_series": len(normalized_series),
+            "written": 1,
+            "skipped": 0,
+            "empty": 0,
+            "total_rows": len(rows),
+            "output_keys": [key],
+            "snapshot_date": as_of_date.isoformat(),
         },
     )
 

--- a/core/features/loaders.py
+++ b/core/features/loaders.py
@@ -85,13 +85,22 @@ def load_macro_frame(
         payload = active_writer.get_object(key)
         frames.append(pd.read_parquet(io.BytesIO(payload)))
     frame = pd.concat(frames, ignore_index=True)
-    sort_columns = [
+    identity_columns = [
         column
         for column in ("series_id", "observation_date", "realtime_start", "realtime_end")
         if column in frame.columns
     ]
-    if sort_columns:
-        return frame.sort_values(sort_columns).reset_index(drop=True)
+    if identity_columns:
+        dedupe_order = identity_columns + [
+            column for column in ("retrieved_at",) if column in frame.columns
+        ]
+        frame = (
+            frame.sort_values(dedupe_order)
+            .drop_duplicates(subset=identity_columns, keep="last")
+            .sort_values(identity_columns)
+            .reset_index(drop=True)
+        )
+        return frame
     return frame.reset_index(drop=True)
 
 

--- a/services/fred/macro_fetcher.py
+++ b/services/fred/macro_fetcher.py
@@ -269,6 +269,89 @@ class FredMacroFetcher:
             )
         return rows
 
+    def fetch_latest_available_macro_observations(
+        self,
+        *,
+        series_ids: Sequence[str],
+        as_of_date: str,
+        limit: int = DEFAULT_FRED_PAGE_LIMIT,
+    ) -> list[dict[str, Any]]:
+        """Fetch the latest point-in-time-safe observation per series as of one date."""
+        normalized_series_ids = _normalize_series_ids(series_ids)
+        snapshot_date = _validate_date(as_of_date, "as_of_date")
+        if limit <= 0:
+            raise ValueError("limit must be positive")
+        rows: list[dict[str, Any]] = []
+        for series_id in normalized_series_ids:
+            row = self._fetch_latest_available_observation(
+                series_id=series_id,
+                as_of_date=snapshot_date,
+                limit=limit,
+            )
+            if row is not None:
+                rows.append(row)
+        return rows
+
+    def _fetch_latest_available_observation(
+        self,
+        *,
+        series_id: str,
+        as_of_date: str,
+        limit: int,
+    ) -> dict[str, Any] | None:
+        """Fetch the latest available observation for one series as of one date."""
+        snapshot_rows = self._fetch_latest_available_snapshot_rows(
+            series_id=series_id,
+            as_of_date=as_of_date,
+        )
+        if not snapshot_rows:
+            return None
+
+        observation_date = str(snapshot_rows[0]["observation_date"])
+        vintage_rows = self.fetch_series_observations(
+            series_id=series_id,
+            start_date=observation_date,
+            end_date=observation_date,
+            realtime_start=observation_date,
+            realtime_end=as_of_date,
+            limit=limit,
+        )
+        if not vintage_rows:
+            return snapshot_rows[0]
+        return max(
+            vintage_rows,
+            key=lambda row: (
+                str(row.get("observation_date") or ""),
+                str(row.get("realtime_start") or ""),
+                str(row.get("realtime_end") or ""),
+            ),
+        )
+
+    def _fetch_latest_available_snapshot_rows(
+        self,
+        *,
+        series_id: str,
+        as_of_date: str,
+    ) -> list[dict[str, Any]]:
+        """Fetch a descending one-row snapshot to identify the latest observation date."""
+        normalized_series_id = _normalize_series_id(series_id)
+        payload = self._request_json(
+            params={
+                "series_id": normalized_series_id,
+                "realtime_start": as_of_date,
+                "realtime_end": as_of_date,
+                "observation_end": as_of_date,
+                "sort_order": "desc",
+                "file_type": "json",
+                "output_type": 1,
+                "limit": 1,
+                "offset": 0,
+                "api_key": self.config.api_key,
+            }
+        )
+        observations = _extract_observations(payload)
+        return normalize_fred_observations(observations, series_id=normalized_series_id)
+
     def _request_json(self, params: Mapping[str, Any]) -> Any:
         """Request one FRED payload with bounded retries for transient failures."""
         url = f"{self.config.base_url.rstrip('/')}{FRED_OBSERVATIONS_ENDPOINT}"

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -61,9 +61,9 @@ def raw_fundamentals_path(ticker: str) -> str:
     return build_r2_key("raw", "fundamentals", f"{safe_ticker}.parquet")
 
 
-def raw_macro_path(observation_date: str | Date | datetime) -> str:
-    """Return the canonical raw macro/rates Parquet path for one observation date."""
-    return build_r2_key("raw", "macro", f"{_format_date(observation_date)}.parquet")
+def raw_macro_path(archive_date: str | Date | datetime) -> str:
+    """Return the canonical raw macro/rates Parquet path for one archive date."""
+    return build_r2_key("raw", "macro", f"{_format_date(archive_date)}.parquet")
 
 
 def raw_reference_path(name: str, extension: str = "json") -> str:

--- a/tests/unit/test_feature_loaders.py
+++ b/tests/unit/test_feature_loaders.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.features.loaders import load_macro_frame
+from services.r2.paths import raw_macro_path
+from tests.fixtures.layer1_support import local_writer
+
+
+def test_load_macro_frame_deduplicates_equivalent_vintages_across_archive_dates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Run-date and legacy observation-date shards should not duplicate one macro vintage."""
+    writer = local_writer(tmp_path, monkeypatch)
+    vintage = pd.DataFrame(
+        [
+            {
+                "source": "fred",
+                "series_id": "DGS10",
+                "observation_date": "2026-05-12",
+                "realtime_start": "2026-05-12",
+                "realtime_end": "2026-05-12",
+                "retrieved_at": "2026-05-12T20:00:00+00:00",
+                "value": 4.42,
+                "is_missing": False,
+                "raw": {"series_id": "DGS10"},
+            }
+        ]
+    )
+    snapshot = vintage.assign(retrieved_at="2026-05-13T20:00:00+00:00")
+    for key, frame in (
+        (raw_macro_path("2026-05-12"), vintage),
+        (raw_macro_path("2026-05-13"), snapshot),
+    ):
+        buffer = io.BytesIO()
+        frame.to_parquet(buffer, index=False)
+        writer.put_object(key, buffer.getvalue())
+
+    frame = load_macro_frame(writer=writer)
+
+    assert len(frame.index) == 1
+    assert frame.loc[0, "series_id"] == "DGS10"
+    assert frame.loc[0, "observation_date"] == "2026-05-12"
+    assert frame.loc[0, "retrieved_at"] == "2026-05-13T20:00:00+00:00"

--- a/tests/unit/test_fred_macro_fetcher.py
+++ b/tests/unit/test_fred_macro_fetcher.py
@@ -289,6 +289,100 @@ def test_fetch_series_page_accepts_empty_response() -> None:
     assert page.rows == []
 
 
+def test_fetch_latest_available_macro_observations_uses_as_of_snapshot_params() -> None:
+    """Daily latest-available pulls ask FRED for one descending as-of snapshot per series."""
+    session = _FakeSession(
+        [
+            _FakeResponse(
+                {
+                    "observations": [
+                        {
+                            "realtime_start": "2026-05-13",
+                            "realtime_end": "2026-05-13",
+                            "date": "2026-05-12",
+                            "value": "4.42",
+                        }
+                    ]
+                }
+            ),
+            _FakeResponse(
+                {
+                    "observations": [
+                        {
+                            "realtime_start": "2026-05-12",
+                            "realtime_end": "2026-05-12",
+                            "date": "2026-05-12",
+                            "value": "4.42",
+                        }
+                    ]
+                }
+            ),
+        ]
+    )
+    fetcher = FredMacroFetcher(
+        FredClientConfig(api_key="test-key", retry_sleep_seconds=0),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    rows = fetcher.fetch_latest_available_macro_observations(
+        series_ids=["DGS10"],
+        as_of_date="2026-05-13",
+        limit=17,
+    )
+
+    assert rows == [
+        {
+            "source": "fred",
+            "series_id": "DGS10",
+            "observation_date": "2026-05-12",
+            "realtime_start": "2026-05-12",
+            "realtime_end": "2026-05-12",
+            "retrieved_at": rows[0]["retrieved_at"],  # generated at runtime
+            "value": 4.42,
+            "is_missing": False,
+            "raw": {
+                "realtime_start": "2026-05-12",
+                "realtime_end": "2026-05-12",
+                "date": "2026-05-12",
+                "value": "4.42",
+            },
+        }
+    ]
+    assert session.calls[0] == {
+        "url": "https://api.stlouisfed.org/fred/series/observations",
+        "params": {
+            "series_id": "DGS10",
+            "realtime_start": "2026-05-13",
+            "realtime_end": "2026-05-13",
+            "observation_end": "2026-05-13",
+            "sort_order": "desc",
+            "file_type": "json",
+            "output_type": 1,
+            "limit": 1,
+            "offset": 0,
+            "api_key": "test-key",
+        },
+        "timeout": 30,
+    }
+    assert session.calls[1] == {
+        "url": "https://api.stlouisfed.org/fred/series/observations",
+        "params": {
+            "series_id": "DGS10",
+            "observation_start": "2026-05-12",
+            "observation_end": "2026-05-12",
+            "realtime_start": "2026-05-12",
+            "realtime_end": "2026-05-13",
+            "sort_order": "asc",
+            "file_type": "json",
+            "output_type": 1,
+            "limit": 17,
+            "offset": 0,
+            "api_key": "test-key",
+        },
+        "timeout": 30,
+    }
+
+
 def test_fetch_series_page_rejects_malformed_required_fields() -> None:
     """Malformed FRED observations fail with actionable diagnostics."""
     fixture = _fixture_payload()

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -169,6 +169,7 @@ class _FundamentalsFetcher:
 class _MacroFetcher:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
+        self.snapshot_calls: list[dict[str, Any]] = []
 
     def fetch_all_macro_observations(
         self,
@@ -191,6 +192,34 @@ class _MacroFetcher:
             }
         )
         return [{"series_id": series_ids[0], "observation_date": start_date, "value": "1.0"}]
+
+    def fetch_latest_available_macro_observations(
+        self,
+        *,
+        series_ids: list[str] | tuple[str, ...],
+        as_of_date: str,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        self.snapshot_calls.append(
+            {
+                "series_ids": tuple(series_ids),
+                "as_of_date": as_of_date,
+                "limit": limit,
+            }
+        )
+        previous_day = (date.fromisoformat(as_of_date) - date.resolution).isoformat()
+        return [
+            {
+                "series_id": series_ids[0],
+                "observation_date": previous_day,
+                "realtime_start": previous_day,
+                "realtime_end": as_of_date,
+                "retrieved_at": f"{as_of_date}T00:00:00+00:00",
+                "value": 1.0,
+                "is_missing": False,
+                "raw": {"series_id": series_ids[0]},
+            }
+        ]
 
 
 def _bar(*, date_value: str, ticker: str, dollar_volume: float = 2_000_000.0) -> OHLCVRecord:
@@ -410,6 +439,54 @@ def test_daily_layer0_incremental_uses_alpaca_shape_and_canonical_paths() -> Non
     price_payload = json.loads(writer.objects[raw_price_path("AAPL")])
     assert price_payload[0]["ticker"] == "AAPL"
     assert price_payload[0]["date"] == "2024-01-02"
+
+
+def test_daily_layer0_incremental_writes_run_date_macro_snapshot_from_latest_available_rows() -> None:
+    """Daily Layer 0 keys macro shards by run date even when FRED lags one day."""
+    writer = _Writer()
+    macro_fetcher = _MacroFetcher()
+
+    run_daily_layer0_incremental(
+        config=DailyLayer0Config(
+            as_of_date=date(2026, 5, 13),
+            tickers=("AAPL",),
+            fred_series_ids=("DGS10",),
+            run_id="test-daily-macro-snapshot",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        live_price_fetcher=_LivePriceFetcher(
+            records=[
+                _bar(date_value="2026-05-13", ticker="AAPL"),
+                _bar(date_value="2026-05-13", ticker="SPY"),
+            ]
+        ),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=macro_fetcher,
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        price_deserializer=_bytes_deserializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+    )
+
+    assert macro_fetcher.snapshot_calls == [
+        {"series_ids": ("DGS10",), "as_of_date": "2026-05-13", "limit": 1000}
+    ]
+    payload = json.loads(writer.objects[raw_macro_path("2026-05-13")])
+    assert payload == [
+        {
+            "is_missing": False,
+            "observation_date": "2026-05-12",
+            "raw": {"series_id": "DGS10"},
+            "realtime_end": "2026-05-13",
+            "realtime_start": "2026-05-12",
+            "retrieved_at": "2026-05-13T00:00:00+00:00",
+            "series_id": "DGS10",
+            "value": 1.0,
+        }
+    ]
 
 
 def test_daily_layer0_incremental_canonicalizes_dot_tickers_across_outputs() -> None:


### PR DESCRIPTION
## What this PR does
This fixes the #172 blocker in the daily Layer 0 macro path. Daily runs now write `raw/macro/{run_date}.parquet` from the latest FRED observations available as of the run date, even when FRED has not published same-observation-date rows yet. The fetch path preserves point-in-time safety by resolving the latest observation date first and then fetching the exact vintage history for that observation before writing the run-date snapshot. Layer 1 keeps reading mixed legacy observation-date shards and new run-date snapshots safely via macro-vintage deduplication. This stays scoped to the #143 readiness blocker and leaves the broader archive-convention cleanup in #148.

## Closes
Closes #172

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [ ] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
None

## Notes for reviewer
- The daily Layer 0 macro write path is the intentional scope boundary. Historical/backfill behavior is left in place so #148 can handle the broader archive-convention cleanup separately.
- `TODO.md` now reflects that remaining #148 debt is mixed legacy observation-date shards plus run-date readiness snapshots, not a single monolithic macro parquet.
- Commands run:
  - `./.venv/bin/python -m ruff check core/data/layer0_pipeline.py services/fred/macro_fetcher.py app/lab/data_pipelines/validate_layer0_archive.py core/features/loaders.py core/features/macro_features.py tests/unit/`
  - `./.venv/bin/pytest tests/unit/test_layer0_pipeline.py tests/unit/test_fred_macro_fetcher.py tests/unit/test_feature_loaders.py -v --tb=short`
  - `./.venv/bin/pytest tests/unit/ -v --tb=short`
- Exact #143 resume sequence after merge:
  1. rerun/validate Layer 0 for `2026-05-13`
  2. then run Layer 1 readiness for `2026-04-14..2026-05-13` with a new run id and validate the authoritative top-level Layer 1 manifest/report
