### PR TITLE
[Codex] Standardize FRED macro run-date snapshots

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -24,10 +24,10 @@
   `list_keys()` (paginated ListObjectsV2) for every existence check. Should add a
   `head_object`-based `exists()` to `CloudflareR2Client`. Affects all data families
   (prices, universe, news, fundamentals, macro) — thousands of slow calls per backfill run.
-- [ ] Macro archive layout still mixes legacy observation-date shards with run-date
-  readiness snapshots under `raw/macro/{YYYY-MM-DD}.parquet`. Issue `#148` should
-  consolidate the convention and document/migrate any backward-compatibility cleanup
-  needed across backfill, validation, and Layer 1 consumers.
+- [x] Macro archive layout no longer mixes observation-date-only shards with run-date
+  snapshots. Issue `#148` standardized `raw/macro/{YYYY-MM-DD}.parquet` as a run-date
+  point-in-time snapshot, added backward-compatible legacy recovery, and tightened
+  validation/Layer 1 macro loading around deterministic as-of-date reconstruction.
 - [ ] `_SHARES_OUTSTANDING_KEYS` in `core/data/layer0_pipeline.py` duplicates `_SHARES_KEYS`
   in `core/features/fundamentals_features.py`; consolidate SimFin share-key ownership before
   the next fundamentals or market-cap filter change.

--- a/app/lab/data_pipelines/backfill_fred.py
+++ b/app/lab/data_pipelines/backfill_fred.py
@@ -17,6 +17,10 @@ from loguru import logger
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(_REPO_ROOT))
 
+from core.data.macro_archive import (  # noqa: E402
+    build_latest_available_macro_snapshot,
+    macro_snapshot_is_usable,
+)
 from services.fred.macro_fetcher import (  # noqa: E402
     DEFAULT_FRED_CONFIG_PATH,
     DEFAULT_FRED_PAGE_LIMIT,
@@ -89,7 +93,7 @@ def backfill_fred_archive(
     serializer: MacroSerializer | None = None,
     deserializer: MacroDeserializer | None = None,
 ) -> BackfillResult:
-    """Backfill FRED macro/rate observations into R2, sharding per observation_date."""
+    """Backfill one point-in-time-safe raw macro snapshot per business day."""
     if from_date > to_date:
         raise ValueError("from_date must be <= to_date")
     if limit <= 0:
@@ -100,7 +104,13 @@ def backfill_fred_archive(
     if (
         not overwrite
         and not merge_existing
-        and _macro_archive_covers_range(writer, from_date, to_date)
+        and _macro_archive_covers_range(
+            writer,
+            from_date,
+            to_date,
+            series_ids=normalized_series_ids,
+            deserializer=deserializer,
+        )
     ):
         logger.info(
             "FRED macro archive already covers {}..{}; skipping provider fetch",
@@ -124,12 +134,7 @@ def backfill_fred_archive(
         realtime_end=to_date.isoformat(),
         limit=limit,
     )
-    rows_by_date: dict[str, list[dict[str, object]]] = {}
-    for row in rows:
-        observation_date = str(row.get("observation_date") or "").strip()
-        if not observation_date:
-            continue
-        rows_by_date.setdefault(observation_date, []).append(row)
+    ordered_rows = _sort_macro_observations(rows)
 
     payload_serializer = serializer or _macro_to_parquet_bytes
     payload_deserializer = deserializer or _macro_from_parquet_bytes
@@ -138,25 +143,36 @@ def backfill_fred_archive(
     skipped = 0
     total_rows = 0
     empty = 0
-    for observation_date in sorted(rows_by_date):
-        date_rows = _sort_macro_observations(rows_by_date[observation_date])
-        key = raw_macro_path(observation_date)
-        if writer.exists(key) and not overwrite and not merge_existing:
-            skipped += 1
-            continue
-        output_rows = date_rows
-        if writer.exists(key) and merge_existing and not overwrite:
+    for snapshot_day in _business_days(from_date, to_date):
+        snapshot_date = snapshot_day.isoformat()
+        date_rows = build_latest_available_macro_snapshot(
+            ordered_rows,
+            snapshot_date=snapshot_date,
+            series_ids=normalized_series_ids,
+        )
+        key = raw_macro_path(snapshot_date)
+        output_rows = list(date_rows)
+        if writer.exists(key) and not overwrite:
             existing_rows = payload_deserializer(writer.get_object(key))
-            if _rows_already_include_series(existing_rows, date_rows):
+            if macro_snapshot_is_usable(
+                existing_rows,
+                snapshot_date=snapshot_date,
+                required_series_ids=normalized_series_ids,
+            ):
                 skipped += 1
                 continue
-            output_rows = _merge_macro_observations(existing_rows, date_rows)
+            if merge_existing:
+                output_rows = build_latest_available_macro_snapshot(
+                    [*existing_rows, *date_rows],
+                    snapshot_date=snapshot_date,
+                )
+        if not output_rows:
+            empty += 1
+            continue
         writer.put_object(key, payload_serializer(output_rows))
         output_keys.append(key)
         written += 1
         total_rows += len(output_rows)
-        if not output_rows:
-            empty += 1
         if written % 100 == 0:
             logger.info("FRED macro backfill progress written={} skipped={}", written, skipped)
     logger.info(
@@ -332,18 +348,42 @@ def _resolve_to_date(value: str) -> date:
     return date.fromisoformat(value)
 
 
-def _macro_archive_covers_range(writer: ObjectWriter, from_date: date, to_date: date) -> bool:
-    """Return True when every business day in the range has a raw/macro/{date}.parquet key."""
-    expected: set[str] = set()
+def _macro_archive_covers_range(
+    writer: ObjectWriter,
+    from_date: date,
+    to_date: date,
+    *,
+    series_ids: Sequence[str] | None = None,
+    deserializer: MacroDeserializer | None = None,
+) -> bool:
+    """Return True when every business day already has a usable raw macro snapshot."""
+    business_days = _business_days(from_date, to_date)
+    if not business_days:
+        return False
+    payload_deserializer = deserializer or _macro_from_parquet_bytes
+    for day in business_days:
+        key = raw_macro_path(day.isoformat())
+        if not writer.exists(key):
+            return False
+        rows = payload_deserializer(writer.get_object(key))
+        if not macro_snapshot_is_usable(
+            rows,
+            snapshot_date=day.isoformat(),
+            required_series_ids=series_ids,
+        ):
+            return False
+    return True
+
+
+def _business_days(from_date: date, to_date: date) -> list[date]:
+    """Return every business day in the inclusive window."""
+    days: list[date] = []
     day = from_date
     while day <= to_date:
         if day.weekday() < 5:
-            expected.add(raw_macro_path(day.isoformat()))
+            days.append(day)
         day += timedelta(days=1)
-    if not expected:
-        return False
-    present = set(writer.list_keys("raw/macro/"))
-    return expected.issubset(present)
+    return days
 
 
 def _normalize_series_ids(series_ids: Sequence[str]) -> tuple[str, ...]:

--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -101,7 +101,6 @@ from services.r2.paths import (  # noqa: E402
     layer1_ticker_history_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
-    raw_macro_path,
     raw_news_path,
     raw_price_path,
     raw_universe_path,

--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -86,6 +86,7 @@ from core.features.io import (  # noqa: E402
     write_feature_records,
 )
 from core.features.loaders import (  # noqa: E402
+    available_macro_series_by_date,
     load_fundamentals_frame,
     load_macro_frame,
     load_ohlcv_frame,
@@ -367,6 +368,7 @@ def run_daily_layer1(
             scope_tickers=scope_tickers,
             benchmark_ticker=config.benchmark_ticker,
             universe_by_date=universe_by_date,
+            required_macro_series=_manifest_fred_series_ids(upstream_manifest),
         )
 
         news_results = _run_news_stage(
@@ -985,12 +987,12 @@ def _require_upstream_archives(
     scope_tickers: Sequence[str],
     benchmark_ticker: str,
     universe_by_date: Mapping[str, Sequence[str]],
+    required_macro_series: Sequence[str],
 ) -> None:
     """Require the Layer 0 archives needed by the daily Layer 1 run."""
     required_keys = [raw_price_path(benchmark_ticker)]
     required_keys.extend(raw_news_path(date_text) for date_text in processed_dates)
     required_keys.extend(raw_universe_path(date_text) for date_text in processed_dates)
-    required_keys.extend(raw_macro_path(date_text) for date_text in processed_dates)
     for ticker in scope_tickers:
         required_keys.append(raw_price_path(ticker))
         required_keys.append(raw_fundamentals_path(ticker))
@@ -1001,12 +1003,42 @@ def _require_upstream_archives(
             "Missing required Layer 0 archives for Layer 1 run: "
             + ", ".join(missing)
         )
+    macro_available = available_macro_series_by_date(
+        list(processed_dates),
+        writer=writer,  # type: ignore[arg-type]
+        series_ids=required_macro_series or None,
+    )
+    macro_missing = {
+        date_text: sorted(set(required_macro_series) - set(macro_available.get(date_text, [])))
+        for date_text in processed_dates
+        if set(required_macro_series) - set(macro_available.get(date_text, []))
+    }
+    if macro_missing:
+        raise FileNotFoundError(
+            "Missing recoverable raw macro coverage for Layer 1 run: "
+            + _format_ticker_dates(macro_missing)
+        )
     _require_target_date_price_coverage(
         writer,
         processed_dates=processed_dates,
         benchmark_ticker=benchmark_ticker,
         universe_by_date=universe_by_date,
     )
+
+
+def _manifest_fred_series_ids(manifest: PipelineManifestRecord) -> list[str]:
+    """Return normalized FRED series IDs recorded by the completed Layer 0 manifest."""
+    value = manifest.metadata.get("fred_series_ids")
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    for series_id in value:
+        if not isinstance(series_id, str):
+            continue
+        cleaned = series_id.strip().upper()
+        if cleaned:
+            normalized.append(cleaned)
+    return sorted(set(normalized))
 
 
 def _require_target_date_price_coverage(

--- a/app/lab/data_pipelines/validate_layer0_archive.py
+++ b/app/lab/data_pipelines/validate_layer0_archive.py
@@ -18,11 +18,13 @@ from loguru import logger
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(_REPO_ROOT))
 
+from core.features.loaders import available_macro_series_by_date  # noqa: E402
 from services.r2.paths import (  # noqa: E402
     is_canonical_raw_price_key,
     layer0_ohlcv_provenance_report_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
+    raw_macro_path,
     raw_news_path,
     raw_universe_path,
 )
@@ -90,6 +92,12 @@ class Layer0ArchiveValidationReport:
     fundamentals_min_rows: int
     fundamentals_tickers_below_min_rows: list[str]
     macro_day_count: int
+    macro_days_expected: int
+    macro_days_recoverable: int
+    macro_available_series_by_date: dict[str, list[str]]
+    macro_missing_series_by_date: dict[str, list[str]]
+    missing_macro_dates: list[str]
+    macro_recovered_from_legacy_dates: list[str]
     manifest_present: bool
     ohlcv_provenance_report_present: bool
     ohlcv_provenance_policy_id: str | None
@@ -133,6 +141,7 @@ def validate_layer0_archive(
     manifest_key = pipeline_manifest_path("layer0", run_id)
     manifest_present = reader.exists(manifest_key)
     manifest_payload = _read_json_object(reader, manifest_key) if manifest_present else None
+    requested_macro_series = _manifest_fred_series_ids(manifest_payload)
     fundamentals_expected = 0
     fundamentals_present = len(fundamentals_keys)
     fundamentals_below_min: list[str] = []
@@ -155,11 +164,36 @@ def validate_layer0_archive(
         run_id=run_id,
         manifest_payload=manifest_payload,
     )
+    macro_available_series_by_date = available_macro_series_by_date(
+        [day.isoformat() for day in business_days],
+        writer=reader,  # type: ignore[arg-type]
+        series_ids=requested_macro_series or None,
+    )
+    macro_missing_series_by_date: dict[str, list[str]] = {}
+    missing_macro_dates: list[str] = []
+    macro_recovered_from_legacy_dates: list[str] = []
+    requested_macro_series_set = set(requested_macro_series)
+    for day in business_days:
+        date_text = day.isoformat()
+        available_series = sorted(macro_available_series_by_date.get(date_text, []))
+        available_series_set = set(available_series)
+        if requested_macro_series_set:
+            missing_series = sorted(requested_macro_series_set - available_series_set)
+        else:
+            missing_series = []
+        macro_missing_series_by_date[date_text] = missing_series
+        if (requested_macro_series_set and missing_series) or (
+            not requested_macro_series_set and not available_series
+        ):
+            missing_macro_dates.append(date_text)
+        if not reader.exists(raw_macro_path(date_text)) and available_series:
+            macro_recovered_from_legacy_dates.append(date_text)
 
     ready = bool(canonical_price_keys) and not noncanonical_price_keys
     ready = ready and not missing_news and not missing_universe
     ready = ready and bool(fundamentals_keys) and bool(macro_keys) and manifest_present
     ready = ready and not fundamentals_below_min
+    ready = ready and not missing_macro_dates
     ready = ready and provenance_report.ready
 
     return Layer0ArchiveValidationReport(
@@ -177,6 +211,12 @@ def validate_layer0_archive(
         fundamentals_min_rows=fundamentals_min_rows,
         fundamentals_tickers_below_min_rows=fundamentals_below_min,
         macro_day_count=len(macro_keys),
+        macro_days_expected=len(business_days),
+        macro_days_recoverable=len(business_days) - len(missing_macro_dates),
+        macro_available_series_by_date=macro_available_series_by_date,
+        macro_missing_series_by_date=macro_missing_series_by_date,
+        missing_macro_dates=missing_macro_dates,
+        macro_recovered_from_legacy_dates=macro_recovered_from_legacy_dates,
         manifest_present=manifest_present,
         ohlcv_provenance_report_present=provenance_report.report_present,
         ohlcv_provenance_policy_id=provenance_report.policy_id,
@@ -221,6 +261,26 @@ def _count_parquet_rows(reader: ArchiveReader, key: str) -> int:
         ) from exc
     frame = pd.read_parquet(BytesIO(payload))
     return int(len(frame.index))
+
+
+def _manifest_fred_series_ids(manifest_payload: dict[str, object] | None) -> list[str]:
+    """Return normalized FRED series IDs declared in the Layer 0 manifest metadata."""
+    if not isinstance(manifest_payload, dict):
+        return []
+    metadata = manifest_payload.get("metadata")
+    if not isinstance(metadata, dict):
+        return []
+    value = metadata.get("fred_series_ids")
+    if not isinstance(value, list):
+        return []
+    normalized: list[str] = []
+    for series_id in value:
+        if not isinstance(series_id, str):
+            continue
+        cleaned = series_id.strip().upper()
+        if cleaned:
+            normalized.append(cleaned)
+    return sorted(set(normalized))
 
 
 @dataclass(frozen=True)

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -13,6 +13,10 @@ from typing import Protocol
 from loguru import logger
 
 from core.contracts.schemas import OHLCVRecord, PipelineManifestRecord, RunStatus, UniverseRecord
+from core.data.macro_archive import (
+    build_latest_available_macro_snapshot,
+    macro_snapshot_is_usable,
+)
 from core.data.quality import (
     QualityFilterConfig,
     SharesOutstandingSnapshot,
@@ -1187,9 +1191,14 @@ def _write_macro_archive(
     writer: ObjectWriter,
     serializer: RawRowSerializer,
 ) -> _WriteResult:
-    """Fetch and persist FRED macro observations per observation_date."""
+    """Fetch vintages once and persist one run-date macro snapshot per business day."""
     normalized_series = _normalize_tokens(series_ids)
-    if not overwrite and _macro_archive_covers_range(writer, from_date, to_date):
+    if not overwrite and _macro_archive_covers_range(
+        writer,
+        from_date,
+        to_date,
+        series_ids=normalized_series,
+    ):
         logger.info(
             "Macro archive already covers {}..{}; skipping FRED fetch",
             from_date.isoformat(),
@@ -1215,33 +1224,39 @@ def _write_macro_archive(
         realtime_end=to_date.isoformat(),
         limit=limit,
     )
-    rows_by_date: dict[str, list[dict[str, object]]] = {}
-    for row in rows:
-        observation_date = str(row.get("observation_date") or "").strip()
-        if not observation_date:
-            continue
-        rows_by_date.setdefault(observation_date, []).append(row)
+    ordered_rows = _sort_raw_rows(
+        rows,
+        ("series_id", "observation_date", "realtime_start", "realtime_end"),
+    )
 
     output_keys: list[str] = []
     written = 0
     skipped = 0
     empty = 0
     total_rows = 0
-    for observation_date in sorted(rows_by_date):
-        date_rows = _sort_raw_rows(
-            rows_by_date[observation_date],
-            ("series_id", "realtime_start", "realtime_end"),
+    for snapshot_day in _business_days(from_date, to_date):
+        snapshot_date = snapshot_day.isoformat()
+        date_rows = build_latest_available_macro_snapshot(
+            ordered_rows,
+            snapshot_date=snapshot_date,
+            series_ids=normalized_series,
         )
-        key = raw_macro_path(observation_date)
-        if not overwrite and writer.exists(key):
+        key = raw_macro_path(snapshot_date)
+        if not date_rows:
+            empty += 1
+            continue
+        if not overwrite and _macro_snapshot_key_is_usable(
+            writer,
+            key,
+            snapshot_date=snapshot_date,
+            required_series_ids=normalized_series,
+        ):
             skipped += 1
             continue
         writer.put_object(key, serializer(date_rows))
         output_keys.append(key)
         written += 1
         total_rows += len(date_rows)
-        if not date_rows:
-            empty += 1
 
     return _WriteResult(
         output_keys=output_keys,
@@ -1269,7 +1284,12 @@ def _write_daily_macro_snapshot(
     """Fetch and persist one run-date macro snapshot using latest available observations."""
     normalized_series = _normalize_tokens(series_ids)
     key = raw_macro_path(as_of_date)
-    if not overwrite and writer.exists(key):
+    if not overwrite and _macro_snapshot_key_is_usable(
+        writer,
+        key,
+        snapshot_date=as_of_date.isoformat(),
+        required_series_ids=normalized_series,
+    ):
         logger.info(
             "Daily macro snapshot already exists for {}; skipping FRED fetch",
             as_of_date.isoformat(),
@@ -1295,7 +1315,12 @@ def _write_daily_macro_snapshot(
         ),
         ("series_id", "observation_date", "realtime_start", "realtime_end"),
     )
-    if not rows:
+    snapshot_rows = build_latest_available_macro_snapshot(
+        rows,
+        snapshot_date=as_of_date.isoformat(),
+        series_ids=normalized_series,
+    )
+    if not snapshot_rows:
         return _WriteResult(
             output_keys=[],
             metadata={
@@ -1309,7 +1334,7 @@ def _write_daily_macro_snapshot(
             },
         )
 
-    writer.put_object(key, serializer(rows))
+    writer.put_object(key, serializer(snapshot_rows))
     return _WriteResult(
         output_keys=[key],
         metadata={
@@ -1317,7 +1342,7 @@ def _write_daily_macro_snapshot(
             "written": 1,
             "skipped": 0,
             "empty": 0,
-            "total_rows": len(rows),
+            "total_rows": len(snapshot_rows),
             "output_keys": [key],
             "snapshot_date": as_of_date.isoformat(),
         },
@@ -1508,6 +1533,22 @@ def _parquet_bytes_to_raw_rows(data: bytes) -> list[dict[str, object]]:
 
     frame = pd.read_parquet(io.BytesIO(data))
     return [dict(row) for row in frame.to_dict("records")]
+
+
+def _best_effort_raw_rows_from_payload(data: bytes) -> list[dict[str, object]]:
+    """Deserialize raw-row payloads from Parquet first, then JSON test fixtures."""
+    try:
+        return _parquet_bytes_to_raw_rows(data)
+    except (ModuleNotFoundError, ValueError, TypeError):
+        payload = json.loads(data.decode("utf-8"))
+        if not isinstance(payload, list):
+            raise ValueError("Expected a list of raw rows")
+        rows: list[dict[str, object]] = []
+        for row in payload:
+            if not isinstance(row, dict):
+                raise ValueError("Expected raw rows to be JSON objects")
+            rows.append(dict(row))
+        return rows
 
 
 def _raw_rows_to_parquet_bytes(rows: list[dict[str, object]]) -> bytes:
@@ -2120,13 +2161,47 @@ def _next_business_day(value: date) -> date:
     return current
 
 
-def _macro_archive_covers_range(writer: ObjectWriter, from_date: date, to_date: date) -> bool:
-    """Return True when every business day in the range has a raw/macro/{date}.parquet key."""
-    expected = {raw_macro_path(day.isoformat()) for day in _business_days(from_date, to_date)}
-    if not expected:
+def _macro_archive_covers_range(
+    writer: ObjectWriter,
+    from_date: date,
+    to_date: date,
+    *,
+    series_ids: Sequence[str] | None = None,
+) -> bool:
+    """Return True when every business day already has a usable raw macro snapshot."""
+    business_days = _business_days(from_date, to_date)
+    if not business_days:
         return False
-    present = set(writer.list_keys("raw/macro/"))
-    return expected.issubset(present)
+    return all(
+        _macro_snapshot_key_is_usable(
+            writer,
+            raw_macro_path(day.isoformat()),
+            snapshot_date=day.isoformat(),
+            required_series_ids=series_ids,
+        )
+        for day in business_days
+    )
+
+
+def _macro_snapshot_key_is_usable(
+    writer: ObjectWriter,
+    key: str,
+    *,
+    snapshot_date: str,
+    required_series_ids: Sequence[str] | None = None,
+) -> bool:
+    """Return True when an existing macro shard is already a usable run-date snapshot."""
+    if not writer.exists(key):
+        return False
+    try:
+        rows = _best_effort_raw_rows_from_payload(writer.get_object(key))
+    except (json.JSONDecodeError, ModuleNotFoundError, TypeError, ValueError):
+        return False
+    return macro_snapshot_is_usable(
+        rows,
+        snapshot_date=snapshot_date,
+        required_series_ids=required_series_ids,
+    )
 
 
 def _sort_ohlcv_records(records: Sequence[OHLCVRecord]) -> list[OHLCVRecord]:

--- a/core/data/macro_archive.py
+++ b/core/data/macro_archive.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import date as Date
+
+MACRO_SNAPSHOT_DATE_COLUMN = "snapshot_date"
+
+
+def annotate_macro_snapshot_rows(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    snapshot_date: str,
+) -> list[dict[str, object]]:
+    """Stamp one snapshot date onto every macro archive row."""
+    normalized_snapshot_date = _normalize_iso_date(snapshot_date)
+    return [
+        dict(row, **{MACRO_SNAPSHOT_DATE_COLUMN: normalized_snapshot_date})
+        for row in rows
+    ]
+
+
+def build_latest_available_macro_snapshot(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    snapshot_date: str,
+    series_ids: Sequence[str] | None = None,
+) -> list[dict[str, object]]:
+    """Return the latest point-in-time-safe row per series for one snapshot date."""
+    normalized_snapshot_date = _normalize_iso_date(snapshot_date)
+    requested_series = _normalize_series_ids(series_ids)
+    latest_by_series: dict[str, dict[str, object]] = {}
+    for row in rows:
+        series_id = _normalize_series_id(row.get("series_id"))
+        if series_id is None:
+            continue
+        if requested_series and series_id not in requested_series:
+            continue
+        if not _row_is_available_as_of(row, normalized_snapshot_date):
+            continue
+        candidate = dict(row)
+        candidate[MACRO_SNAPSHOT_DATE_COLUMN] = normalized_snapshot_date
+        current = latest_by_series.get(series_id)
+        if current is None or _row_priority(candidate) > _row_priority(current):
+            latest_by_series[series_id] = candidate
+    return sorted(latest_by_series.values(), key=_row_sort_key)
+
+
+def macro_snapshot_is_usable(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    snapshot_date: str,
+    required_series_ids: Sequence[str] | None = None,
+) -> bool:
+    """Return True when one stored macro shard is already a usable run-date snapshot."""
+    normalized_snapshot_date = _normalize_iso_date(snapshot_date)
+    requested_series = _normalize_series_ids(required_series_ids)
+    present_series: set[str] = set()
+    for row in rows:
+        explicit_snapshot_date = row.get(MACRO_SNAPSHOT_DATE_COLUMN)
+        if explicit_snapshot_date is not None:
+            try:
+                if _normalize_iso_date(str(explicit_snapshot_date)) != normalized_snapshot_date:
+                    return False
+            except ValueError:
+                return False
+
+        series_id = _normalize_series_id(row.get("series_id"))
+        if series_id is None:
+            return False
+        if series_id in present_series:
+            return False
+        if not _row_is_available_as_of(row, normalized_snapshot_date):
+            return False
+        present_series.add(series_id)
+
+    if not present_series:
+        return False
+    return not requested_series or requested_series.issubset(present_series)
+
+
+def _row_is_available_as_of(row: Mapping[str, object], snapshot_date: str) -> bool:
+    """Return True when a macro row was public on or before the snapshot date."""
+    observation_date = _coerce_iso_date(row.get("observation_date"))
+    realtime_start = _coerce_iso_date(row.get("realtime_start"))
+    if observation_date is None or realtime_start is None:
+        return False
+    return observation_date <= snapshot_date and realtime_start <= snapshot_date
+
+
+def _row_priority(row: Mapping[str, object]) -> tuple[str, str, str, str]:
+    """Return the ordering used to select the latest available row per series."""
+    return (
+        _coerce_iso_date(row.get("observation_date")) or "",
+        _coerce_iso_date(row.get("realtime_start")) or "",
+        _coerce_iso_date(row.get("realtime_end")) or "",
+        str(row.get("retrieved_at") or ""),
+    )
+
+
+def _row_sort_key(row: Mapping[str, object]) -> tuple[str, str, str, str, str]:
+    """Return the deterministic serialization order for snapshot rows."""
+    return (
+        str(row.get("series_id") or ""),
+        _coerce_iso_date(row.get("observation_date")) or "",
+        _coerce_iso_date(row.get("realtime_start")) or "",
+        _coerce_iso_date(row.get("realtime_end")) or "",
+        str(row.get("retrieved_at") or ""),
+    )
+
+
+def _normalize_series_ids(series_ids: Sequence[str] | None) -> set[str]:
+    if not series_ids:
+        return set()
+    return {
+        normalized
+        for series_id in series_ids
+        if (normalized := _normalize_series_id(series_id)) is not None
+    }
+
+
+def _normalize_series_id(value: object) -> str | None:
+    text = str(value or "").strip().upper()
+    return text or None
+
+
+def _normalize_iso_date(value: str) -> str:
+    return Date.fromisoformat(value.strip()).isoformat()
+
+
+def _coerce_iso_date(value: object) -> str | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    candidate = text.split("T", maxsplit=1)[0].split(" ", maxsplit=1)[0]
+    try:
+        return Date.fromisoformat(candidate).isoformat()
+    except ValueError:
+        return None

--- a/core/features/loaders.py
+++ b/core/features/loaders.py
@@ -8,9 +8,19 @@ from __future__ import annotations
 
 import importlib
 import io
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
-from services.r2.paths import raw_fundamentals_path, raw_price_path
+from core.data.macro_archive import (
+    MACRO_SNAPSHOT_DATE_COLUMN,
+    build_latest_available_macro_snapshot,
+)
+from services.r2.paths import (
+    is_canonical_raw_macro_key,
+    raw_fundamentals_path,
+    raw_macro_date_from_key,
+    raw_price_path,
+)
 from services.r2.writer import R2Writer
 
 if TYPE_CHECKING:
@@ -64,12 +74,15 @@ def load_macro_frame(
     """
     pd = _require_pandas()
     active_writer = writer or R2Writer()
-    keys = sorted(active_writer.list_keys("raw/macro/"))
+    keys = sorted(
+        key for key in active_writer.list_keys("raw/macro/") if is_canonical_raw_macro_key(key)
+    )
     if not keys:
         return pd.DataFrame(
             columns=[
                 "source",
                 "series_id",
+                MACRO_SNAPSHOT_DATE_COLUMN,
                 "observation_date",
                 "realtime_start",
                 "realtime_end",
@@ -83,7 +96,10 @@ def load_macro_frame(
     frames = []
     for key in keys:
         payload = active_writer.get_object(key)
-        frames.append(pd.read_parquet(io.BytesIO(payload)))
+        frame = pd.read_parquet(io.BytesIO(payload))
+        if MACRO_SNAPSHOT_DATE_COLUMN not in frame.columns:
+            frame[MACRO_SNAPSHOT_DATE_COLUMN] = raw_macro_date_from_key(key)
+        frames.append(frame)
     frame = pd.concat(frames, ignore_index=True)
     identity_columns = [
         column
@@ -102,6 +118,33 @@ def load_macro_frame(
         )
         return frame
     return frame.reset_index(drop=True)
+
+
+def available_macro_series_by_date(
+    target_dates: Sequence[str],
+    *,
+    writer: R2Writer | None = None,
+    series_ids: Sequence[str] | None = None,
+) -> dict[str, list[str]]:
+    """Return recoverable macro series IDs for each requested snapshot date."""
+    normalized_dates = sorted({str(value).strip() for value in target_dates if str(value).strip()})
+    if not normalized_dates:
+        return {}
+
+    macro_frame = load_macro_frame(writer=writer)
+    if len(macro_frame.index) == 0:
+        return {date_text: [] for date_text in normalized_dates}
+
+    rows = macro_frame.to_dict("records")
+    available: dict[str, list[str]] = {}
+    for date_text in normalized_dates:
+        snapshot_rows = build_latest_available_macro_snapshot(
+            rows,
+            snapshot_date=date_text,
+            series_ids=series_ids,
+        )
+        available[date_text] = [str(row["series_id"]) for row in snapshot_rows]
+    return available
 
 
 def _require_pandas() -> Any:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -187,7 +187,7 @@ r2/
     news/             # Raw news as JSON Lines (one article per line)
     universe/         # Daily eligibility masks as CSV
     fundamentals/     # SimFin as-reported point-in-time fundamentals per ticker parquet
-    macro/            # FRED macro/rate observations as available on the run date
+    macro/            # FRED per-run-date point-in-time macro snapshots
     reference/        # Symbol/security-reference snapshots
   features/
     layer1/           # Layer 1 feature histories as Parquet (one file per ticker)
@@ -232,7 +232,7 @@ Any artifact that must survive a Pi restart or be accessed by Modal must be writ
 | Model scores | Parquet | Small, fast to read |
 | News raw archive | JSON Lines | One article per line; easy to stream |
 | Fundamentals archive | Parquet (per ticker history) | Point-in-time company fundamentals at `raw/fundamentals/{ticker}.parquet`; efficient ticker/date joins and targeted recovery |
-| Macro/rates archive | Parquet or CSV | Small daily series; preserve observations used by a run |
+| Macro/rates archive | Parquet | `raw/macro/{run_date}.parquet` snapshot; preserve the latest available row per series plus row-level observation/realtime metadata |
 | Sentiment scores | Parquet | Processed output from FinBERT pipeline |
 | Universe eligibility masks | CSV | Small; human-inspectable |
 | Daily order files | CSV | Human-readable for debugging |

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -173,8 +173,14 @@ Purpose:
 - avoid rewriting historical feature values when upstream macro series are revised
 
 Notes:
-- raw macro/rate observations are stored as archival Layer 0 data in R2, for example under
-  `raw/macro/`
+- raw macro/rate observations are stored as archival Layer 0 data in R2 under
+  `raw/macro/{run_date}.parquet`
+- each raw macro shard is a run-date point-in-time snapshot containing the latest available
+  row per configured series as of that `run_date`; the row payload still preserves the
+  underlying `observation_date`, `realtime_start`, and `realtime_end`
+- Layer 1 loaders and validators read legacy observation-date shards backward-compatibly when
+  rebuilding historical macro vintages, but new Layer 0 writes must use the run-date snapshot
+  convention above
 - Layer 1 converts these raw records into macro and regime-context features such as
   yield-curve slope, policy-rate level, CPI context, and credit/risk proxies
 - this archive is not a replacement for `FeatureRecord`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -54,6 +54,8 @@ Expected execution chain:
    Alpaca live bars/news, SimFin refreshes, FRED refreshes, universe masks, and manifests
    - daily OHLCV provenance must record `adjustment=raw`; the run-date bar is stored as a
      raw snapshot and is not retroactively rewritten in-place during the same run
+   - daily FRED refreshes must persist `raw/macro/{run_date}.parquet` as the point-in-time
+     snapshot for that run date rather than keying shards only by observation date
 3. Validate the Pi -> Modal Layer 1 handoff:
    Pi submits the daily Modal job, then blocks on the R2 Layer 1 manifest
 4. Build Layer 1 features strictly from existing R2 Layer 0 archives

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -75,7 +75,8 @@ Execution chain:
    - Normalize and append it to the canonical raw price store in R2
    - Fetch today's raw Alpaca news -> write `raw/news/YYYY-MM-DD.jsonl` to R2
    - Refresh newly available SimFin filings and earnings-calendar data -> write `raw/fundamentals/`
-   - Refresh FRED macro/rate observations available for the run date -> write `raw/macro/`
+   - Refresh FRED macro/rate observations available for the run date -> write
+     `raw/macro/{YYYY-MM-DD}.parquet`
    - Recompute today's eligibility mask (quality + liquidity filters)
    - Write `raw/universe/YYYY-MM-DD.csv` to R2
    - Write `PipelineManifestRecord` (stage=layer0)
@@ -99,7 +100,9 @@ Execution chain:
    - Pi records the expected Layer 1 manifest key and waits on R2 before moving on
    - Read today's OHLCV Parquet, news JSON Lines, and universe CSV from R2
    - Read point-in-time SimFin fundamentals and earnings dates from R2
-   - Read FRED macro context series persisted for the run date from R2
+   - Read FRED macro context series from the `raw/macro/{run_date}.parquet` point-in-time
+     snapshot (with backward-compatible legacy-vintage recovery when older observation-date
+     shards still exist)
    - Fail closed if the required Layer 0 raw archives or manifests are missing
    - Derive the ticker scope from Layer 0 universe masks; optional ticker filters may only
      narrow that scope, never replace it with a hand-maintained production list

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -7,6 +7,7 @@ from pathlib import PurePosixPath
 
 RAW_PRICE_PREFIX = "raw/prices/"
 _CANONICAL_RAW_PRICE_KEY_RE = re.compile(r"^raw/prices/[^/_]+\.parquet$")
+_CANONICAL_RAW_MACRO_KEY_RE = re.compile(r"^raw/macro/(?P<date>\d{4}-\d{2}-\d{2})\.parquet$")
 
 
 def build_r2_key(*parts: str) -> str:
@@ -64,6 +65,23 @@ def raw_fundamentals_path(ticker: str) -> str:
 def raw_macro_path(archive_date: str | Date | datetime) -> str:
     """Return the canonical raw macro/rates Parquet path for one archive date."""
     return build_r2_key("raw", "macro", f"{_format_date(archive_date)}.parquet")
+
+
+def is_canonical_raw_macro_key(key: str) -> bool:
+    """Return True when a raw macro key follows the one-file-per-day pattern."""
+    if not isinstance(key, str):
+        raise TypeError("key must be a string")
+    return bool(_CANONICAL_RAW_MACRO_KEY_RE.fullmatch(key.strip()))
+
+
+def raw_macro_date_from_key(key: str) -> str:
+    """Return the archive date encoded in a canonical raw macro key."""
+    if not isinstance(key, str):
+        raise TypeError("key must be a string")
+    match = _CANONICAL_RAW_MACRO_KEY_RE.fullmatch(key.strip())
+    if match is None:
+        raise ValueError(f"Not a canonical raw macro key: {key}")
+    return _format_date(match.group("date"))
 
 
 def raw_reference_path(name: str, extension: str = "json") -> str:

--- a/tests/fixtures/layer1_support.py
+++ b/tests/fixtures/layer1_support.py
@@ -84,6 +84,16 @@ def seed_layer0_archives(
             metadata={
                 "from_date": min(dates),
                 "to_date": max(dates),
+                "fred_series_ids": [
+                    "FEDFUNDS",
+                    "DGS3MO",
+                    "DGS2",
+                    "DGS10",
+                    "VIXCLS",
+                    "DTWEXBGS",
+                    "CPIAUCSL",
+                    "BAMLH0A0HYM2",
+                ],
             },
         )
         for run_id in layer0_run_ids or ("layer1-daily",):

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -33,6 +33,7 @@ from services.r2.paths import (
     layer1_sentiment_feature_path,
     layer1_validation_report_path,
     pipeline_manifest_path,
+    raw_macro_path,
     raw_price_path,
 )
 from services.r2.writer import R2Writer
@@ -328,6 +329,42 @@ def test_run_daily_layer1_fails_closed_when_raw_price_history_misses_target_date
     )
     assert manifest.status is RunStatus.FAILED
     assert "missing target-date coverage" in str(manifest.metadata["error"]["message"])
+
+
+def test_run_daily_layer1_recovers_macro_inputs_without_target_date_snapshot_key(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Layer 1 can recover point-in-time macro rows from legacy-compatible prior shards."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2024-01-02", "2024-01-03"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-macro-recovery",),
+    )
+    macro_key = raw_macro_path("2024-01-03")
+    macro_payload = writer.get_object(macro_key)
+    writer.delete_object(macro_key)
+
+    result = run_daily_layer1(
+        Layer1DailyConfig(
+            run_id="layer1-macro-recovery",
+            from_date="2024-01-03",
+            to_date="2024-01-03",
+            allow_layer0_manifest_date_range=True,
+        ),
+        writer=writer,
+        news_runner=fake_news_runner(writer, ["AAPL"]),
+        text_topic_runner=fake_topic_runner(writer, ["AAPL"]),
+        finbert_runner=fake_sentiment_runner(writer, ["AAPL"]),
+        regime_runner=fake_regime_runner(writer),
+        validation_output_dir=tmp_path / "reports",
+    )
+
+    writer.put_object(macro_key, macro_payload)
+
+    assert result.ready_for_layer2 is True
 
 
 def test_run_daily_layer1_writes_failed_manifest_on_branch_error(

--- a/tests/unit/test_feature_loaders.py
+++ b/tests/unit/test_feature_loaders.py
@@ -45,5 +45,6 @@ def test_load_macro_frame_deduplicates_equivalent_vintages_across_archive_dates(
 
     assert len(frame.index) == 1
     assert frame.loc[0, "series_id"] == "DGS10"
+    assert frame.loc[0, "snapshot_date"] == "2026-05-13"
     assert frame.loc[0, "observation_date"] == "2026-05-12"
     assert frame.loc[0, "retrieved_at"] == "2026-05-13T20:00:00+00:00"

--- a/tests/unit/test_fred_macro_fetcher.py
+++ b/tests/unit/test_fred_macro_fetcher.py
@@ -475,7 +475,7 @@ def test_normalize_preserves_retrieval_and_realtime_dates() -> None:
 
 
 def test_backfill_writes_raw_macro_archive() -> None:
-    """Backfill writes one deterministic raw macro archive for the range."""
+    """Backfill writes one deterministic run-date macro snapshot per business day."""
     rows = normalize_fred_observations(
         _fixture_payload()["page1"]["observations"],
         series_id="FEDFUNDS",
@@ -486,7 +486,7 @@ def test_backfill_writes_raw_macro_archive() -> None:
 
     result = backfill_fred_archive(
         from_date=date(2024, 1, 1),
-        to_date=date(2024, 12, 31),
+        to_date=date(2024, 1, 2),
         fetcher=fetcher,
         writer=writer,
         series_ids=["FEDFUNDS", "DGS10"],
@@ -505,10 +505,12 @@ def test_backfill_writes_raw_macro_archive() -> None:
     day2_rows = _read_json(writer.objects[key_day2])
     assert [row["observation_date"] for row in day1_rows] == ["2024-01-01"]
     assert [row["observation_date"] for row in day2_rows] == ["2024-01-02"]
+    assert all(row["snapshot_date"] == "2024-01-01" for row in day1_rows)
+    assert all(row["snapshot_date"] == "2024-01-02" for row in day2_rows)
     assert "raw" in day1_rows[0]
     assert fetcher.calls[0]["series_ids"] == ("DGS10", "FEDFUNDS")
     assert fetcher.calls[0]["realtime_start"] == "2024-01-01"
-    assert fetcher.calls[0]["realtime_end"] == "2024-12-31"
+    assert fetcher.calls[0]["realtime_end"] == "2024-01-02"
 
 
 def test_backfill_is_idempotent_for_existing_archive() -> None:
@@ -520,20 +522,26 @@ def test_backfill_is_idempotent_for_existing_archive() -> None:
     )
     existing_keys = {raw_macro_path(row["observation_date"]) for row in rows}
     writer = _FakeWriter(existing=existing_keys)
+    for row in rows:
+        key = raw_macro_path(row["observation_date"])
+        writer.objects[key] = _json_serializer(
+            [dict(row, snapshot_date=row["observation_date"])]
+        )
     fetcher = _FakeFetcher(rows)
 
     result = backfill_fred_archive(
         from_date=date(2024, 1, 1),
-        to_date=date(2024, 12, 31),
+        to_date=date(2024, 1, 2),
         fetcher=fetcher,
         writer=writer,
         series_ids=["FEDFUNDS"],
         serializer=_json_serializer,
+        deserializer=_json_deserializer,
     )
 
     assert result.written == 0
-    assert result.skipped == len(existing_keys)
-    assert fetcher.calls
+    assert result.skipped == 0
+    assert fetcher.calls == []
 
 
 def test_backfill_merge_existing_preserves_old_series_and_adds_new_rows() -> None:

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -221,7 +221,18 @@ class _MacroFetcher:
                 "limit": limit,
             }
         )
-        return [{"series_id": series_ids[0], "observation_date": start_date, "value": "1.0"}]
+        return [
+            {
+                "series_id": series_ids[0],
+                "observation_date": start_date,
+                "realtime_start": start_date,
+                "realtime_end": end_date,
+                "retrieved_at": f"{end_date}T00:00:00+00:00",
+                "value": "1.0",
+                "is_missing": False,
+                "raw": {"series_id": series_ids[0]},
+            }
+        ]
 
     def fetch_latest_available_macro_observations(
         self,
@@ -391,6 +402,7 @@ def test_historical_layer0_backfill_writes_all_raw_archives_and_manifest() -> No
         raw_fundamentals_path("AAPL"),
         raw_fundamentals_path("MSFT"),
         raw_macro_path("2024-01-02"),
+        raw_macro_path("2024-01-03"),
         pipeline_manifest_path("layer0", run_id),
     }
     assert expected_keys.issubset(writer.objects)
@@ -569,6 +581,7 @@ def test_daily_layer0_incremental_writes_run_date_macro_snapshot() -> None:
             "realtime_start": "2026-05-12",
             "retrieved_at": "2026-05-13T00:00:00+00:00",
             "series_id": "DGS10",
+            "snapshot_date": "2026-05-13",
             "value": 1.0,
         }
     ]
@@ -908,7 +921,23 @@ def test_daily_layer0_incremental_is_idempotent_for_existing_raw_outputs() -> No
     )
     writer.put_object(raw_news_path("2024-01-02"), b"existing")
     writer.put_object(raw_fundamentals_path("AAPL"), b"existing")
-    writer.put_object(raw_macro_path("2024-01-02"), b"existing")
+    writer.put_object(
+        raw_macro_path("2024-01-02"),
+        _bytes_serializer(
+            [
+                {
+                    "series_id": "DGS10",
+                    "observation_date": "2024-01-01",
+                    "realtime_start": "2024-01-01",
+                    "realtime_end": "2024-01-02",
+                    "retrieved_at": "2024-01-02T00:00:00+00:00",
+                    "snapshot_date": "2024-01-02",
+                    "value": 4.2,
+                    "is_missing": False,
+                }
+            ]
+        ),
+    )
     writer.put_object(
         universe_key,
         _universe_serializer(

--- a/tests/unit/test_r2_paths.py
+++ b/tests/unit/test_r2_paths.py
@@ -6,6 +6,7 @@ import pytest
 
 from services.r2.paths import (
     build_r2_key,
+    is_canonical_raw_macro_key,
     is_canonical_raw_price_key,
     is_legacy_raw_price_key,
     layer0_ohlcv_provenance_report_path,
@@ -21,6 +22,7 @@ from services.r2.paths import (
     layer1_validation_report_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
+    raw_macro_date_from_key,
     raw_macro_path,
     raw_news_path,
     raw_price_path,
@@ -44,6 +46,8 @@ def test_layer0_raw_path_builders_return_canonical_keys() -> None:
     assert raw_fundamentals_path("AAPL") == "raw/fundamentals/AAPL.parquet"
     assert raw_macro_path(date(2025, 1, 2)) == "raw/macro/2025-01-02.parquet"
     assert raw_macro_path("2025-01-02") == "raw/macro/2025-01-02.parquet"
+    assert is_canonical_raw_macro_key("raw/macro/2025-01-02.parquet") is True
+    assert raw_macro_date_from_key("raw/macro/2025-01-02.parquet") == "2025-01-02"
     assert raw_reference_path("tiingo_security_master") == "raw/reference/tiingo_security_master.json"
     assert (
         raw_security_master_path("2025-01-02")

--- a/tests/unit/test_validate_layer0_archive.py
+++ b/tests/unit/test_validate_layer0_archive.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import io
 import json
 from datetime import date
 from pathlib import Path
+
+import pandas as pd
 
 from app.lab.data_pipelines.validate_layer0_archive import (
     validate_layer0_archive,
@@ -49,6 +52,7 @@ def _historical_manifest_objects(run_id: str) -> dict[str, bytes]:
                 "status": "completed",
                 "metadata": {
                     "mode": "historical_backfill",
+                    "fred_series_ids": ["DGS10"],
                     "prices": {
                         "adjustment_provenance": {
                             "policy_id": "alpaca_historical_1day_adjustment_all",
@@ -84,6 +88,7 @@ def _daily_manifest_objects(run_id: str, *, feed: str) -> dict[str, bytes]:
                 "status": "completed",
                 "metadata": {
                     "mode": "daily_incremental",
+                    "fred_series_ids": ["DGS10"],
                     "prices": {
                         "adjustment_provenance": {
                             "policy_id": "alpaca_live_1day_adjustment_raw",
@@ -109,12 +114,38 @@ def _daily_manifest_objects(run_id: str, *, feed: str) -> dict[str, bytes]:
     }
 
 
+def _macro_snapshot_object(snapshot_date: str, *, observation_date: str | None = None) -> bytes:
+    rows = [
+        {
+            "source": "fred",
+            "series_id": "DGS10",
+            "snapshot_date": snapshot_date,
+            "observation_date": observation_date or snapshot_date,
+            "realtime_start": observation_date or snapshot_date,
+            "realtime_end": snapshot_date,
+            "retrieved_at": f"{snapshot_date}T00:00:00+00:00",
+            "value": 4.2,
+            "is_missing": False,
+        }
+    ]
+    buffer = io.BytesIO()
+    pd.DataFrame(rows).to_parquet(buffer, index=False)
+    return buffer.getvalue()
+
+
 def test_validate_layer0_archive_reports_ready_when_required_keys_exist() -> None:
     """Validation is ready when all required archive families and manifest exist."""
     from_date = date(2024, 1, 1)
     to_date = date(2024, 1, 3)
     run_id = "layer0-historical-2024-01-01_to_2024-01-03"
     objects = _historical_manifest_objects(run_id)
+    objects.update(
+        {
+            raw_macro_path("2024-01-01"): _macro_snapshot_object("2024-01-01"),
+            raw_macro_path("2024-01-02"): _macro_snapshot_object("2024-01-02"),
+            raw_macro_path("2024-01-03"): _macro_snapshot_object("2024-01-03"),
+        }
+    )
     keys = {
         raw_price_path("AAPL"),
         raw_news_path("2024-01-01"),
@@ -124,7 +155,9 @@ def test_validate_layer0_archive_reports_ready_when_required_keys_exist() -> Non
         raw_universe_path("2024-01-02"),
         raw_universe_path("2024-01-03"),
         raw_fundamentals_path("AAPL"),
+        raw_macro_path("2024-01-01"),
         raw_macro_path("2024-01-02"),
+        raw_macro_path("2024-01-03"),
         pipeline_manifest_path("layer0", run_id),
         layer0_ohlcv_provenance_report_path(run_id),
     }
@@ -142,7 +175,10 @@ def test_validate_layer0_archive_reports_ready_when_required_keys_exist() -> Non
     assert report.news_days_present == 3
     assert report.universe_days_present == 3
     assert report.fundamentals_ticker_count == 1
-    assert report.macro_day_count == 1
+    assert report.macro_day_count == 3
+    assert report.macro_days_recoverable == 3
+    assert report.macro_available_series_by_date["2024-01-02"] == ["DGS10"]
+    assert report.macro_missing_series_by_date["2024-01-02"] == []
     assert report.noncanonical_price_keys == []
     assert report.ohlcv_provenance_report_present is True
     assert report.ohlcv_provenance_policy_id == "alpaca_historical_1day_adjustment_all"
@@ -155,6 +191,13 @@ def test_validate_layer0_archive_blocks_layer1_when_active_fundamentals_are_miss
     to_date = date(2024, 1, 3)
     run_id = "layer0-historical-2024-01-01_to_2024-01-03"
     objects = _historical_manifest_objects(run_id)
+    objects.update(
+        {
+            raw_macro_path("2024-01-01"): _macro_snapshot_object("2024-01-01"),
+            raw_macro_path("2024-01-02"): _macro_snapshot_object("2024-01-02"),
+            raw_macro_path("2024-01-03"): _macro_snapshot_object("2024-01-03"),
+        }
+    )
     keys = {
         raw_price_path("AAPL"),
         raw_news_path("2024-01-01"),
@@ -165,7 +208,9 @@ def test_validate_layer0_archive_blocks_layer1_when_active_fundamentals_are_miss
         raw_universe_path("2024-01-03"),
         raw_fundamentals_path("AAPL"),
         raw_fundamentals_path("MSFT"),
+        raw_macro_path("2024-01-01"),
         raw_macro_path("2024-01-02"),
+        raw_macro_path("2024-01-03"),
         pipeline_manifest_path("layer0", run_id),
         layer0_ohlcv_provenance_report_path(run_id),
     }
@@ -206,6 +251,7 @@ def test_validate_layer0_archive_reports_missing_dates() -> None:
         "2024-01-08",
     ]
     assert report.missing_universe_dates == ["2024-01-05", "2024-01-08"]
+    assert report.missing_macro_dates == ["2024-01-05", "2024-01-08"]
     assert "missing_manifest_payload" in report.ohlcv_provenance_validation_errors
 
 
@@ -215,6 +261,7 @@ def test_validate_layer0_archive_blocks_noncanonical_price_keys() -> None:
     to_date = date(2024, 1, 1)
     run_id = "layer0-historical-2024-01-01"
     objects = _historical_manifest_objects(run_id)
+    objects[raw_macro_path("2024-01-01")] = _macro_snapshot_object("2024-01-01")
     keys = {
         raw_price_path("AAPL"),
         "raw/prices/AAPL_2017-01-03_2024-01-01.parquet",
@@ -254,6 +301,7 @@ def test_validate_layer0_archive_blocks_missing_or_mismatched_ohlcv_provenance()
                 "status": "completed",
                 "metadata": {
                     "mode": "historical_backfill",
+                    "fred_series_ids": ["DGS10"],
                     "prices": {
                         "adjustment_provenance": {
                             "policy_id": "alpaca_live_1day_adjustment_raw",
@@ -276,6 +324,7 @@ def test_validate_layer0_archive_blocks_missing_or_mismatched_ohlcv_provenance()
                 observed_rows=2,
             )
         ).encode("utf-8"),
+        raw_macro_path("2024-01-02"): _macro_snapshot_object("2024-01-02"),
     }
     keys = {
         raw_price_path("AAPL"),
@@ -307,6 +356,7 @@ def test_validate_layer0_archive_accepts_valid_daily_incremental_manifest() -> N
     """Validation accepts daily incremental provenance without enforcing one live feed."""
     run_id = "layer0-daily-2024-01-02"
     objects = _daily_manifest_objects(run_id, feed="sip")
+    objects[raw_macro_path("2024-01-02")] = _macro_snapshot_object("2024-01-02")
     keys = {
         raw_price_path("AAPL"),
         raw_news_path("2024-01-02"),
@@ -335,6 +385,7 @@ def test_validate_layer0_archive_surfaces_split_like_discontinuity_count() -> No
     run_id = "layer0-historical-2024-01-03"
     report_key = layer0_ohlcv_provenance_report_path(run_id)
     objects = _historical_manifest_objects(run_id)
+    objects[raw_macro_path("2024-01-03")] = _macro_snapshot_object("2024-01-03")
     objects[report_key] = json.dumps(
         build_provenance_report(
             run_id=run_id,


### PR DESCRIPTION
## What this PR does
Standardizes `raw/macro/{YYYY-MM-DD}.parquet` as a run-date point-in-time snapshot across historical backfill and daily Layer 0 writes, adds shared legacy-aware macro snapshot recovery for Layer 1/HMM consumers, and tightens Layer 0 validation so macro coverage is reported by date/series instead of trusting filename existence alone.

## Closes
Closes #148

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [x] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [ ] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Not applicable.

## Notes for reviewer
- I added `core/data/macro_archive.py` as the shared source of truth for run-date snapshot stamping, latest-available snapshot reconstruction, and legacy shard usability checks.
- `validate_layer0_archive.py` now reports recoverable macro series by business date and surfaces dates recovered via legacy-compatible reads.
- `run_daily_layer1.py` now validates recoverable macro coverage from Layer 0 vintages instead of requiring a same-date macro filename to exist.
- Canonical docs were updated anywhere `raw/macro/` behavior was part of the architecture/runtime contract.

## Verification artifacts to include in PR/issue comment
- Commands run:
  - `./.venv/bin/pytest tests/unit/test_r2_paths.py tests/unit/test_feature_loaders.py tests/unit/test_layer0_pipeline.py tests/unit/test_fred_macro_fetcher.py tests/unit/test_validate_layer0_archive.py tests/unit/test_daily_layer1_runner.py -q`
  - `./.venv/bin/pytest tests/integration/test_macro_features_integration.py tests/integration/test_context_features_integration.py tests/integration/test_regime_training_integration.py -v --tb=short`
  - `./.venv/bin/pytest tests/unit/ -v --tb=short`
- Test result summary:
  - `89 passed` in the focused macro/unit suite
  - `3 passed` in the macro/context/regime integration suite
  - `546 passed` in `tests/unit/`
- Manifest key(s):
  - `artifacts/manifests/layer0/{run_id}.json`
  - `artifacts/manifests/layer1/{run_id}.json`
- Report path(s):
  - `artifacts/reports/integration/layer0_archive_validation_{from}_to_{to}.json`
  - `artifacts/reports/integration/layer1_archive_validation_{run_id}_{from}_to_{to}.json`
- R2 output prefix(es):
  - `raw/macro/{YYYY-MM-DD}.parquet`
- Known skipped/missing data:
  - No live provider calls were run during verification.
  - No production R2 writes or migrations were executed during verification.
