### PR TITLE
Add Layer 0 OHLCV adjustment provenance validation

### DIFF
--- a/app/lab/data_pipelines/validate_layer0_archive.py
+++ b/app/lab/data_pipelines/validate_layer0_archive.py
@@ -60,6 +60,8 @@ _EXPECTED_OHLCV_POLICIES = {
         "normalized_adj_close_policy": "copy_close_to_adj_close",
         "feed": "sip",
     },
+    # Deliberately omit `feed` here: daily runs may use IEX or SIP depending on deployment
+    # configuration, so validation only enforces the raw-bar policy that must hold everywhere.
     "daily_incremental": {
         "policy_id": "alpaca_live_1day_adjustment_raw",
         "provider": "alpaca",

--- a/app/lab/data_pipelines/validate_layer0_archive.py
+++ b/app/lab/data_pipelines/validate_layer0_archive.py
@@ -20,6 +20,7 @@ sys.path.insert(0, str(_REPO_ROOT))
 
 from services.r2.paths import (  # noqa: E402
     is_canonical_raw_price_key,
+    layer0_ohlcv_provenance_report_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_news_path,
@@ -50,6 +51,23 @@ DEFAULT_VALIDATION_FROM_DATE = "2017-01-01"
 DEFAULT_REPORT_DIR = Path("artifacts/reports/integration")
 DEFAULT_FUNDAMENTALS_MIN_ROWS = 1
 FundamentalsRowCounter = Callable[[ArchiveReader, str], int]
+_EXPECTED_OHLCV_POLICIES = {
+    "historical_backfill": {
+        "policy_id": "alpaca_historical_1day_adjustment_all",
+        "provider": "alpaca",
+        "request_adjustment": "all",
+        "stored_ohlc_basis": "provider_adjusted",
+        "normalized_adj_close_policy": "copy_close_to_adj_close",
+        "feed": "sip",
+    },
+    "daily_incremental": {
+        "policy_id": "alpaca_live_1day_adjustment_raw",
+        "provider": "alpaca",
+        "request_adjustment": "raw",
+        "stored_ohlc_basis": "raw",
+        "normalized_adj_close_policy": "copy_close_to_adj_close",
+    },
+}
 
 
 @dataclass(frozen=True)
@@ -71,6 +89,10 @@ class Layer0ArchiveValidationReport:
     fundamentals_tickers_below_min_rows: list[str]
     macro_day_count: int
     manifest_present: bool
+    ohlcv_provenance_report_present: bool
+    ohlcv_provenance_policy_id: str | None
+    ohlcv_provenance_validation_errors: list[str]
+    ohlcv_split_like_discontinuity_count: int
     missing_news_dates: list[str]
     noncanonical_price_keys: list[str]
     missing_universe_dates: list[str]
@@ -106,7 +128,9 @@ def validate_layer0_archive(
     missing_universe = [
         day.isoformat() for day in business_days if not reader.exists(raw_universe_path(day))
     ]
-    manifest_present = reader.exists(pipeline_manifest_path("layer0", run_id))
+    manifest_key = pipeline_manifest_path("layer0", run_id)
+    manifest_present = reader.exists(manifest_key)
+    manifest_payload = _read_json_object(reader, manifest_key) if manifest_present else None
     fundamentals_expected = 0
     fundamentals_present = len(fundamentals_keys)
     fundamentals_below_min: list[str] = []
@@ -124,10 +148,17 @@ def validate_layer0_archive(
             if counter(reader, key) < fundamentals_min_rows:
                 fundamentals_below_min.append(ticker)
 
+    provenance_report = _validate_ohlcv_provenance(
+        reader=reader,
+        run_id=run_id,
+        manifest_payload=manifest_payload,
+    )
+
     ready = bool(canonical_price_keys) and not noncanonical_price_keys
     ready = ready and not missing_news and not missing_universe
     ready = ready and bool(fundamentals_keys) and bool(macro_keys) and manifest_present
     ready = ready and not fundamentals_below_min
+    ready = ready and provenance_report.ready
 
     return Layer0ArchiveValidationReport(
         from_date=from_date.isoformat(),
@@ -145,6 +176,10 @@ def validate_layer0_archive(
         fundamentals_tickers_below_min_rows=fundamentals_below_min,
         macro_day_count=len(macro_keys),
         manifest_present=manifest_present,
+        ohlcv_provenance_report_present=provenance_report.report_present,
+        ohlcv_provenance_policy_id=provenance_report.policy_id,
+        ohlcv_provenance_validation_errors=provenance_report.errors,
+        ohlcv_split_like_discontinuity_count=provenance_report.split_like_discontinuity_count,
         missing_news_dates=missing_news,
         noncanonical_price_keys=noncanonical_price_keys,
         missing_universe_dates=missing_universe,
@@ -184,6 +219,134 @@ def _count_parquet_rows(reader: ArchiveReader, key: str) -> int:
         ) from exc
     frame = pd.read_parquet(BytesIO(payload))
     return int(len(frame.index))
+
+
+@dataclass(frozen=True)
+class _OhlcvProvenanceValidation:
+    """Result of validating Layer 0 OHLCV adjustment provenance artifacts."""
+
+    ready: bool
+    report_present: bool
+    policy_id: str | None
+    errors: list[str]
+    split_like_discontinuity_count: int
+
+
+def _validate_ohlcv_provenance(
+    *,
+    reader: ArchiveReader,
+    run_id: str,
+    manifest_payload: dict[str, object] | None,
+) -> _OhlcvProvenanceValidation:
+    """Validate manifest and report metadata for Layer 0 OHLCV adjustment provenance."""
+    if manifest_payload is None:
+        return _OhlcvProvenanceValidation(
+            ready=False,
+            report_present=False,
+            policy_id=None,
+            errors=["missing_manifest_payload"],
+            split_like_discontinuity_count=0,
+        )
+
+    errors: list[str] = []
+    metadata = manifest_payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return _OhlcvProvenanceValidation(
+            ready=False,
+            report_present=False,
+            policy_id=None,
+            errors=["manifest_missing_metadata"],
+            split_like_discontinuity_count=0,
+        )
+
+    mode = str(metadata.get("mode") or "").strip()
+    expected_policy = _EXPECTED_OHLCV_POLICIES.get(mode)
+    if expected_policy is None:
+        errors.append(f"unsupported_layer0_mode:{mode or 'missing'}")
+
+    prices_metadata = metadata.get("prices")
+    if not isinstance(prices_metadata, dict):
+        return _OhlcvProvenanceValidation(
+            ready=False,
+            report_present=False,
+            policy_id=None,
+            errors=errors + ["manifest_missing_prices_metadata"],
+            split_like_discontinuity_count=0,
+        )
+
+    provenance_metadata = prices_metadata.get("adjustment_provenance")
+    if not isinstance(provenance_metadata, dict):
+        errors.append("manifest_missing_adjustment_provenance")
+        provenance_metadata = {}
+
+    report_key = str(
+        prices_metadata.get("provenance_report_key") or layer0_ohlcv_provenance_report_path(run_id)
+    ).strip()
+    report_present = bool(report_key) and reader.exists(report_key)
+    if report_key != layer0_ohlcv_provenance_report_path(run_id):
+        errors.append("unexpected_provenance_report_key")
+    if not report_present:
+        errors.append("missing_provenance_report")
+        return _OhlcvProvenanceValidation(
+            ready=False,
+            report_present=False,
+            policy_id=str(provenance_metadata.get("policy_id") or "") or None,
+            errors=errors,
+            split_like_discontinuity_count=0,
+        )
+
+    report_payload = _read_json_object(reader, report_key)
+    report_provenance = (
+        report_payload.get("price_adjustment_provenance")
+        if isinstance(report_payload, dict)
+        else None
+    )
+    if not isinstance(report_provenance, dict):
+        errors.append("report_missing_price_adjustment_provenance")
+        report_provenance = {}
+
+    archive_summary = report_payload.get("archive_summary") if isinstance(report_payload, dict) else None
+    if not isinstance(archive_summary, dict):
+        errors.append("report_missing_archive_summary")
+        archive_summary = {}
+
+    policy_id = str(report_provenance.get("policy_id") or provenance_metadata.get("policy_id") or "")
+    split_like_discontinuity_count = int(archive_summary.get("split_like_discontinuity_count", 0))
+    if expected_policy is not None:
+        for field_name, expected_value in expected_policy.items():
+            manifest_value = provenance_metadata.get(field_name)
+            report_value = report_provenance.get(field_name)
+            if manifest_value != expected_value:
+                errors.append(f"manifest_{field_name}_expected_{expected_value}")
+            if report_value != expected_value:
+                errors.append(f"report_{field_name}_expected_{expected_value}")
+            if manifest_value != report_value:
+                errors.append(f"manifest_report_mismatch_{field_name}")
+
+    observed_rows = int(archive_summary.get("observed_rows", 0))
+    equal_rows = int(archive_summary.get("close_equals_adj_close_rows", 0))
+    different_rows = int(archive_summary.get("close_diff_adj_close_rows", 0))
+    if observed_rows != equal_rows + different_rows:
+        errors.append("archive_summary_row_counts_inconsistent")
+    if different_rows != 0:
+        errors.append("normalized_adj_close_policy_violated")
+
+    return _OhlcvProvenanceValidation(
+        ready=not errors,
+        report_present=True,
+        policy_id=policy_id or None,
+        errors=errors,
+        split_like_discontinuity_count=split_like_discontinuity_count,
+    )
+
+
+def _read_json_object(reader: ArchiveReader, key: str) -> dict[str, object]:
+    """Read and decode one JSON object payload from the archive."""
+    payload = reader.get_object(key)
+    parsed = json.loads(payload)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"Expected JSON object at {key}")
+    return dict(parsed)
 
 
 def _normalize_ticker(ticker: str) -> str:

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -393,13 +393,14 @@ def run_historical_layer0_backfill(
         )
         output_keys.extend(price_result.output_keys)
         metadata["prices"] = dict(price_result.metadata)
-        provenance_report_key = _write_ohlcv_provenance_report(
+        provenance_report_key, adjustment_provenance = _write_ohlcv_provenance_report(
             writer=cached_writer,
             run_id=run_id,
             mode="historical_backfill",
             price_metadata=metadata["prices"],
             fetcher=price_fetcher,
         )
+        metadata["prices"]["adjustment_provenance"] = adjustment_provenance
         metadata["prices"]["provenance_report_key"] = provenance_report_key
         output_keys.append(provenance_report_key)
         logger.info("Phase prices done: {}", price_result.metadata)
@@ -570,13 +571,14 @@ def run_daily_layer0_incremental(
         )
         output_keys.extend(price_result.output_keys)
         metadata["prices"] = dict(price_result.metadata)
-        provenance_report_key = _write_ohlcv_provenance_report(
+        provenance_report_key, adjustment_provenance = _write_ohlcv_provenance_report(
             writer=writer,
             run_id=run_id,
             mode="daily_incremental",
             price_metadata=metadata["prices"],
             fetcher=live_price_fetcher,
         )
+        metadata["prices"]["adjustment_provenance"] = adjustment_provenance
         metadata["prices"]["provenance_report_key"] = provenance_report_key
         output_keys.append(provenance_report_key)
 
@@ -1329,8 +1331,8 @@ def _write_ohlcv_provenance_report(
     mode: str,
     price_metadata: dict[str, object],
     fetcher: HistoricalPriceFetcher | LivePriceFetcher,
-) -> str:
-    """Persist an auditable Layer 0 OHLCV adjustment-provenance report for one run."""
+) -> tuple[str, dict[str, object]]:
+    """Persist one provenance report and return its key plus the manifest summary."""
     provenance = _price_adjustment_provenance(fetcher)
     report_key = layer0_ohlcv_provenance_report_path(run_id)
     archive_keys = list(_string_list(price_metadata.get("archive_keys")))
@@ -1361,7 +1363,7 @@ def _write_ohlcv_provenance_report(
         },
     }
     writer.put_object(report_key, json.dumps(report, indent=2, sort_keys=True))
-    price_metadata["adjustment_provenance"] = {
+    adjustment_provenance = {
         "policy_id": provenance["policy_id"],
         "provider": provenance["provider"],
         "feed": provenance["feed"],
@@ -1369,7 +1371,7 @@ def _write_ohlcv_provenance_report(
         "stored_ohlc_basis": provenance["stored_ohlc_basis"],
         "normalized_adj_close_policy": provenance["normalized_adj_close_policy"],
     }
-    return report_key
+    return report_key, adjustment_provenance
 
 
 def _write_pipeline_manifest(

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -22,6 +22,7 @@ from core.data.quality import (
 )
 from core.data.universe import build_universe_record
 from services.r2.paths import (
+    layer0_ohlcv_provenance_report_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_macro_path,
@@ -122,6 +123,13 @@ class LivePriceFetcher(Protocol):
         as_of_date: str,
     ) -> list[OHLCVRecord]:
         """Fetch current daily bars normalized to OHLCVRecord."""
+
+
+class PriceAdjustmentProvenanceProvider(Protocol):
+    """Price fetchers that can describe their corporate-action adjustment policy."""
+
+    def describe_adjustment_provenance(self) -> dict[str, object]:
+        """Return machine-readable adjustment provenance for downstream manifests/reports."""
 
 
 class NewsFetcher(Protocol):
@@ -299,6 +307,10 @@ class Layer0PipelineResult:
     metadata: dict[str, object]
 
 
+_SPLIT_LIKE_RATIO_THRESHOLD = 1.8
+_SPLIT_LIKE_SAMPLE_LIMIT = 20
+
+
 def run_historical_layer0_backfill(
     *,
     config: HistoricalLayer0Config,
@@ -380,7 +392,16 @@ def run_historical_layer0_backfill(
             skip_quality_reads=masks_complete,
         )
         output_keys.extend(price_result.output_keys)
-        metadata["prices"] = price_result.metadata
+        metadata["prices"] = dict(price_result.metadata)
+        provenance_report_key = _write_ohlcv_provenance_report(
+            writer=cached_writer,
+            run_id=run_id,
+            mode="historical_backfill",
+            price_metadata=metadata["prices"],
+            fetcher=price_fetcher,
+        )
+        metadata["prices"]["provenance_report_key"] = provenance_report_key
+        output_keys.append(provenance_report_key)
         logger.info("Phase prices done: {}", price_result.metadata)
 
         logger.info("Phase: fundamentals (SimFin)")
@@ -548,7 +569,16 @@ def run_daily_layer0_incremental(
             deserializer=price_deserializer or _parquet_bytes_to_records,
         )
         output_keys.extend(price_result.output_keys)
-        metadata["prices"] = price_result.metadata
+        metadata["prices"] = dict(price_result.metadata)
+        provenance_report_key = _write_ohlcv_provenance_report(
+            writer=writer,
+            run_id=run_id,
+            mode="daily_incremental",
+            price_metadata=metadata["prices"],
+            fetcher=live_price_fetcher,
+        )
+        metadata["prices"]["provenance_report_key"] = provenance_report_key
+        output_keys.append(provenance_report_key)
 
         quality_window = _copy_ohlcv_window(config.quality_ohlcv_window)
         _extend_quality_window_from_price_archives(
@@ -735,9 +765,14 @@ def _backfill_historical_prices(
     ]
     grouped = _group_securities_by_id(active_securities)
     output_keys: list[str] = []
+    archive_keys: list[str] = []
     written = 0
     skipped = 0
     empty = 0
+    observed_rows = 0
+    close_equals_adj_close_rows = 0
+    close_diff_adj_close_rows = 0
+    split_like_discontinuities: list[dict[str, object]] = []
 
     reference_key = raw_security_master_path(config.to_date)
     if not writer.exists(reference_key) or config.overwrite:
@@ -754,6 +789,7 @@ def _backfill_historical_prices(
 
     for security_id, security_rows in grouped.items():
         key = raw_price_path(security_id)
+        archive_keys.append(key)
         existing_records = (
             _canonicalize_ohlcv_records(_read_existing_records(writer, key, deserializer))
             if writer.exists(key)
@@ -789,6 +825,14 @@ def _backfill_historical_prices(
             empty += 1
             continue
 
+        observed_rows += len(records)
+        equality_counts = _adj_close_equality_counts(records)
+        close_equals_adj_close_rows += equality_counts["equal"]
+        close_diff_adj_close_rows += equality_counts["different"]
+        split_like_discontinuities.extend(
+            _detect_split_like_discontinuities(records, ticker=security_id)
+        )
+
         if history_changed:
             writer.put_object(key, serializer(_sort_ohlcv_records(records)))
             output_keys.append(key)
@@ -808,6 +852,14 @@ def _backfill_historical_prices(
             "empty": empty,
             "missing_tickers": list(missing_tickers),
             "reference_key": reference_key,
+            "archive_keys": archive_keys,
+            "observed_rows": observed_rows,
+            "close_equals_adj_close_rows": close_equals_adj_close_rows,
+            "close_diff_adj_close_rows": close_diff_adj_close_rows,
+            "split_like_discontinuity_count": len(split_like_discontinuities),
+            "split_like_discontinuity_samples": split_like_discontinuities[
+                :_SPLIT_LIKE_SAMPLE_LIMIT
+            ],
             "output_keys": output_keys,
         },
     )
@@ -883,14 +935,28 @@ def _write_daily_prices(
         grouped.setdefault(record.ticker.upper(), []).append(record)
 
     output_keys: list[str] = []
+    archive_keys: list[str] = []
     written = 0
     skipped = 0
+    observed_rows = 0
+    close_equals_adj_close_rows = 0
+    close_diff_adj_close_rows = 0
+    split_like_discontinuities: list[dict[str, object]] = []
     for ticker, ticker_records in sorted(grouped.items()):
         key = raw_price_path(ticker)
+        archive_keys.append(key)
         if not writer.exists(key):
-            writer.put_object(key, serializer(_sort_ohlcv_records(ticker_records)))
+            sorted_records = _sort_ohlcv_records(ticker_records)
+            writer.put_object(key, serializer(sorted_records))
             output_keys.append(key)
             written += 1
+            observed_rows += len(sorted_records)
+            equality_counts = _adj_close_equality_counts(sorted_records)
+            close_equals_adj_close_rows += equality_counts["equal"]
+            close_diff_adj_close_rows += equality_counts["different"]
+            split_like_discontinuities.extend(
+                _detect_split_like_discontinuities(sorted_records, ticker=ticker)
+            )
             continue
 
         existing_records = _canonicalize_ohlcv_records(
@@ -902,10 +968,24 @@ def _write_daily_prices(
         )
         if _ohlcv_histories_equal(existing_records, merged_records):
             skipped += 1
+            observed_rows += len(existing_records)
+            equality_counts = _adj_close_equality_counts(existing_records)
+            close_equals_adj_close_rows += equality_counts["equal"]
+            close_diff_adj_close_rows += equality_counts["different"]
+            split_like_discontinuities.extend(
+                _detect_split_like_discontinuities(existing_records, ticker=ticker)
+            )
             continue
         writer.put_object(key, serializer(_sort_ohlcv_records(merged_records)))
         output_keys.append(key)
         written += 1
+        observed_rows += len(merged_records)
+        equality_counts = _adj_close_equality_counts(merged_records)
+        close_equals_adj_close_rows += equality_counts["equal"]
+        close_diff_adj_close_rows += equality_counts["different"]
+        split_like_discontinuities.extend(
+            _detect_split_like_discontinuities(merged_records, ticker=ticker)
+        )
 
     return _WriteResult(
         output_keys=output_keys,
@@ -914,6 +994,14 @@ def _write_daily_prices(
             "written": written,
             "skipped": skipped,
             "empty": 0 if records else 1,
+            "archive_keys": archive_keys,
+            "observed_rows": observed_rows,
+            "close_equals_adj_close_rows": close_equals_adj_close_rows,
+            "close_diff_adj_close_rows": close_diff_adj_close_rows,
+            "split_like_discontinuity_count": len(split_like_discontinuities),
+            "split_like_discontinuity_samples": split_like_discontinuities[
+                :_SPLIT_LIKE_SAMPLE_LIMIT
+            ],
             "output_keys": output_keys,
         },
     )
@@ -1234,6 +1322,56 @@ def _write_daily_macro_snapshot(
     )
 
 
+def _write_ohlcv_provenance_report(
+    *,
+    writer: ObjectWriter,
+    run_id: str,
+    mode: str,
+    price_metadata: dict[str, object],
+    fetcher: HistoricalPriceFetcher | LivePriceFetcher,
+) -> str:
+    """Persist an auditable Layer 0 OHLCV adjustment-provenance report for one run."""
+    provenance = _price_adjustment_provenance(fetcher)
+    report_key = layer0_ohlcv_provenance_report_path(run_id)
+    archive_keys = list(_string_list(price_metadata.get("archive_keys")))
+    written_keys = [
+        key for key in _string_list(price_metadata.get("output_keys")) if key in set(archive_keys)
+    ]
+    report = {
+        "run_id": run_id,
+        "mode": mode,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "price_adjustment_provenance": provenance,
+        "archive_summary": {
+            "archive_keys": archive_keys,
+            "written_keys": written_keys,
+            "observed_rows": int(price_metadata.get("observed_rows", 0)),
+            "close_equals_adj_close_rows": int(
+                price_metadata.get("close_equals_adj_close_rows", 0)
+            ),
+            "close_diff_adj_close_rows": int(
+                price_metadata.get("close_diff_adj_close_rows", 0)
+            ),
+            "split_like_discontinuity_count": int(
+                price_metadata.get("split_like_discontinuity_count", 0)
+            ),
+            "split_like_discontinuity_samples": list(
+                _mapping_list(price_metadata.get("split_like_discontinuity_samples"))
+            ),
+        },
+    }
+    writer.put_object(report_key, json.dumps(report, indent=2, sort_keys=True))
+    price_metadata["adjustment_provenance"] = {
+        "policy_id": provenance["policy_id"],
+        "provider": provenance["provider"],
+        "feed": provenance["feed"],
+        "request_adjustment": provenance["request_adjustment"],
+        "stored_ohlc_basis": provenance["stored_ohlc_basis"],
+        "normalized_adj_close_policy": provenance["normalized_adj_close_policy"],
+    }
+    return report_key
+
+
 def _write_pipeline_manifest(
     *,
     writer: ObjectWriter,
@@ -1283,6 +1421,22 @@ def _write_failure_manifest(
 
 def _sanitize_error_message(message: str) -> str:
     return SENSITIVE_ERROR_PATTERN.sub(r"\g<prefix><redacted>", message)
+
+
+def _price_adjustment_provenance(
+    fetcher: HistoricalPriceFetcher | LivePriceFetcher,
+) -> dict[str, object]:
+    """Return machine-readable OHLCV adjustment provenance for a price fetcher."""
+    describe = getattr(fetcher, "describe_adjustment_provenance", None)
+    if callable(describe):
+        provenance = describe()
+        if not isinstance(provenance, Mapping):
+            raise TypeError("describe_adjustment_provenance() must return a mapping")
+        return dict(provenance)
+    raise TypeError(
+        f"{type(fetcher).__name__} must implement describe_adjustment_provenance() "
+        "for Layer 0 OHLCV provenance tracking"
+    )
 
 
 def _base_metadata(
@@ -1872,6 +2026,59 @@ def _positive_finite_ratio(
     if candidate != candidate or candidate in {float("inf"), float("-inf")}:
         return None
     return candidate
+
+
+def _adj_close_equality_counts(records: Sequence[OHLCVRecord]) -> dict[str, int]:
+    """Count rows whose normalized adj_close matches or differs from close."""
+    equal = 0
+    different = 0
+    for record in records:
+        if abs(record.close - record.adj_close) <= 1e-9:
+            equal += 1
+        else:
+            different += 1
+    return {"equal": equal, "different": different}
+
+
+def _detect_split_like_discontinuities(
+    records: Sequence[OHLCVRecord],
+    *,
+    ticker: str,
+) -> list[dict[str, object]]:
+    """Flag large adjacent close-ratio jumps for audit-only corporate-action review."""
+    sorted_records = _sort_ohlcv_records(records)
+    discontinuities: list[dict[str, object]] = []
+    for previous, current in zip(sorted_records, sorted_records[1:], strict=False):
+        prior_close = previous.adj_close
+        current_close = current.adj_close
+        if prior_close <= 0.0 or current_close <= 0.0:
+            continue
+        ratio = max(current_close / prior_close, prior_close / current_close)
+        if ratio < _SPLIT_LIKE_RATIO_THRESHOLD:
+            continue
+        discontinuities.append(
+            {
+                "ticker": ticker,
+                "previous_date": previous.date,
+                "current_date": current.date,
+                "price_ratio": round(ratio, 6),
+            }
+        )
+    return discontinuities
+
+
+def _string_list(value: object) -> tuple[str, ...]:
+    """Return only string values from a generic list-like object."""
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(item for item in value if isinstance(item, str))
+
+
+def _mapping_list(value: object) -> tuple[dict[str, object], ...]:
+    """Return dictionary items from a generic list-like object."""
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        return ()
+    return tuple(dict(item) for item in value if isinstance(item, Mapping))
 
 
 def _validate_date_window(from_date: date, to_date: date) -> None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,6 +160,17 @@ used for the live daily bar snapshot that the Pi needs near the close or before 
 Historical and live Alpaca bars must both normalize into the same `OHLCVRecord` shape before
 being written to the raw store.
 
+Adjustment policy and limitation:
+- historical Layer 0 backfills request Alpaca daily bars with `feed=sip` and
+  `adjustment=all`, so stored OHLC values reflect Alpaca's split/dividend-adjusted response
+- daily incremental Layer 0 runs request Alpaca daily bars with `adjustment=raw`, so the
+  run-date OHLC values reflect the live raw snapshot rather than a later retroactive rewrite
+- `OHLCVRecord.adj_close` currently mirrors the normalized `close` in both flows because the
+  Alpaca daily-bar payload does not provide a second adjusted-close field for the contract
+- Layer 0 therefore persists explicit adjustment provenance per run in the manifest metadata
+  plus `artifacts/reports/integration/layer0_ohlcv_provenance_{run_id}.json` so downstream
+  validation can audit which policy produced each archive update
+
 ---
 
 ## Storage model
@@ -194,6 +205,7 @@ r2/
     bundles/          # Packaged model bundles
     diagnostics/      # SHAP plots, metrics JSON
     manifests/        # ArtifactManifestRecord JSON files
+    reports/          # Validation and adjustment-provenance reports
   reports/
     daily/            # Daily execution summaries
     backtests/        # Backtest result JSON and equity curves
@@ -215,6 +227,7 @@ Any artifact that must survive a Pi restart or be accessed by Modal must be writ
 | Data type | Format | Reason |
 |---|---|---|
 | OHLCV history | Parquet (per ticker) | 10–50x faster than CSV; columnar reads; `pd.read_parquet()` |
+| OHLCV adjustment provenance | JSON report per Layer 0 run | Auditable request policy for `adjustment=all` vs `adjustment=raw`, plus continuity audit samples |
 | Feature tables | Parquet (per ticker history) | Keeps Layer 1 artifacts aligned to the FeatureRecord contract while reducing object count |
 | Model scores | Parquet | Small, fast to read |
 | News raw archive | JSON Lines | One article per line; easy to stream |

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -107,7 +107,33 @@ Implementation notes:
 - missing price fields fail fast; non-finite values are rejected
 - OHLC price relationships are validated before record construction: `high >= low`, `open in [low, high]`, `close in [low, high]`
 - volume must be non-negative integer; dollar_volume must be non-negative float
+- historical Alpaca backfills request `adjustment=all`; daily incremental Alpaca bars request
+  `adjustment=raw`
+- `OHLCVRecord.adj_close` currently mirrors the normalized `close` for both flows because the
+  Alpaca daily-bar payload does not expose a second adjusted-close field to store separately
+- the contract therefore does not by itself encode whether a stored row came from raw or
+  provider-adjusted OHLC; Layer 0 persists that provenance in the run manifest metadata and
+  in `artifacts/reports/integration/layer0_ohlcv_provenance_{run_id}.json`
 
+### Layer 0 OHLCV adjustment provenance report (non-contract artifact)
+
+Purpose:
+- make the historical-vs-live Alpaca adjustment policy explicit and auditable
+- let Layer 0 validation fail closed when the expected price-adjustment policy was not
+  recorded for a run
+- surface audit-only split-like continuity jumps without pretending the system stores a full
+  corporate-actions ledger
+
+Notes:
+- stored as JSON under `artifacts/reports/integration/layer0_ohlcv_provenance_{run_id}.json`
+- manifest metadata for `stage=layer0` includes the compact `prices.adjustment_provenance`
+  summary plus the `prices.provenance_report_key`
+- this artifact records the request policy (`adjustment=all` vs `adjustment=raw`), feed,
+  normalized `adj_close` behavior, archive counts, and heuristic split-like discontinuity
+  samples
+- it does not replace a dedicated splits/dividends archive; if later work needs exact
+  corporate-action event history or raw-vs-adjusted dual pricing, that remains a separate
+  design decision
 ### Layer 0 raw news archive (non-contract artifact)
 
 Purpose:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -47,8 +47,13 @@ Expected execution chain:
 1. Build and validate the complete Layer 0 historical backfill in R2:
    Wikipedia universe, Alpaca delayed SIP OHLCV, Alpaca news,
    SimFin fundamentals/earnings, and FRED macro/rates
+   - historical OHLCV provenance must record `feed=sip` and `adjustment=all`
+     in the Layer 0 manifest metadata plus
+     `artifacts/reports/integration/layer0_ohlcv_provenance_{run_id}.json`
 2. Validate the Layer 0 daily incremental path:
    Alpaca live bars/news, SimFin refreshes, FRED refreshes, universe masks, and manifests
+   - daily OHLCV provenance must record `adjustment=raw`; the run-date bar is stored as a
+     raw snapshot and is not retroactively rewritten in-place during the same run
 3. Validate the Pi -> Modal Layer 1 handoff:
    Pi submits the daily Modal job, then blocks on the R2 Layer 1 manifest
 4. Build Layer 1 features strictly from existing R2 Layer 0 archives
@@ -213,6 +218,16 @@ Operational notes for the readiness report:
 - The report records the authoritative manifest key/status plus sibling stale `running`
   manifests so operators can distinguish the successful run from interrupted attempts such as
   `...-v4` or `...-v6`.
+
+Operational notes for Layer 0 OHLCV provenance:
+- `python app/lab/data_pipelines/validate_layer0_archive.py ...` now fails closed when the
+  Layer 0 manifest omits the OHLCV adjustment provenance summary or when the companion
+  `artifacts/reports/integration/layer0_ohlcv_provenance_{run_id}.json` report is missing
+  or inconsistent
+- the provenance report is the authoritative audit record for whether a Layer 0 run wrote
+  Alpaca `adjustment=all` historical bars or `adjustment=raw` daily bars
+- split-like discontinuity samples in that report are heuristic audit context only; they are
+  not a substitute for a dedicated provider corporate-actions archive
 
 Baseline paper execution is long-only equities. Hedge and long-short capabilities must stay
 disabled by policy until the relevant risk and execution gates are implemented:

--- a/services/alpaca/market_data.py
+++ b/services/alpaca/market_data.py
@@ -197,6 +197,24 @@ class AlpacaMarketDataClient:
             raise last_error
         raise RuntimeError("Alpaca market-data request failed without an exception")
 
+    def describe_adjustment_provenance(self) -> dict[str, object]:
+        """Describe the corporate-action adjustment policy for live daily bars."""
+        return {
+            "policy_id": "alpaca_live_1day_adjustment_raw",
+            "provider": "alpaca",
+            "endpoint": ALPACA_STOCK_BARS_ENDPOINT,
+            "timeframe": "1Day",
+            "feed": _normalize_feed(self.config.feed),
+            "request_adjustment": "raw",
+            "stored_ohlc_basis": "raw",
+            "normalized_adj_close_policy": "copy_close_to_adj_close",
+            "corporate_actions_reflected": [],
+            "limitations": [
+                "Daily incremental bars preserve Alpaca's raw close for the run date and do not retroactively replay later split/dividend adjustments.",
+                "OHLCVRecord.adj_close mirrors the normalized close because Alpaca daily bars do not supply a second adjusted-close field.",
+            ],
+        }
+
 
 def normalize_alpaca_bar_response(
     payload: Mapping[str, Any],

--- a/services/alpaca/ohlcv_fetcher.py
+++ b/services/alpaca/ohlcv_fetcher.py
@@ -158,6 +158,24 @@ class AlpacaHistoricalOHLCVFetcher:
         """Fetch records for a resolved Alpaca ticker identity."""
         return self.fetch_records(ticker=security.ticker, from_date=from_date, to_date=to_date)
 
+    def describe_adjustment_provenance(self) -> dict[str, object]:
+        """Describe the corporate-action adjustment policy for historical bars."""
+        return {
+            "policy_id": "alpaca_historical_1day_adjustment_all",
+            "provider": "alpaca",
+            "endpoint": ALPACA_STOCK_BARS_ENDPOINT,
+            "timeframe": "1Day",
+            "feed": self.feed,
+            "request_adjustment": self.adjustment,
+            "stored_ohlc_basis": "provider_adjusted",
+            "normalized_adj_close_policy": "copy_close_to_adj_close",
+            "corporate_actions_reflected": ["splits", "dividends"],
+            "limitations": [
+                "Stored OHLC fields preserve Alpaca's adjustment=all response but do not persist a separate corporate-actions ledger.",
+                "OHLCVRecord.adj_close mirrors the normalized close because Alpaca daily bars do not supply a second adjusted-close field.",
+            ],
+        }
+
     def _request_json(self, params: Mapping[str, Any]) -> Any:
         """Request one Alpaca bars payload with bounded retries and provider throttling."""
         url = f"{self.config.base_url.rstrip('/')}{ALPACA_STOCK_BARS_ENDPOINT}"

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -179,6 +179,17 @@ def layer1_validation_report_path(run_id: str, from_date: str, to_date: str) -> 
     )
 
 
+def layer0_ohlcv_provenance_report_path(run_id: str) -> str:
+    """Return the canonical Layer 0 OHLCV adjustment-provenance report key for one run."""
+    safe_run_id = _validate_key_part(run_id)
+    return build_r2_key(
+        "artifacts",
+        "reports",
+        "integration",
+        f"layer0_ohlcv_provenance_{safe_run_id}.json",
+    )
+
+
 def layer1_label_path(as_of_date: str | Date | datetime, ticker: str) -> str:
     """Return the canonical Layer 1 label-shard Parquet path for one date/ticker pair."""
     safe_ticker = _validate_key_part(ticker)

--- a/tests/fixtures/layer0_ohlcv_support.py
+++ b/tests/fixtures/layer0_ohlcv_support.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from core.contracts.schemas import OHLCVRecord
+
+
+def historical_adjusted_provenance() -> dict[str, object]:
+    """Return the canonical historical Alpaca adjustment policy fixture."""
+    return {
+        "policy_id": "alpaca_historical_1day_adjustment_all",
+        "provider": "alpaca",
+        "endpoint": "/v2/stocks/bars",
+        "timeframe": "1Day",
+        "feed": "sip",
+        "request_adjustment": "all",
+        "stored_ohlc_basis": "provider_adjusted",
+        "normalized_adj_close_policy": "copy_close_to_adj_close",
+        "corporate_actions_reflected": ["splits", "dividends"],
+    }
+
+
+def daily_raw_provenance(*, feed: str = "iex") -> dict[str, object]:
+    """Return the canonical daily incremental Alpaca adjustment policy fixture."""
+    return {
+        "policy_id": "alpaca_live_1day_adjustment_raw",
+        "provider": "alpaca",
+        "endpoint": "/v2/stocks/bars",
+        "timeframe": "1Day",
+        "feed": feed,
+        "request_adjustment": "raw",
+        "stored_ohlc_basis": "raw",
+        "normalized_adj_close_policy": "copy_close_to_adj_close",
+        "corporate_actions_reflected": [],
+    }
+
+
+def build_provenance_report(
+    *,
+    run_id: str,
+    mode: str,
+    provenance: dict[str, object],
+    observed_rows: int,
+    split_like_discontinuity_count: int = 0,
+) -> dict[str, object]:
+    """Build a minimal Layer 0 OHLCV provenance report payload."""
+    return {
+        "run_id": run_id,
+        "mode": mode,
+        "generated_at": datetime.now(UTC).isoformat(),
+        "price_adjustment_provenance": provenance,
+        "archive_summary": {
+            "archive_keys": ["raw/prices/AAPL.parquet"],
+            "written_keys": ["raw/prices/AAPL.parquet"],
+            "observed_rows": observed_rows,
+            "close_equals_adj_close_rows": observed_rows,
+            "close_diff_adj_close_rows": 0,
+            "split_like_discontinuity_count": split_like_discontinuity_count,
+            "split_like_discontinuity_samples": (
+                [
+                    {
+                        "ticker": "AAPL",
+                        "previous_date": "2024-01-02",
+                        "current_date": "2024-01-03",
+                        "price_ratio": 2.0,
+                    }
+                ]
+                if split_like_discontinuity_count
+                else []
+            ),
+        },
+    }
+
+
+def build_split_like_history(ticker: str) -> list[OHLCVRecord]:
+    """Return a synthetic OHLCV history with one split-like adjacent close jump."""
+    return [
+        OHLCVRecord(
+            date="2024-01-02",
+            ticker=ticker,
+            open=100.0,
+            high=101.0,
+            low=99.0,
+            close=100.0,
+            volume=1000,
+            adj_close=100.0,
+            dollar_volume=100_000.0,
+        ),
+        OHLCVRecord(
+            date="2024-01-03",
+            ticker=ticker,
+            open=50.0,
+            high=51.0,
+            low=49.0,
+            close=50.0,
+            volume=1000,
+            adj_close=50.0,
+            dollar_volume=50_000.0,
+        ),
+    ]

--- a/tests/unit/test_alpaca_market_data.py
+++ b/tests/unit/test_alpaca_market_data.py
@@ -179,6 +179,26 @@ def test_fetch_live_daily_bars_rejects_empty_ticker_list() -> None:
         client.fetch_live_daily_bars(tickers=[], as_of_date="2024-01-02")
 
 
+def test_describe_adjustment_provenance_reports_live_policy() -> None:
+    """Live market-data client exposes the raw daily-bar adjustment policy explicitly."""
+    client = AlpacaMarketDataClient(
+        AlpacaMarketDataConfig(
+            api_key_id="test-key",
+            api_secret_key="test-secret",
+            feed="iex",
+        )
+    )
+
+    provenance = client.describe_adjustment_provenance()
+
+    assert provenance["policy_id"] == "alpaca_live_1day_adjustment_raw"
+    assert provenance["provider"] == "alpaca"
+    assert provenance["feed"] == "iex"
+    assert provenance["request_adjustment"] == "raw"
+    assert provenance["stored_ohlc_basis"] == "raw"
+    assert provenance["normalized_adj_close_policy"] == "copy_close_to_adj_close"
+
+
 def test_normalize_alpaca_bar_response_builds_schema_valid_records() -> None:
     """Alpaca bars normalize into OHLCVRecord rows compatible with Layer 0 storage."""
     records = normalize_alpaca_bar_response(

--- a/tests/unit/test_alpaca_ohlcv_fetcher.py
+++ b/tests/unit/test_alpaca_ohlcv_fetcher.py
@@ -187,3 +187,17 @@ def test_fetch_price_page_rejects_nan_values() -> None:
 
     with pytest.raises(ValueError, match="finite"):
         fetcher.fetch_price_page(ticker="AAPL", from_date="2024-01-02", to_date="2024-01-02")
+
+
+def test_describe_adjustment_provenance_reports_historical_policy() -> None:
+    """Historical fetcher exposes the stored Alpaca corporate-action policy explicitly."""
+    fetcher = _client(_FakeSession([]))
+
+    provenance = fetcher.describe_adjustment_provenance()
+
+    assert provenance["policy_id"] == "alpaca_historical_1day_adjustment_all"
+    assert provenance["provider"] == "alpaca"
+    assert provenance["feed"] == "sip"
+    assert provenance["request_adjustment"] == "all"
+    assert provenance["stored_ohlc_basis"] == "provider_adjusted"
+    assert provenance["normalized_adj_close_policy"] == "copy_close_to_adj_close"

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -19,6 +19,7 @@ from core.data.layer0_pipeline import (
 )
 from core.data.quality import QualityFilterConfig, SharesOutstandingSnapshot
 from services.r2.paths import (
+    layer0_ohlcv_provenance_report_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_macro_path,
@@ -26,6 +27,11 @@ from services.r2.paths import (
     raw_price_path,
     raw_security_master_path,
     raw_universe_path,
+)
+from tests.fixtures.layer0_ohlcv_support import (
+    build_split_like_history,
+    daily_raw_provenance,
+    historical_adjusted_provenance,
 )
 
 
@@ -101,6 +107,9 @@ class _HistoricalPriceFetcher:
         self.calls.append({"ticker": security.ticker, "from_date": from_date, "to_date": to_date})
         return [_bar(date_value=from_date, ticker=security.ticker)]
 
+    def describe_adjustment_provenance(self) -> dict[str, object]:
+        return historical_adjusted_provenance()
+
 
 class _LivePriceFetcher:
     def __init__(self, records: list[OHLCVRecord] | None = None) -> None:
@@ -114,6 +123,9 @@ class _LivePriceFetcher:
         if self.records is not None:
             return self.records
         return [_bar(date_value=as_of_date, ticker=ticker) for ticker in tickers]
+
+    def describe_adjustment_provenance(self) -> dict[str, object]:
+        return daily_raw_provenance()
 
 
 class _NewsFetcher:
@@ -371,6 +383,7 @@ def test_historical_layer0_backfill_writes_all_raw_archives_and_manifest() -> No
         raw_price_path("perm-aapl"),
         raw_price_path("perm-msft"),
         raw_price_path("perm-spy"),
+        layer0_ohlcv_provenance_report_path(run_id),
         raw_universe_path("2024-01-02"),
         raw_universe_path("2024-01-03"),
         raw_news_path("2024-01-02"),
@@ -392,6 +405,17 @@ def test_historical_layer0_backfill_writes_all_raw_archives_and_manifest() -> No
         "macro",
         "manifest",
     }
+    assert manifest["metadata"]["prices"]["adjustment_provenance"] == {
+        "policy_id": "alpaca_historical_1day_adjustment_all",
+        "provider": "alpaca",
+        "feed": "sip",
+        "request_adjustment": "all",
+        "stored_ohlc_basis": "provider_adjusted",
+        "normalized_adj_close_policy": "copy_close_to_adj_close",
+    }
+    provenance_report = json.loads(writer.objects[layer0_ohlcv_provenance_report_path(run_id)])
+    assert provenance_report["price_adjustment_provenance"]["feed"] == "sip"
+    assert provenance_report["archive_summary"]["close_diff_adj_close_rows"] == 0
 
     universe_rows = list(
         csv.DictReader(io.StringIO(writer.objects[raw_universe_path("2024-01-02")].decode()))
@@ -486,12 +510,20 @@ def test_daily_layer0_incremental_uses_alpaca_shape_and_canonical_paths() -> Non
     assert raw_fundamentals_path("AAPL") in writer.objects
     assert raw_macro_path("2024-01-02") in writer.objects
     assert raw_universe_path("2024-01-02") in writer.objects
+    assert layer0_ohlcv_provenance_report_path(run_id) in writer.objects
     assert pipeline_manifest_path("layer0", run_id) in writer.objects
     assert result.status == RunStatus.COMPLETED
 
     price_payload = json.loads(writer.objects[raw_price_path("AAPL")])
     assert price_payload[0]["ticker"] == "AAPL"
     assert price_payload[0]["date"] == "2024-01-02"
+    manifest = _manifest(writer, run_id)
+    assert manifest["metadata"]["prices"]["adjustment_provenance"]["policy_id"] == (
+        "alpaca_live_1day_adjustment_raw"
+    )
+    provenance_report = json.loads(writer.objects[layer0_ohlcv_provenance_report_path(run_id)])
+    assert provenance_report["price_adjustment_provenance"]["request_adjustment"] == "raw"
+    assert provenance_report["archive_summary"]["close_diff_adj_close_rows"] == 0
 
 
 def test_daily_layer0_incremental_writes_run_date_macro_snapshot() -> None:
@@ -913,7 +945,57 @@ def test_daily_layer0_incremental_is_idempotent_for_existing_raw_outputs() -> No
     )
 
     assert {key: writer.put_counts[key] for key in keys} == {key: 0 for key in keys}
+    assert writer.put_counts[layer0_ohlcv_provenance_report_path("test-idempotent")] == 1
     assert writer.objects[pipeline_manifest_path("layer0", "test-idempotent")]
+
+
+def test_historical_layer0_backfill_reports_split_like_discontinuities_for_audit() -> None:
+    """Provenance reports surface split-like price jumps as audit-only context."""
+    writer = _Writer()
+
+    class _SplitLikeHistoricalPriceFetcher(_HistoricalPriceFetcher):
+        def fetch_security_records(
+            self,
+            security: _Security,
+            from_date: str,
+            to_date: str,
+        ) -> list[OHLCVRecord]:
+            self.calls.append(
+                {"ticker": security.ticker, "from_date": from_date, "to_date": to_date}
+            )
+            return build_split_like_history(security.ticker)
+
+    run_historical_layer0_backfill(
+        config=HistoricalLayer0Config(
+            from_date=date(2024, 1, 2),
+            to_date=date(2024, 1, 3),
+            fred_series_ids=("DGS10",),
+            run_id="test-split-like-audit",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        universe_provider=_UniverseProvider(),
+        price_fetcher=_SplitLikeHistoricalPriceFetcher(),
+        security_master=_SecurityMaster(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=_FundamentalsFetcher(),
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        price_deserializer=_bytes_deserializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        macro_serializer=_bytes_serializer,
+    )
+
+    provenance_report = json.loads(
+        writer.objects[layer0_ohlcv_provenance_report_path("test-split-like-audit")]
+    )
+    assert provenance_report["archive_summary"]["split_like_discontinuity_count"] >= 1
+    assert provenance_report["archive_summary"]["split_like_discontinuity_samples"][0]["ticker"] in {
+        "perm-aapl",
+        "perm-msft",
+        "perm-spy",
+    }
 
 
 def test_daily_layer0_incremental_skips_new_empty_fundamentals_archives() -> None:

--- a/tests/unit/test_r2_paths.py
+++ b/tests/unit/test_r2_paths.py
@@ -8,6 +8,7 @@ from services.r2.paths import (
     build_r2_key,
     is_canonical_raw_price_key,
     is_legacy_raw_price_key,
+    layer0_ohlcv_provenance_report_path,
     layer1_feature_path,
     layer1_news_preprocessing_path,
     layer1_regime_path,
@@ -99,6 +100,10 @@ def test_layer1_text_artifact_paths_return_canonical_keys() -> None:
         == "features/layer1/sentiment_features/2025-01-02/run-001.parquet"
     )
     assert layer1_regime_path("run-001") == "features/layer1_5/regime/run-001.parquet"
+    assert (
+        layer0_ohlcv_provenance_report_path("run-001")
+        == "artifacts/reports/integration/layer0_ohlcv_provenance_run-001.json"
+    )
     assert (
         layer1_validation_report_path("run-001", "2025-01-02", "2025-01-03")
         == "artifacts/reports/integration/"

--- a/tests/unit/test_validate_layer0_archive.py
+++ b/tests/unit/test_validate_layer0_archive.py
@@ -74,6 +74,41 @@ def _historical_manifest_objects(run_id: str) -> dict[str, bytes]:
     }
 
 
+def _daily_manifest_objects(run_id: str, *, feed: str) -> dict[str, bytes]:
+    report_key = layer0_ohlcv_provenance_report_path(run_id)
+    return {
+        pipeline_manifest_path("layer0", run_id): json.dumps(
+            {
+                "run_id": run_id,
+                "stage": "layer0",
+                "status": "completed",
+                "metadata": {
+                    "mode": "daily_incremental",
+                    "prices": {
+                        "adjustment_provenance": {
+                            "policy_id": "alpaca_live_1day_adjustment_raw",
+                            "provider": "alpaca",
+                            "request_adjustment": "raw",
+                            "stored_ohlc_basis": "raw",
+                            "normalized_adj_close_policy": "copy_close_to_adj_close",
+                            "feed": feed,
+                        },
+                        "provenance_report_key": report_key,
+                    },
+                },
+            }
+        ).encode("utf-8"),
+        report_key: json.dumps(
+            build_provenance_report(
+                run_id=run_id,
+                mode="daily_incremental",
+                provenance=daily_raw_provenance(feed=feed),
+                observed_rows=2,
+            )
+        ).encode("utf-8"),
+    }
+
+
 def test_validate_layer0_archive_reports_ready_when_required_keys_exist() -> None:
     """Validation is ready when all required archive families and manifest exist."""
     from_date = date(2024, 1, 1)
@@ -266,6 +301,33 @@ def test_validate_layer0_archive_blocks_missing_or_mismatched_ohlcv_provenance()
         report.ohlcv_provenance_validation_errors
     )
     assert "report_request_adjustment_expected_all" in report.ohlcv_provenance_validation_errors
+
+
+def test_validate_layer0_archive_accepts_valid_daily_incremental_manifest() -> None:
+    """Validation accepts daily incremental provenance without enforcing one live feed."""
+    run_id = "layer0-daily-2024-01-02"
+    objects = _daily_manifest_objects(run_id, feed="sip")
+    keys = {
+        raw_price_path("AAPL"),
+        raw_news_path("2024-01-02"),
+        raw_universe_path("2024-01-02"),
+        raw_fundamentals_path("AAPL"),
+        raw_macro_path("2024-01-02"),
+        pipeline_manifest_path("layer0", run_id),
+        layer0_ohlcv_provenance_report_path(run_id),
+    }
+
+    report = validate_layer0_archive(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 2),
+        run_id=run_id,
+        reader=_Reader(keys, objects),
+    )
+
+    assert report.ready_for_layer1 is True
+    assert report.ohlcv_provenance_report_present is True
+    assert report.ohlcv_provenance_policy_id == "alpaca_live_1day_adjustment_raw"
+    assert report.ohlcv_provenance_validation_errors == []
 
 
 def test_validate_layer0_archive_surfaces_split_like_discontinuity_count() -> None:

--- a/tests/unit/test_validate_layer0_archive.py
+++ b/tests/unit/test_validate_layer0_archive.py
@@ -9,6 +9,7 @@ from app.lab.data_pipelines.validate_layer0_archive import (
     write_validation_report,
 )
 from services.r2.paths import (
+    layer0_ohlcv_provenance_report_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_macro_path,
@@ -16,11 +17,17 @@ from services.r2.paths import (
     raw_price_path,
     raw_universe_path,
 )
+from tests.fixtures.layer0_ohlcv_support import (
+    build_provenance_report,
+    daily_raw_provenance,
+    historical_adjusted_provenance,
+)
 
 
 class _Reader:
-    def __init__(self, keys: set[str]) -> None:
+    def __init__(self, keys: set[str], objects: dict[str, bytes] | None = None) -> None:
         self.keys = keys
+        self.objects = objects or {}
 
     def exists(self, key: str) -> bool:
         return key in self.keys
@@ -28,12 +35,51 @@ class _Reader:
     def list_keys(self, prefix: str) -> list[str]:
         return sorted(key for key in self.keys if key.startswith(prefix))
 
+    def get_object(self, key: str) -> bytes:
+        return self.objects[key]
+
+
+def _historical_manifest_objects(run_id: str) -> dict[str, bytes]:
+    report_key = layer0_ohlcv_provenance_report_path(run_id)
+    return {
+        pipeline_manifest_path("layer0", run_id): json.dumps(
+            {
+                "run_id": run_id,
+                "stage": "layer0",
+                "status": "completed",
+                "metadata": {
+                    "mode": "historical_backfill",
+                    "prices": {
+                        "adjustment_provenance": {
+                            "policy_id": "alpaca_historical_1day_adjustment_all",
+                            "provider": "alpaca",
+                            "request_adjustment": "all",
+                            "stored_ohlc_basis": "provider_adjusted",
+                            "normalized_adj_close_policy": "copy_close_to_adj_close",
+                            "feed": "sip",
+                        },
+                        "provenance_report_key": report_key,
+                    },
+                },
+            }
+        ).encode("utf-8"),
+        report_key: json.dumps(
+            build_provenance_report(
+                run_id=run_id,
+                mode="historical_backfill",
+                provenance=historical_adjusted_provenance(),
+                observed_rows=3,
+            )
+        ).encode("utf-8"),
+    }
+
 
 def test_validate_layer0_archive_reports_ready_when_required_keys_exist() -> None:
     """Validation is ready when all required archive families and manifest exist."""
     from_date = date(2024, 1, 1)
     to_date = date(2024, 1, 3)
     run_id = "layer0-historical-2024-01-01_to_2024-01-03"
+    objects = _historical_manifest_objects(run_id)
     keys = {
         raw_price_path("AAPL"),
         raw_news_path("2024-01-01"),
@@ -45,13 +91,14 @@ def test_validate_layer0_archive_reports_ready_when_required_keys_exist() -> Non
         raw_fundamentals_path("AAPL"),
         raw_macro_path("2024-01-02"),
         pipeline_manifest_path("layer0", run_id),
+        layer0_ohlcv_provenance_report_path(run_id),
     }
 
     report = validate_layer0_archive(
         from_date=from_date,
         to_date=to_date,
         run_id=run_id,
-        reader=_Reader(keys),
+        reader=_Reader(keys, objects),
     )
 
     assert report.ready_for_layer1 is True
@@ -62,6 +109,9 @@ def test_validate_layer0_archive_reports_ready_when_required_keys_exist() -> Non
     assert report.fundamentals_ticker_count == 1
     assert report.macro_day_count == 1
     assert report.noncanonical_price_keys == []
+    assert report.ohlcv_provenance_report_present is True
+    assert report.ohlcv_provenance_policy_id == "alpaca_historical_1day_adjustment_all"
+    assert report.ohlcv_provenance_validation_errors == []
 
 
 def test_validate_layer0_archive_blocks_layer1_when_active_fundamentals_are_missing_or_empty() -> None:
@@ -69,6 +119,7 @@ def test_validate_layer0_archive_blocks_layer1_when_active_fundamentals_are_miss
     from_date = date(2024, 1, 1)
     to_date = date(2024, 1, 3)
     run_id = "layer0-historical-2024-01-01_to_2024-01-03"
+    objects = _historical_manifest_objects(run_id)
     keys = {
         raw_price_path("AAPL"),
         raw_news_path("2024-01-01"),
@@ -81,13 +132,14 @@ def test_validate_layer0_archive_blocks_layer1_when_active_fundamentals_are_miss
         raw_fundamentals_path("MSFT"),
         raw_macro_path("2024-01-02"),
         pipeline_manifest_path("layer0", run_id),
+        layer0_ohlcv_provenance_report_path(run_id),
     }
 
     report = validate_layer0_archive(
         from_date=from_date,
         to_date=to_date,
         run_id=run_id,
-        reader=_Reader(keys),
+        reader=_Reader(keys, objects),
         active_fundamentals_tickers=["AAPL", "MSFT", "GOOGL"],
         fundamentals_min_rows=1,
         fundamentals_row_counter=lambda _reader, key: {
@@ -119,6 +171,7 @@ def test_validate_layer0_archive_reports_missing_dates() -> None:
         "2024-01-08",
     ]
     assert report.missing_universe_dates == ["2024-01-05", "2024-01-08"]
+    assert "missing_manifest_payload" in report.ohlcv_provenance_validation_errors
 
 
 def test_validate_layer0_archive_blocks_noncanonical_price_keys() -> None:
@@ -126,6 +179,7 @@ def test_validate_layer0_archive_blocks_noncanonical_price_keys() -> None:
     from_date = date(2024, 1, 1)
     to_date = date(2024, 1, 1)
     run_id = "layer0-historical-2024-01-01"
+    objects = _historical_manifest_objects(run_id)
     keys = {
         raw_price_path("AAPL"),
         "raw/prices/AAPL_2017-01-03_2024-01-01.parquet",
@@ -134,13 +188,14 @@ def test_validate_layer0_archive_blocks_noncanonical_price_keys() -> None:
         raw_fundamentals_path("AAPL"),
         raw_macro_path("2024-01-01"),
         pipeline_manifest_path("layer0", run_id),
+        layer0_ohlcv_provenance_report_path(run_id),
     }
 
     report = validate_layer0_archive(
         from_date=from_date,
         to_date=to_date,
         run_id=run_id,
-        reader=_Reader(keys),
+        reader=_Reader(keys, objects),
     )
 
     assert report.ready_for_layer1 is False
@@ -149,6 +204,103 @@ def test_validate_layer0_archive_blocks_noncanonical_price_keys() -> None:
     assert report.noncanonical_price_keys == [
         "raw/prices/AAPL_2017-01-03_2024-01-01.parquet"
     ]
+
+
+def test_validate_layer0_archive_blocks_missing_or_mismatched_ohlcv_provenance() -> None:
+    """Validation fails closed when Layer 0 omits OHLCV adjustment provenance."""
+    run_id = "layer0-historical-2024-01-02"
+    report_key = layer0_ohlcv_provenance_report_path(run_id)
+    manifest_key = pipeline_manifest_path("layer0", run_id)
+    objects = {
+        manifest_key: json.dumps(
+            {
+                "run_id": run_id,
+                "stage": "layer0",
+                "status": "completed",
+                "metadata": {
+                    "mode": "historical_backfill",
+                    "prices": {
+                        "adjustment_provenance": {
+                            "policy_id": "alpaca_live_1day_adjustment_raw",
+                            "provider": "alpaca",
+                            "request_adjustment": "raw",
+                            "stored_ohlc_basis": "raw",
+                            "normalized_adj_close_policy": "copy_close_to_adj_close",
+                            "feed": "iex",
+                        },
+                        "provenance_report_key": report_key,
+                    },
+                },
+            }
+        ).encode("utf-8"),
+        report_key: json.dumps(
+            build_provenance_report(
+                run_id=run_id,
+                mode="historical_backfill",
+                provenance=daily_raw_provenance(),
+                observed_rows=2,
+            )
+        ).encode("utf-8"),
+    }
+    keys = {
+        raw_price_path("AAPL"),
+        raw_news_path("2024-01-02"),
+        raw_universe_path("2024-01-02"),
+        raw_fundamentals_path("AAPL"),
+        raw_macro_path("2024-01-02"),
+        manifest_key,
+        report_key,
+    }
+
+    report = validate_layer0_archive(
+        from_date=date(2024, 1, 2),
+        to_date=date(2024, 1, 2),
+        run_id=run_id,
+        reader=_Reader(keys, objects),
+    )
+
+    assert report.ready_for_layer1 is False
+    assert report.ohlcv_provenance_report_present is True
+    assert report.ohlcv_provenance_policy_id == "alpaca_live_1day_adjustment_raw"
+    assert "manifest_policy_id_expected_alpaca_historical_1day_adjustment_all" in (
+        report.ohlcv_provenance_validation_errors
+    )
+    assert "report_request_adjustment_expected_all" in report.ohlcv_provenance_validation_errors
+
+
+def test_validate_layer0_archive_surfaces_split_like_discontinuity_count() -> None:
+    """Validation preserves split-like audit counts without treating them as policy failures."""
+    run_id = "layer0-historical-2024-01-03"
+    report_key = layer0_ohlcv_provenance_report_path(run_id)
+    objects = _historical_manifest_objects(run_id)
+    objects[report_key] = json.dumps(
+        build_provenance_report(
+            run_id=run_id,
+            mode="historical_backfill",
+            provenance=historical_adjusted_provenance(),
+            observed_rows=2,
+            split_like_discontinuity_count=1,
+        )
+    ).encode("utf-8")
+    keys = {
+        raw_price_path("AAPL"),
+        raw_news_path("2024-01-03"),
+        raw_universe_path("2024-01-03"),
+        raw_fundamentals_path("AAPL"),
+        raw_macro_path("2024-01-03"),
+        pipeline_manifest_path("layer0", run_id),
+        report_key,
+    }
+
+    report = validate_layer0_archive(
+        from_date=date(2024, 1, 3),
+        to_date=date(2024, 1, 3),
+        run_id=run_id,
+        reader=_Reader(keys, objects),
+    )
+
+    assert report.ready_for_layer1 is True
+    assert report.ohlcv_split_like_discontinuity_count == 1
 
 
 def test_write_validation_report_writes_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## What this PR does
Layer 0 now persists explicit OHLCV corporate-action adjustment provenance for every run instead of relying on implicit Alpaca request defaults. The pipeline writes a dedicated `layer0_ohlcv_provenance_{run_id}.json` artifact, records the compact policy summary in the Layer 0 manifest, and makes `validate_layer0_archive.py` fail closed when that provenance is missing or inconsistent. The report also includes audit-only split-like continuity samples so large adjustment-style jumps are visible without pretending the system already stores a full corporate-actions ledger.

## Closes
Closes #145

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [ ] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Not applicable.

## Notes for reviewer
- Commands run:
  - `./.venv/bin/pytest tests/unit/test_alpaca_ohlcv_fetcher.py tests/unit/test_alpaca_market_data.py tests/unit/test_r2_paths.py tests/unit/test_layer0_pipeline.py tests/unit/test_validate_layer0_archive.py -v --tb=short`
  - `./.venv/bin/pytest tests/unit/ -v --tb=short`
- Test result summary: `536 passed` in the full unit suite; focused Layer 0 provenance subset `76 passed`.
- Manifest key(s): `artifacts/manifests/layer0/{run_id}.json` now carry `metadata.prices.adjustment_provenance` plus `metadata.prices.provenance_report_key`.
- Report path(s): `artifacts/reports/integration/layer0_ohlcv_provenance_{run_id}.json`.
- R2 output prefix(es): `raw/prices/`, `artifacts/manifests/layer0/`, `artifacts/reports/integration/`.
- Known skipped/missing data: no integration/readiness tests were run in this PR; no live provider calls were required.