### PR TITLE
Harden SimFin fundamentals recovery

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,13 +24,6 @@
   `list_keys()` (paginated ListObjectsV2) for every existence check. Should add a
   `head_object`-based `exists()` to `CloudflareR2Client`. Affects all data families
   (prices, universe, news, fundamentals, macro) — thousands of slow calls per backfill run.
-- [ ] Fundamentals archive is written as a single `raw/fundamentals/{from}_to_{to}.parquet`
-  file, unlike prices (per-ticker) and news/universe (per-day). Shard per-ticker with
-  per-filing-date history (e.g. `raw/fundamentals/{TICKER}/{report_date}.parquet`, or
-  per-ticker historical files analogous to price parquets) so partial SimFin progress is
-  persisted, failures recover batch-by-batch, and incremental updates don't require
-  refetching the full range. Requires updating `raw_fundamentals_path`,
-  `_write_fundamentals_archive`, `validate_layer0_archive.py`, and Layer 1 consumers.
 - [ ] Macro archive layout still mixes legacy observation-date shards with run-date
   readiness snapshots under `raw/macro/{YYYY-MM-DD}.parquet`. Issue `#148` should
   consolidate the convention and document/migrate any backward-compatibility cleanup
@@ -41,3 +34,8 @@
 - [ ] Universe validation still reports a few historical symbol-identity mismatches
   (e.g., UAA, AGN, IQV transition events); evaluate date-bounded symbol mapping
   policy to reduce residual event-boundary violations.
+- [ ] SimFin still lacks direct coverage for several current S&P 500 symbols even after
+  per-ticker recovery and safe alias rewrites (confirmed on 2026-05-13 for `BF-B`,
+  `BRK-B`, `GEV`, `SOLV`, `TKO`, `VLTO`). Decide whether to maintain explicit
+  provider-gap exceptions, source a secondary fundamentals provider for those names, or
+  relax readiness rules only with explicit human approval.

--- a/TODO.md
+++ b/TODO.md
@@ -36,6 +36,6 @@
   policy to reduce residual event-boundary violations.
 - [ ] SimFin still lacks direct coverage for several current S&P 500 symbols even after
   per-ticker recovery and safe alias rewrites (confirmed on 2026-05-13 for `BF-B`,
-  `BRK-B`, `GEV`, `SOLV`, `TKO`, `VLTO`). Decide whether to maintain explicit
+  `BRK-B`, `GEV`, `SOLV`, `SW`, `TKO`, `VLTO`). Decide whether to maintain explicit
   provider-gap exceptions, source a secondary fundamentals provider for those names, or
   relax readiness rules only with explicit human approval.

--- a/app/lab/data_pipelines/backfill_simfin.py
+++ b/app/lab/data_pipelines/backfill_simfin.py
@@ -68,6 +68,7 @@ class BackfillResult:
     skipped: int
     empty: int
     total_rows: int
+    missing_tickers: tuple[str, ...]
     output_keys: tuple[str, ...]
 
 
@@ -112,6 +113,7 @@ def backfill_simfin_archive(
             skipped=len(ticker_source),
             empty=0,
             total_rows=0,
+            missing_tickers=(),
             output_keys=(),
         )
 
@@ -135,14 +137,24 @@ def backfill_simfin_archive(
     output_keys: list[str] = []
     empty = 0
     total_rows = 0
+    missing_tickers: list[str] = []
     for ticker in remaining:
         ticker_rows = _sort_fundamentals(rows_by_ticker.get(ticker, []))
+        if not ticker_rows:
+            empty += 1
+            missing_tickers.append(ticker)
+            logger.warning(
+                "SimFin returned no fundamentals rows for ticker {} in {}..{}; "
+                "skipping archive write",
+                ticker,
+                from_date.isoformat(),
+                to_date.isoformat(),
+            )
+            continue
         key = raw_fundamentals_path(ticker)
         writer.put_object(key, payload_serializer(ticker_rows))
         output_keys.append(key)
         total_rows += len(ticker_rows)
-        if not ticker_rows:
-            empty += 1
 
     logger.info(
         "Wrote {} SimFin fundamentals files ({} rows) for {} tickers",
@@ -156,6 +168,7 @@ def backfill_simfin_archive(
         skipped=len(ticker_source) - len(remaining),
         empty=empty,
         total_rows=total_rows,
+        missing_tickers=tuple(missing_tickers),
         output_keys=tuple(output_keys),
     )
 

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -944,6 +944,7 @@ def _write_fundamentals_archive(
     skipped = 0
     empty = 0
     total_rows = 0
+    missing_tickers: list[str] = []
     retrieved_at = datetime.now(UTC)
     batch_size = 50
     batches = [
@@ -990,13 +991,22 @@ def _write_fundamentals_archive(
         skipped += len(batch) - len(remaining)
         for ticker in remaining:
             ticker_rows = _sort_raw_rows(rows_by_ticker.get(ticker, []), ("report_date",))
+            if not ticker_rows:
+                empty += 1
+                missing_tickers.append(ticker)
+                logger.warning(
+                    "SimFin returned no fundamentals rows for ticker {} in {}..{}; "
+                    "skipping archive write",
+                    ticker,
+                    from_date.isoformat(),
+                    to_date.isoformat(),
+                )
+                continue
             key = raw_fundamentals_path(ticker)
             writer.put_object(key, serializer(ticker_rows))
             output_keys.append(key)
             written += 1
             total_rows += len(ticker_rows)
-            if not ticker_rows:
-                empty += 1
 
     return _WriteResult(
         output_keys=output_keys,
@@ -1005,6 +1015,7 @@ def _write_fundamentals_archive(
             "written": written,
             "skipped": skipped,
             "empty": empty,
+            "missing_tickers": missing_tickers,
             "total_rows": total_rows,
             "output_keys": output_keys,
         },

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -175,7 +175,7 @@ r2/
     prices/           # OHLCV Parquet, one file per ticker
     news/             # Raw news as JSON Lines (one article per line)
     universe/         # Daily eligibility masks as CSV
-    fundamentals/     # SimFin as-reported point-in-time fundamentals and earnings data
+    fundamentals/     # SimFin as-reported point-in-time fundamentals per ticker parquet
     macro/            # FRED macro/rate observations as available on the run date
     reference/        # Symbol/security-reference snapshots
   features/
@@ -218,7 +218,7 @@ Any artifact that must survive a Pi restart or be accessed by Modal must be writ
 | Feature tables | Parquet (per ticker history) | Keeps Layer 1 artifacts aligned to the FeatureRecord contract while reducing object count |
 | Model scores | Parquet | Small, fast to read |
 | News raw archive | JSON Lines | One article per line; easy to stream |
-| Fundamentals archive | Parquet | Point-in-time company fundamentals; efficient ticker/date joins |
+| Fundamentals archive | Parquet (per ticker history) | Point-in-time company fundamentals at `raw/fundamentals/{ticker}.parquet`; efficient ticker/date joins and targeted recovery |
 | Macro/rates archive | Parquet or CSV | Small daily series; preserve observations used by a run |
 | Sentiment scores | Parquet | Processed output from FinBERT pipeline |
 | Universe eligibility masks | CSV | Small; human-inspectable |

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -122,8 +122,8 @@ Purpose:
 - prevent Layer 1 from calling SimFin directly or accidentally using future restatements
 
 Notes:
-- raw fundamentals are stored as archival Layer 0 data in R2, for example under
-  `raw/fundamentals/`
+- raw fundamentals are stored as archival Layer 0 data in R2 as per-ticker parquet
+  histories under `raw/fundamentals/{ticker}.parquet`
 - Layer 1 converts these raw records into context features such as valuation ratios,
   leverage, profitability, earnings proximity, and earnings surprises
 - this archive is not a replacement for `FeatureRecord`

--- a/services/simfin/fundamentals_fetcher.py
+++ b/services/simfin/fundamentals_fetcher.py
@@ -23,6 +23,18 @@ DEFAULT_SIMFIN_TICKER_BATCH_SIZE = 50
 DEFAULT_SIMFIN_STATEMENTS = ("pl", "bs", "cf", "derived")
 DEFAULT_SIMFIN_PERIODS = ("q1", "q2", "q3", "q4", "fy")
 SIMFIN_ENV_FILE = Path(__file__).resolve().parents[2] / "config" / "simfin.env"
+_SIMFIN_REQUEST_TICKER_OVERRIDES: dict[str, str] = {
+    # Current S&P 500 ticker aliases that SimFin still serves under an older
+    # vendor symbol or the economic share-class peer with identical company fundamentals.
+    "CPAY": "FLT",
+    "FISV": "FI",
+    "FOXA": "FOX",
+    "GOOGL": "GOOG",
+    "MRSH": "MMC",
+    "NWSA": "NWS",
+    "RVTY": "PKI",
+    "XYZ": "SQ",
+}
 
 
 @dataclass(frozen=True)
@@ -87,6 +99,7 @@ class SimFinFundamentalsFetcher:
     ) -> SimFinPage:
         """Fetch one page of raw SimFin statement rows for a ticker/date range."""
         normalized_tickers = _normalize_tickers(tickers)
+        request_groups = _group_requested_tickers_by_vendor_symbol(normalized_tickers)
         normalized_statements = _normalize_tokens(statements, "statements")
         normalized_periods = _normalize_tokens(periods, "periods")
         start = _validate_date(start_date, "start_date")
@@ -100,7 +113,7 @@ class SimFinFundamentalsFetcher:
 
         payload = self._request_json(
             params={
-                "ticker": ",".join(_simfin_request_ticker(ticker) for ticker in normalized_tickers),
+                "ticker": ",".join(_simfin_request_ticker(ticker) for ticker in request_groups),
                 "statements": ",".join(normalized_statements),
                 "period": ",".join(normalized_periods),
                 "start": start,
@@ -111,7 +124,10 @@ class SimFinFundamentalsFetcher:
             }
         )
         raw_rows = _extract_payload_rows(payload)
-        rows = normalize_simfin_fundamental_rows(raw_rows, retrieved_at=retrieved_at)
+        rows = _expand_requested_ticker_aliases(
+            normalize_simfin_fundamental_rows(raw_rows, retrieved_at=retrieved_at),
+            request_groups=request_groups,
+        )
         return SimFinPage(rows=rows, offset=offset, limit=limit)
 
     def fetch_all_fundamentals(
@@ -552,6 +568,30 @@ def _ticker_batches(tickers: Sequence[str]) -> list[tuple[str, ...]]:
     ]
 
 
+def _group_requested_tickers_by_vendor_symbol(tickers: Sequence[str]) -> dict[str, tuple[str, ...]]:
+    """Group canonical archive tickers by the SimFin vendor symbol to request."""
+    groups: dict[str, list[str]] = {}
+    for ticker in tickers:
+        request_symbol = _simfin_vendor_ticker(ticker)
+        groups.setdefault(request_symbol, []).append(ticker)
+    return {ticker: tuple(canonicals) for ticker, canonicals in groups.items()}
+
+
+def _expand_requested_ticker_aliases(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    request_groups: Mapping[str, Sequence[str]],
+) -> list[dict[str, Any]]:
+    """Duplicate provider rows back onto every requested canonical ticker alias."""
+    expanded: list[dict[str, Any]] = []
+    for row in rows:
+        provider_ticker = _normalize_ticker(str(row.get("ticker") or ""))
+        target_tickers = tuple(request_groups.get(provider_ticker, (provider_ticker,)))
+        for target_ticker in target_tickers:
+            expanded.append({**row, "ticker": target_ticker})
+    return expanded
+
+
 def _normalize_ticker(ticker: str) -> str:
     """Normalize one ticker symbol."""
     if not isinstance(ticker, str):
@@ -564,7 +604,13 @@ def _normalize_ticker(ticker: str) -> str:
 
 def _simfin_request_ticker(ticker: str) -> str:
     """Translate canonical archive tickers to SimFin's request symbol convention."""
-    return ticker.replace("-", ".")
+    return _simfin_vendor_ticker(ticker).replace("-", ".")
+
+
+def _simfin_vendor_ticker(ticker: str) -> str:
+    """Return the normalized SimFin vendor symbol for one canonical archive ticker."""
+    normalized = _normalize_ticker(ticker)
+    return _SIMFIN_REQUEST_TICKER_OVERRIDES.get(normalized, normalized)
 
 
 def _normalize_tokens(values: Sequence[str], field_name: str) -> tuple[str, ...]:

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -163,7 +163,22 @@ class _FundamentalsFetcher:
                 "limit": limit,
             }
         )
-        return [{"ticker": tickers[0], "report_date": start_date, "raw": {"x": 1}}]
+        return [{"ticker": ticker, "report_date": start_date, "raw": {"x": 1}} for ticker in tickers]
+
+
+class _EmptyFundamentalsFetcher:
+    def fetch_all_fundamentals(
+        self,
+        *,
+        tickers: list[str] | tuple[str, ...],
+        start_date: str,
+        end_date: str,
+        statements: list[str] | tuple[str, ...],
+        periods: list[str] | tuple[str, ...],
+        retrieved_at: datetime | None,
+        limit: int,
+    ) -> list[dict[str, object]]:
+        return []
 
 
 class _MacroFetcher:
@@ -589,6 +604,37 @@ def test_daily_layer0_incremental_is_idempotent_for_existing_raw_outputs() -> No
 
     assert {key: writer.put_counts[key] for key in keys} == {key: 0 for key in keys}
     assert writer.objects[pipeline_manifest_path("layer0", "test-idempotent")]
+
+
+def test_daily_layer0_incremental_skips_new_empty_fundamentals_archives() -> None:
+    """Missing fundamentals history is surfaced without creating a zero-row archive placeholder."""
+    writer = _Writer()
+
+    run_daily_layer0_incremental(
+        config=DailyLayer0Config(
+            as_of_date=date(2024, 1, 2),
+            tickers=("AAPL",),
+            fred_series_ids=("DGS10",),
+            run_id="test-empty-fundamentals",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        live_price_fetcher=_LivePriceFetcher(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_EmptyFundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        price_deserializer=_bytes_deserializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+        universe_serializer=_universe_serializer,
+    )
+
+    assert raw_fundamentals_path("AAPL") not in writer.objects
+    manifest = _manifest(writer, "test-empty-fundamentals")
+    assert manifest["metadata"]["fundamentals"]["empty"] == 1
+    assert manifest["metadata"]["fundamentals"]["missing_tickers"] == ["AAPL"]
 
 
 def test_daily_layer0_incremental_repairs_missing_target_date_and_rewrites_universe_mask() -> None:

--- a/tests/unit/test_simfin_fundamentals_fetcher.py
+++ b/tests/unit/test_simfin_fundamentals_fetcher.py
@@ -491,6 +491,68 @@ def test_fetch_statement_rows_uses_simfin_share_class_symbols() -> None:
     assert [row["ticker"] for row in page.rows] == ["BRK-B", "BF-B"]
 
 
+def test_fetch_statement_rows_duplicates_company_fundamentals_for_requested_share_classes() -> None:
+    """One provider company-symbol response can populate multiple requested archive tickers."""
+    payload = [
+        {
+            "ticker": "GOOG",
+            "currency": "USD",
+            "statements": [
+                {
+                    "statement": "PL",
+                    "columns": ["Fiscal Period", "Fiscal Year", "Report Date", "Publish Date"],
+                    "data": [["Q1", 2024, "2024-03-31", "2024-05-03"]],
+                }
+            ],
+        }
+    ]
+    session = _FakeSession([_FakeResponse(payload)])
+    fetcher = SimFinFundamentalsFetcher(
+        SimFinClientConfig(api_key="test-key", retry_sleep_seconds=0),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    page = fetcher.fetch_statement_rows(
+        tickers=["GOOG", "GOOGL"],
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+    )
+
+    assert session.calls[0]["params"]["ticker"] == "GOOG"
+    assert [row["ticker"] for row in page.rows] == ["GOOG", "GOOGL"]
+
+
+def test_fetch_statement_rows_maps_provider_rename_aliases_back_to_canonical_ticker() -> None:
+    """Vendor rename aliases are rewritten to the canonical archive ticker."""
+    payload = [
+        {
+            "ticker": "FLT",
+            "currency": "USD",
+            "statements": [
+                {
+                    "statement": "PL",
+                    "columns": ["Fiscal Period", "Fiscal Year", "Report Date", "Publish Date"],
+                    "data": [["Q1", 2024, "2024-03-31", "2024-05-03"]],
+                }
+            ],
+        }
+    ]
+    session = _FakeSession([_FakeResponse(payload)])
+    fetcher = SimFinFundamentalsFetcher(
+        SimFinClientConfig(api_key="test-key", retry_sleep_seconds=0),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    page = fetcher.fetch_statement_rows(
+        tickers=["CPAY"],
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+    )
+
+    assert session.calls[0]["params"]["ticker"] == "FLT"
+    assert [row["ticker"] for row in page.rows] == ["CPAY"]
+
+
 def test_normalize_accepts_missing_optional_fields() -> None:
     """Optional earnings/currency metadata can be absent without losing raw data."""
     retrieved_at = datetime(2024, 5, 4, tzinfo=UTC)
@@ -595,6 +657,26 @@ def test_backfill_is_idempotent_for_existing_archive() -> None:
     assert result.written == 0
     assert result.skipped == 1
     assert fetcher.calls == []
+
+
+def test_backfill_skips_writing_new_empty_archives() -> None:
+    """A zero-row SimFin fetch does not create a brand-new empty parquet placeholder."""
+    writer = _FakeWriter()
+    fetcher = _FakeFetcher([])
+
+    result = backfill_simfin_archive(
+        from_date=date(2024, 1, 1),
+        to_date=date(2024, 12, 31),
+        fetcher=fetcher,
+        writer=writer,
+        tickers=["AAPL"],
+        serializer=_json_serializer,
+    )
+
+    assert result.written == 0
+    assert result.empty == 1
+    assert result.missing_tickers == ("AAPL",)
+    assert writer.objects == {}
 
 
 def test_diagnose_fundamentals_coverage_tags_active_and_delisted_gaps() -> None:


### PR DESCRIPTION
## What this PR does
Preserves the safe Codex recovery work from #147: SimFin request aliases are rewritten back to canonical archive tickers for safe rename/share-class recoveries, and Layer 0/backfill no longer writes brand-new empty `raw/fundamentals/{ticker}.parquet` placeholders when SimFin returns zero rows. This recovered 10 of the 17 latest-date fundamentals blockers observed by #143, while documenting the remaining provider gaps separately.

## Closes
Refs #147 — does not close yet. #147 remains blocked on the 7 unresolved provider-gap tickers (`BF-B`, `BRK-B`, `GEV`, `SOLV`, `SW`, `TKO`, `VLTO`) unless a follow-up provider/source fix or explicit readiness exception is approved.

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input where applicable
- [x] No live API calls in unit tests — fixtures/mocks used

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [ ] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Operational evidence from the #143/#147 run:

- Pre-repair diagnostic report: `artifacts/reports/integration/simfin_coverage_gaps_min1.json`
- Targeted repair writes succeeded for:
  - `CPAY=133`, `FISV=133`, `FOXA=133`, `GOOGL=133`, `MRSH=133`, `NWSA=133`, `RVTY=133`, `SNDK=47`, `VEEV=129`, `XYZ=133`
- Latest Layer 0 validation remained `ready_for_layer1=false` because 7 provider-gap tickers still had insufficient/latest coverage.

## Notes for reviewer
This PR is intentionally a partial #147 recovery: it prevents new empty archive placeholders and supports safe SimFin alias recovery, but it does not introduce an exception policy or secondary fundamentals provider for the 7 residual names. Do not run full #143 Layer 1 readiness from this PR alone; #143 remains blocked until the residual provider gaps are resolved or explicitly waived.

Verification reported by Codex:
- `./.venv/bin/python -m ruff check services/r2/paths.py core/data/layer0_pipeline.py app/lab/data_pipelines/validate_layer0_archive.py app/lab/data_pipelines/backfill_layer0.py core/features/ tests/unit/`
- `./.venv/bin/pytest tests/unit/ -v --tb=short`
- Result: `522 passed`
