### PR TITLE
[Codex] Harden Layer 1.5 HMM regime features and readiness validation

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -1220,6 +1220,19 @@ def _expected_dates_by_ticker(
 
 def _validation_failure_summary(report: Layer1ValidationReport) -> str:
     """Return a compact operator-facing summary for one failed validation report."""
+    if report.regime_failures:
+        sample = report.regime_failures[0]
+        date_text = sample.get("date")
+        reason = sample.get("reason")
+        ticker = sample.get("ticker")
+        location = f"{ticker}/{date_text}" if ticker else str(date_text)
+        return f"regime validation failed at {location}: {reason}"
+    if report.regime_warnings:
+        sample = report.regime_warnings[0]
+        return (
+            f"regime warm-up warning on {sample.get('date')}: "
+            f"{sample.get('reason')}"
+        )
     if report.missing_ticker_files:
         return (
             f"{len(report.missing_ticker_files)} ticker histories missing; "

--- a/app/lab/data_pipelines/run_hmm_regime_detection.py
+++ b/app/lab/data_pipelines/run_hmm_regime_detection.py
@@ -17,9 +17,12 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol
+from typing import TYPE_CHECKING, Protocol
 
 from loguru import logger
+
+if TYPE_CHECKING:
+    import pandas as pd
 
 
 def _resolve_repo_root() -> Path:
@@ -39,6 +42,7 @@ from core.features.loaders import load_macro_frame, load_ohlcv_frame  # noqa: E4
 from core.features.regime_detection import (  # noqa: E402
     HMM_REGIME_COLUMNS,
     HMMRegimeConfig,
+    HMMRegimeReadiness,
     fit_and_emit_hmm_regime_features,
     inspect_hmm_regime_readiness,
     validate_hmm_regime_probabilities,
@@ -260,7 +264,7 @@ def load_modal_runtime_config(path: Path = MODAL_CONFIG_PATH) -> ModalRuntimeCon
     )
 
 
-def _empty_regime_frame(inference_dates: Sequence[str]):
+def _empty_regime_frame(inference_dates: Sequence[str]) -> pd.DataFrame:
     """Return one explicit null regime row for each requested inference date."""
     try:
         import pandas as pd
@@ -283,7 +287,11 @@ def _empty_regime_frame(inference_dates: Sequence[str]):
     return pd.DataFrame(rows, columns=list(HMM_REGIME_COLUMNS))
 
 
-def _with_regime_readiness_columns(frame, *, readiness) -> object:
+def _with_regime_readiness_columns(
+    frame: pd.DataFrame,
+    *,
+    readiness: HMMRegimeReadiness,
+) -> pd.DataFrame:
     """Annotate the regime artifact with per-date readiness diagnostics."""
     try:
         import pandas as pd

--- a/app/lab/data_pipelines/run_hmm_regime_detection.py
+++ b/app/lab/data_pipelines/run_hmm_regime_detection.py
@@ -37,8 +37,8 @@ sys.path.insert(0, str(_REPO_ROOT))
 from core.contracts.schemas import PipelineManifestRecord, RunStatus  # noqa: E402
 from core.features.loaders import load_macro_frame, load_ohlcv_frame  # noqa: E402
 from core.features.regime_detection import (  # noqa: E402
-    HMMRegimeConfig,
     HMM_REGIME_COLUMNS,
+    HMMRegimeConfig,
     fit_and_emit_hmm_regime_features,
     inspect_hmm_regime_readiness,
     validate_hmm_regime_probabilities,

--- a/app/lab/data_pipelines/run_hmm_regime_detection.py
+++ b/app/lab/data_pipelines/run_hmm_regime_detection.py
@@ -10,6 +10,7 @@ import argparse
 import importlib
 import io
 import json
+import math
 import os
 import sys
 from collections.abc import Sequence
@@ -37,7 +38,10 @@ from core.contracts.schemas import PipelineManifestRecord, RunStatus  # noqa: E4
 from core.features.loaders import load_macro_frame, load_ohlcv_frame  # noqa: E402
 from core.features.regime_detection import (  # noqa: E402
     HMMRegimeConfig,
+    HMM_REGIME_COLUMNS,
     fit_and_emit_hmm_regime_features,
+    inspect_hmm_regime_readiness,
+    validate_hmm_regime_probabilities,
 )
 from core.features.regime_training import build_hmm_training_frame  # noqa: E402
 from services.r2.paths import build_r2_key, pipeline_manifest_path, raw_price_path  # noqa: E402
@@ -152,22 +156,57 @@ def run_hmm_regime_detection(
         benchmark = load_ohlcv_frame(config.benchmark_ticker, writer=active_writer)  # type: ignore[arg-type]
         macro = load_macro_frame(writer=active_writer)  # type: ignore[arg-type]
         training_frame = build_hmm_training_frame(benchmark, macro)
-        regime_frame = fit_and_emit_hmm_regime_features(
+        hmm_config = HMMRegimeConfig(
+            max_iterations=config.max_iterations,
+            min_training_rows=config.min_training_rows,
+        )
+        readiness = inspect_hmm_regime_readiness(
             training_frame,
             train_start_date=config.train_start_date,
             train_end_date=config.train_end_date,
             inference_dates=list(config.inference_dates) or None,
-            config=HMMRegimeConfig(
-                max_iterations=config.max_iterations,
-                min_training_rows=config.min_training_rows,
-            ),
+            config=hmm_config,
         )
+        if readiness.can_fit_model:
+            regime_frame = fit_and_emit_hmm_regime_features(
+                training_frame,
+                train_start_date=config.train_start_date,
+                train_end_date=config.train_end_date,
+                inference_dates=list(config.inference_dates) or None,
+                config=hmm_config,
+            )
+        else:
+            regime_frame = _empty_regime_frame(readiness.inference_dates)
+        regime_frame = _with_regime_readiness_columns(regime_frame, readiness=readiness)
+        probability_errors = validate_hmm_regime_probabilities(regime_frame)
+        if probability_errors:
+            raise ValueError(
+                "Invalid HMM regime probabilities emitted: "
+                + "; ".join(probability_errors[:5])
+            )
         active_writer.put_object(output_key, _frame_to_parquet_bytes(regime_frame))
-        complete_training_rows = int(training_frame["is_complete"].astype(bool).sum())
         metadata.update(
             {
-                "training_rows": len(training_frame),
-                "complete_training_rows": complete_training_rows,
+                "training_rows": readiness.training_rows,
+                "complete_training_rows": readiness.complete_training_rows,
+                "dropped_feature_columns": list(readiness.dropped_feature_columns),
+                "ready_inference_dates": list(readiness.complete_inference_dates),
+                "inference_feature_gaps": {
+                    date_text: list(columns)
+                    for date_text, columns in sorted(
+                        readiness.incomplete_inference_feature_gaps.items()
+                    )
+                },
+                "warning_inference_dates": [
+                    date_text
+                    for date_text in readiness.inference_dates
+                    if (not readiness.can_fit_model)
+                    or date_text in readiness.incomplete_inference_feature_gaps
+                ],
+                "regime_layer2_ready": bool(
+                    readiness.can_fit_model
+                    and len(readiness.complete_inference_dates) == len(readiness.inference_dates)
+                ),
                 "regime_rows": len(regime_frame),
             }
         )
@@ -185,8 +224,8 @@ def run_hmm_regime_detection(
             run_id=config.run_id,
             output_key=output_key,
             manifest_key=manifest_key,
-            training_rows=len(training_frame),
-            complete_training_rows=complete_training_rows,
+            training_rows=readiness.training_rows,
+            complete_training_rows=readiness.complete_training_rows,
             regime_rows=len(regime_frame),
         )
     except Exception as exc:
@@ -219,6 +258,77 @@ def load_modal_runtime_config(path: Path = MODAL_CONFIG_PATH) -> ModalRuntimeCon
         python_version=str(payload.get("python_version", "3.11")),
         requirements_path=str(payload.get("requirements_path", "requirements/modal.txt")),
     )
+
+
+def _empty_regime_frame(inference_dates: Sequence[str]):
+    """Return one explicit null regime row for each requested inference date."""
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to write HMM regime outputs."
+        ) from exc
+
+    rows = [
+        {
+            "date": date_text,
+            "regime_label": None,
+            "regime_confidence": math.nan,
+            "regime_prob_bear": math.nan,
+            "regime_prob_sideways": math.nan,
+            "regime_prob_bull": math.nan,
+        }
+        for date_text in inference_dates
+    ]
+    return pd.DataFrame(rows, columns=list(HMM_REGIME_COLUMNS))
+
+
+def _with_regime_readiness_columns(frame, *, readiness) -> object:
+    """Annotate the regime artifact with per-date readiness diagnostics."""
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to write HMM regime outputs."
+        ) from exc
+    if not isinstance(frame, pd.DataFrame):
+        raise TypeError("frame must be a pandas DataFrame")
+
+    annotated = frame.copy()
+    annotated["regime_required_for_layer2"] = False
+    annotated["regime_readiness_status"] = "warning"
+    annotated["regime_readiness_reason"] = "insufficient_training_history"
+    annotated["regime_missing_features"] = ""
+    annotated["regime_probability_sum"] = math.nan
+    annotated["training_rows"] = readiness.training_rows
+    annotated["complete_training_rows"] = readiness.complete_training_rows
+    annotated["min_training_rows"] = readiness.min_training_rows
+
+    for index, row in annotated.iterrows():
+        date_text = str(row["date"])
+        missing_features = readiness.incomplete_inference_feature_gaps.get(date_text, ())
+        if not readiness.can_fit_model:
+            reason = "insufficient_training_history"
+        elif missing_features:
+            reason = "incomplete_inference_features"
+        else:
+            reason = "ready"
+        annotated.loc[index, "regime_readiness_reason"] = reason
+        annotated.loc[index, "regime_missing_features"] = ",".join(missing_features)
+        if reason == "ready":
+            annotated.loc[index, "regime_required_for_layer2"] = True
+            annotated.loc[index, "regime_readiness_status"] = "ready"
+        else:
+            annotated.loc[index, "regime_required_for_layer2"] = False
+            annotated.loc[index, "regime_readiness_status"] = "warning"
+        probability_values = [
+            row.get("regime_prob_bear"),
+            row.get("regime_prob_sideways"),
+            row.get("regime_prob_bull"),
+        ]
+        if all(value is not None and not pd.isna(value) for value in probability_values):
+            annotated.loc[index, "regime_probability_sum"] = float(sum(probability_values))
+    return annotated
 
 
 def _frame_to_parquet_bytes(frame: object) -> bytes:

--- a/app/lab/data_pipelines/validate_layer1_archive.py
+++ b/app/lab/data_pipelines/validate_layer1_archive.py
@@ -21,6 +21,7 @@ import argparse
 import csv
 import io
 import json
+import math
 import os
 import random
 import re
@@ -316,9 +317,18 @@ def validate_layer1_archive(
         )
     if manifest_state.manifest_errors:
         ready = False
-    validation_status = "completed" if ready else "failed"
-    if not ready and not missing and not schema_failures and not row_count_failures and not manifest_state.manifest_errors and not any(check["status"] == "fail" for check in leakage_spot_checks) and regime_warnings and not regime_failures:
-        validation_status = "warning"
+    has_leakage_failures = any(check["status"] == "fail" for check in leakage_spot_checks)
+    only_regime_warnings = (
+        not ready
+        and not missing
+        and not schema_failures
+        and not row_count_failures
+        and not manifest_state.manifest_errors
+        and not has_leakage_failures
+        and bool(regime_warnings)
+        and not regime_failures
+    )
+    validation_status = "completed" if ready else ("warning" if only_regime_warnings else "failed")
     return Layer1ValidationReport(
         run_id=run_id,
         from_date=from_date,
@@ -815,13 +825,12 @@ def _load_regime_diagnostic(
     if "regime_required_for_layer2" not in row:
         required_for_layer2 = _row_has_populated_regime_values(row)
     missing_features = _split_csv_values(row.get("regime_missing_features"))
+    default_status = "ready" if required_for_layer2 else "warning"
+    default_reason = "ready" if required_for_layer2 else "legacy_missing_diagnostics"
     diagnostic.update(
         {
-            "status": str(row.get("regime_readiness_status") or ("ready" if required_for_layer2 else "warning")),
-            "reason": str(
-                row.get("regime_readiness_reason")
-                or ("ready" if required_for_layer2 else "legacy_missing_diagnostics")
-            ),
+            "status": str(row.get("regime_readiness_status") or default_status),
+            "reason": str(row.get("regime_readiness_reason") or default_reason),
             "required_for_layer2": required_for_layer2,
             "missing_features": missing_features,
             "complete_training_rows": _safe_int(row.get("complete_training_rows")),
@@ -913,10 +922,12 @@ def _row_has_populated_regime_values(row: Mapping[str, object]) -> bool:
 
 def _normalize_optional_value(value: object) -> object | None:
     """Normalize common null-like feature values to None."""
+    if value is None:
+        return None
     numeric = _safe_float(value)
     if numeric is not None:
-        return numeric
-    if value is None:
+        return numeric if math.isfinite(numeric) else None
+    if isinstance(value, float) and not math.isfinite(value):
         return None
     normalized = str(value).strip()
     return normalized or None

--- a/app/lab/data_pipelines/validate_layer1_archive.py
+++ b/app/lab/data_pipelines/validate_layer1_archive.py
@@ -47,6 +47,12 @@ _REPO_ROOT = _resolve_repo_root()
 sys.path.insert(0, str(_REPO_ROOT))
 
 from core.features.io import parquet_bytes_to_feature_records  # noqa: E402
+from core.features.regime_detection import (  # noqa: E402
+    HMM_REGIME_COLUMNS,
+    REGIME_LABELS,
+    REGIME_PROBABILITY_COLUMNS,
+    REGIME_PROBABILITY_SUM_TOLERANCE,
+)
 from services.r2.paths import (  # noqa: E402
     layer1_feature_path,
     layer1_news_preprocessing_path,
@@ -115,6 +121,12 @@ class Layer1ValidationReport:
     skipped_dates: list[dict[str, object]] = field(default_factory=list)
     output_prefixes: dict[str, str] = field(default_factory=dict)
     leakage_spot_checks: list[dict[str, object]] = field(default_factory=list)
+    regime_validation_status: str = "not_checked"
+    layer2_regime_required_dates: list[str] = field(default_factory=list)
+    layer2_regime_optional_dates: list[str] = field(default_factory=list)
+    regime_diagnostics_by_date: dict[str, dict[str, object]] = field(default_factory=dict)
+    regime_failures: list[dict[str, object]] = field(default_factory=list)
+    regime_warnings: list[dict[str, object]] = field(default_factory=list)
     ready_for_layer2: bool = False
 
     def to_dict(self) -> dict:
@@ -173,6 +185,7 @@ def validate_layer1_archive(
     foreign_ticker_rows: dict[str, list[str]] = {}
     skipped_tickers: list[dict[str, object]] = []
     skipped_dates: list[dict[str, object]] = []
+    feature_rows_by_ticker_date: dict[tuple[str, str], FeatureRecord] = {}
 
     for ticker, expected_dates in sorted(expected_dates_by_ticker.items()):
         key = layer1_ticker_history_path(ticker)
@@ -222,6 +235,7 @@ def validate_layer1_archive(
             if record.date in expected_dates:
                 ticker_dates.append(record.date)
                 date_counts[record.date] = date_counts.get(record.date, 0) + 1
+                feature_rows_by_ticker_date.setdefault((ticker, record.date), record)
 
         actual_dates = set(ticker_dates)
         missing_dates = sorted(expected_dates - actual_dates)
@@ -277,6 +291,21 @@ def validate_layer1_archive(
     )
     if any(check["status"] == "fail" for check in leakage_spot_checks):
         ready = False
+    (
+        regime_status,
+        layer2_regime_required_dates,
+        layer2_regime_optional_dates,
+        regime_diagnostics_by_date,
+        regime_failures,
+        regime_warnings,
+    ) = _validate_regime_handoff(
+        run_id=run_id,
+        universe=universe,
+        feature_rows_by_ticker_date=feature_rows_by_ticker_date,
+        reader=reader,
+    )
+    if regime_failures or regime_warnings:
+        ready = False
     manifest_state = _empty_manifest_inspection()
     if require_completed_manifest or inspect_related_manifests:
         manifest_state = _inspect_layer1_manifests(
@@ -286,11 +315,14 @@ def validate_layer1_archive(
         )
     if manifest_state.manifest_errors:
         ready = False
+    validation_status = "completed" if ready else "failed"
+    if not ready and not missing and not schema_failures and not row_count_failures and not manifest_state.manifest_errors and not any(check["status"] == "fail" for check in leakage_spot_checks) and regime_warnings and not regime_failures:
+        validation_status = "warning"
     return Layer1ValidationReport(
         run_id=run_id,
         from_date=from_date,
         to_date=to_date,
-        validation_status="completed" if ready else "failed",
+        validation_status=validation_status,
         expected_ticker_files=expected_files,
         present_ticker_files=present_files,
         expected_rows=expected_rows,
@@ -318,6 +350,12 @@ def validate_layer1_archive(
         skipped_dates=skipped_dates,
         output_prefixes=dict(output_prefixes or {}),
         leakage_spot_checks=leakage_spot_checks,
+        regime_validation_status=regime_status,
+        layer2_regime_required_dates=layer2_regime_required_dates,
+        layer2_regime_optional_dates=layer2_regime_optional_dates,
+        regime_diagnostics_by_date=regime_diagnostics_by_date,
+        regime_failures=regime_failures,
+        regime_warnings=regime_warnings,
         ready_for_layer2=ready,
     )
 
@@ -579,6 +617,336 @@ def _build_leakage_spot_checks(
             "failures": failures,
         }
     ]
+
+
+def _validate_regime_handoff(
+    *,
+    run_id: str,
+    universe: Mapping[str, Sequence[str]],
+    feature_rows_by_ticker_date: Mapping[tuple[str, str], FeatureRecord],
+    reader: ArchiveReader,
+) -> tuple[
+    str,
+    list[str],
+    list[str],
+    dict[str, dict[str, object]],
+    list[dict[str, object]],
+    list[dict[str, object]],
+]:
+    """Validate Layer 1 regime completeness against Layer 1.5 diagnostics."""
+    if not _has_regime_validation_evidence(
+        run_id=run_id,
+        universe=universe,
+        feature_rows_by_ticker_date=feature_rows_by_ticker_date,
+        reader=reader,
+    ):
+        return ("not_checked", [], [], {}, [], [])
+    diagnostics_by_date: dict[str, dict[str, object]] = {}
+    regime_failures: list[dict[str, object]] = []
+    regime_warnings: list[dict[str, object]] = []
+    required_dates: list[str] = []
+    optional_dates: list[str] = []
+
+    for date_text, tickers in sorted(universe.items()):
+        diagnostic = _load_regime_diagnostic(run_id=run_id, date_text=date_text, reader=reader)
+        diagnostics_by_date[date_text] = diagnostic
+        if bool(diagnostic.get("required_for_layer2")):
+            required_dates.append(date_text)
+        else:
+            optional_dates.append(date_text)
+        if diagnostic["status"] == "failure":
+            regime_failures.append(diagnostic)
+            continue
+
+        explicit_null_tickers: list[str] = []
+        for ticker in sorted({_normalize_ticker(value) for value in tickers}):
+            record = feature_rows_by_ticker_date.get((ticker, date_text))
+            if record is None:
+                continue
+            presence = _inspect_regime_feature_presence(record.features)
+            if diagnostic["status"] == "ready":
+                if presence["state"] != "full":
+                    regime_failures.append(
+                        {
+                            "date": date_text,
+                            "ticker": ticker,
+                            "status": "failure",
+                            "reason": "required_regime_fields_missing",
+                            "required_for_layer2": True,
+                            "missing_keys": presence["missing_keys"],
+                        }
+                    )
+                    continue
+                value_errors = _regime_value_errors(
+                    date_text=date_text,
+                    ticker=ticker,
+                    features=record.features,
+                )
+                if value_errors:
+                    regime_failures.append(
+                        {
+                            "date": date_text,
+                            "ticker": ticker,
+                            "status": "failure",
+                            "reason": "invalid_regime_values",
+                            "required_for_layer2": True,
+                            "errors": value_errors,
+                        }
+                    )
+            else:
+                if presence["missing_keys"]:
+                    regime_failures.append(
+                        {
+                            "date": date_text,
+                            "ticker": ticker,
+                            "status": "failure",
+                            "reason": "regime_placeholder_keys_missing",
+                            "required_for_layer2": False,
+                            "missing_keys": presence["missing_keys"],
+                        }
+                    )
+                    continue
+                if presence["state"] == "partial":
+                    regime_failures.append(
+                        {
+                            "date": date_text,
+                            "ticker": ticker,
+                            "status": "failure",
+                            "reason": "regime_warning_rows_must_use_explicit_nulls",
+                            "required_for_layer2": False,
+                        }
+                    )
+                    continue
+                if presence["state"] == "full":
+                    regime_failures.append(
+                        {
+                            "date": date_text,
+                            "ticker": ticker,
+                            "status": "failure",
+                            "reason": "regime_row_conflicts_with_warning_diagnostic",
+                            "required_for_layer2": False,
+                        }
+                    )
+                    continue
+                explicit_null_tickers.append(ticker)
+        if diagnostic["status"] == "warning" and explicit_null_tickers:
+            regime_warnings.append(
+                {
+                    "date": date_text,
+                    "status": "warning",
+                    "reason": diagnostic.get("reason"),
+                    "required_for_layer2": False,
+                    "ticker_count": len(explicit_null_tickers),
+                    "tickers": explicit_null_tickers[:20],
+                    "complete_training_rows": diagnostic.get("complete_training_rows"),
+                    "min_training_rows": diagnostic.get("min_training_rows"),
+                    "missing_features": diagnostic.get("missing_features"),
+                }
+            )
+
+    status = "completed"
+    if regime_failures:
+        status = "failed"
+    elif regime_warnings:
+        status = "warning"
+    return (
+        status,
+        required_dates,
+        optional_dates,
+        diagnostics_by_date,
+        regime_failures,
+        regime_warnings,
+    )
+
+
+def _has_regime_validation_evidence(
+    *,
+    run_id: str,
+    universe: Mapping[str, Sequence[str]],
+    feature_rows_by_ticker_date: Mapping[tuple[str, str], FeatureRecord],
+    reader: ArchiveReader,
+) -> bool:
+    """Return True when the archive contains regime artifacts or regime feature keys."""
+    for record in feature_rows_by_ticker_date.values():
+        if any(name in record.features for name in HMM_REGIME_COLUMNS[1:]):
+            return True
+    for date_text in universe:
+        if reader.exists(layer1_regime_path(f"{run_id}-{date_text}")):
+            return True
+    return False
+
+
+def _load_regime_diagnostic(
+    *,
+    run_id: str,
+    date_text: str,
+    reader: ArchiveReader,
+) -> dict[str, object]:
+    """Load one Layer 1.5 regime artifact row and normalize its readiness diagnostics."""
+    stage_run_id = f"{run_id}-{date_text}"
+    output_key = layer1_regime_path(stage_run_id)
+    manifest_key = pipeline_manifest_path("layer1_5_regime", stage_run_id)
+    diagnostic: dict[str, object] = {
+        "date": date_text,
+        "status": "failure",
+        "reason": "missing_regime_output",
+        "required_for_layer2": False,
+        "output_key": output_key,
+        "manifest_key": manifest_key,
+    }
+    if not reader.exists(output_key):
+        return diagnostic
+
+    frame = _read_parquet_frame(reader.get_object(output_key))
+    missing = sorted(set(HMM_REGIME_COLUMNS) - set(frame.columns))
+    if missing:
+        diagnostic["reason"] = "regime_output_missing_columns"
+        diagnostic["missing_columns"] = missing
+        return diagnostic
+    rows = frame[frame["date"].astype(str) == date_text].reset_index(drop=True)
+    if len(rows) != 1:
+        diagnostic["reason"] = "regime_output_row_count_mismatch"
+        diagnostic["row_count"] = len(rows)
+        return diagnostic
+
+    row = rows.iloc[0].to_dict()
+    required_for_layer2 = bool(row.get("regime_required_for_layer2"))
+    if "regime_required_for_layer2" not in row:
+        required_for_layer2 = _row_has_populated_regime_values(row)
+    missing_features = _split_csv_values(row.get("regime_missing_features"))
+    diagnostic.update(
+        {
+            "status": str(row.get("regime_readiness_status") or ("ready" if required_for_layer2 else "warning")),
+            "reason": str(
+                row.get("regime_readiness_reason")
+                or ("ready" if required_for_layer2 else "legacy_missing_diagnostics")
+            ),
+            "required_for_layer2": required_for_layer2,
+            "missing_features": missing_features,
+            "complete_training_rows": _safe_int(row.get("complete_training_rows")),
+            "min_training_rows": _safe_int(row.get("min_training_rows")),
+            "probability_sum": _safe_float(row.get("regime_probability_sum")),
+        }
+    )
+    if required_for_layer2 and not _row_has_populated_regime_values(row):
+        diagnostic["status"] = "failure"
+        diagnostic["reason"] = "required_regime_output_is_null"
+    return diagnostic
+
+
+def _inspect_regime_feature_presence(features: Mapping[str, object]) -> dict[str, object]:
+    """Summarize whether the expected regime keys are present and null/non-null."""
+    missing_keys = [
+        name for name in HMM_REGIME_COLUMNS[1:] if name not in features
+    ]
+    values = [features.get(name) for name in HMM_REGIME_COLUMNS[1:]]
+    populated = [_normalize_optional_value(value) is not None for value in values]
+    if missing_keys:
+        state = "missing"
+    elif all(populated):
+        state = "full"
+    elif not any(populated):
+        state = "none"
+    else:
+        state = "partial"
+    return {"state": state, "missing_keys": missing_keys}
+
+
+def _regime_value_errors(
+    *,
+    date_text: str,
+    ticker: str,
+    features: Mapping[str, object],
+) -> list[str]:
+    """Return validation errors for one fully populated ticker-day regime feature set."""
+    errors: list[str] = []
+    label = str(features.get("regime_label")).strip().lower()
+    if label not in REGIME_LABELS:
+        errors.append(f"{ticker}/{date_text}: invalid regime_label={label!r}")
+        return errors
+    confidence = _safe_float(features.get("regime_confidence"))
+    probabilities = {
+        label_name: _safe_float(features.get(column_name))
+        for label_name, column_name in zip(REGIME_LABELS, REGIME_PROBABILITY_COLUMNS, strict=True)
+    }
+    if confidence is None or any(value is None for value in probabilities.values()):
+        errors.append(f"{ticker}/{date_text}: regime fields must be populated together")
+        return errors
+    if confidence < 0.0 or confidence > 1.0:
+        errors.append(f"{ticker}/{date_text}: regime_confidence out of range")
+    if any(value < 0.0 or value > 1.0 for value in probabilities.values()):
+        errors.append(f"{ticker}/{date_text}: regime probabilities out of range")
+    probability_sum = sum(probabilities.values())
+    if abs(probability_sum - 1.0) > REGIME_PROBABILITY_SUM_TOLERANCE:
+        errors.append(
+            f"{ticker}/{date_text}: regime probabilities sum to {probability_sum:.6f}"
+        )
+    max_label = max(probabilities, key=probabilities.get)
+    if label != max_label:
+        errors.append(
+            f"{ticker}/{date_text}: regime_label={label!r} does not match max probability"
+        )
+    if abs(confidence - probabilities[label]) > REGIME_PROBABILITY_SUM_TOLERANCE:
+        errors.append(
+            f"{ticker}/{date_text}: regime_confidence does not match regime_prob_{label}"
+        )
+    return errors
+
+
+def _read_parquet_frame(payload: bytes):
+    """Read a parquet payload into a pandas DataFrame."""
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to read Layer 1 parquet payloads."
+        ) from exc
+    return pd.read_parquet(io.BytesIO(payload))
+
+
+def _row_has_populated_regime_values(row: Mapping[str, object]) -> bool:
+    """Return True when a regime artifact row is fully populated."""
+    values = [_normalize_optional_value(row.get(name)) for name in HMM_REGIME_COLUMNS[1:]]
+    return all(value is not None for value in values)
+
+
+def _normalize_optional_value(value: object) -> object | None:
+    """Normalize common null-like feature values to None."""
+    numeric = _safe_float(value)
+    if numeric is not None:
+        return numeric
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _safe_float(value: object) -> float | None:
+    """Return a finite float or None when the value is null-like."""
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if numeric != numeric:
+        return None
+    return numeric
+
+
+def _safe_int(value: object) -> int | None:
+    """Return an integer when coercion is lossless enough for diagnostics."""
+    numeric = _safe_float(value)
+    if numeric is None:
+        return None
+    return int(numeric)
+
+
+def _split_csv_values(value: object) -> list[str]:
+    """Return a normalized list from a comma-delimited diagnostic string."""
+    if value is None:
+        return []
+    return [item for item in str(value).split(",") if item]
 
 
 def _inspect_layer1_manifests(

--- a/app/lab/data_pipelines/validate_layer1_archive.py
+++ b/app/lab/data_pipelines/validate_layer1_archive.py
@@ -46,6 +46,7 @@ def _resolve_repo_root() -> Path:
 _REPO_ROOT = _resolve_repo_root()
 sys.path.insert(0, str(_REPO_ROOT))
 
+from core.contracts.schemas import FeatureRecord  # noqa: E402
 from core.features.io import parquet_bytes_to_feature_records  # noqa: E402
 from core.features.regime_detection import (  # noqa: E402
     HMM_REGIME_COLUMNS,

--- a/core/features/regime_detection.py
+++ b/core/features/regime_detection.py
@@ -14,14 +14,18 @@ if TYPE_CHECKING:
     import pandas as pd
 
 REGIME_LABELS: tuple[str, str, str] = ("bear", "sideways", "bull")
-HMM_REGIME_FEATURE_COLUMNS: tuple[str, ...] = (
-    "regime_label",
-    "regime_confidence",
+REGIME_PROBABILITY_COLUMNS: tuple[str, ...] = (
     "regime_prob_bear",
     "regime_prob_sideways",
     "regime_prob_bull",
 )
+HMM_REGIME_FEATURE_COLUMNS: tuple[str, ...] = (
+    "regime_label",
+    "regime_confidence",
+    *REGIME_PROBABILITY_COLUMNS,
+)
 HMM_REGIME_COLUMNS: tuple[str, ...] = ("date", *HMM_REGIME_FEATURE_COLUMNS)
+REGIME_PROBABILITY_SUM_TOLERANCE = 1e-4
 
 
 @dataclass(frozen=True)
@@ -67,6 +71,35 @@ class HMMRegimeModel:
     label_by_state: tuple[str, ...]
     log_likelihood: float
     iterations: int
+
+
+@dataclass(frozen=True)
+class HMMRegimeReadiness:
+    """Readiness summary for one bounded HMM training/inference window."""
+
+    feature_columns: tuple[str, ...]
+    dropped_feature_columns: tuple[str, ...]
+    training_rows: int
+    complete_training_rows: int
+    min_training_rows: int
+    inference_dates: tuple[str, ...]
+    complete_inference_dates: tuple[str, ...]
+    incomplete_inference_feature_gaps: dict[str, tuple[str, ...]]
+
+    @property
+    def has_active_feature_columns(self) -> bool:
+        """Return True when the bounded training window exposes usable features."""
+        return bool(self.feature_columns)
+
+    @property
+    def has_sufficient_training_rows(self) -> bool:
+        """Return True when the bounded train window has enough complete rows."""
+        return self.complete_training_rows >= self.min_training_rows
+
+    @property
+    def can_fit_model(self) -> bool:
+        """Return True when the HMM can be fit for this bounded window."""
+        return self.has_active_feature_columns and self.has_sufficient_training_rows
 
 
 def fit_hmm_regime_model(
@@ -118,6 +151,77 @@ def fit_hmm_regime_model(
         label_by_state=labels,
         log_likelihood=float(parameters["log_likelihood"]),
         iterations=int(parameters["iterations"]),
+    )
+
+
+def inspect_hmm_regime_readiness(
+    training_frame: pd.DataFrame,
+    *,
+    train_end_date: str,
+    inference_dates: list[str] | None = None,
+    train_start_date: str | None = None,
+    config: HMMRegimeConfig | None = None,
+    feature_columns: tuple[str, ...] = HMM_TRAINING_FEATURE_COLUMNS,
+) -> HMMRegimeReadiness:
+    """Inspect whether a bounded HMM window can emit non-null regime features."""
+    pd = _require_pandas()
+    active_config = config or HMMRegimeConfig()
+    _validate_training_frame(training_frame, feature_columns)
+    active_feature_columns = _active_feature_columns(
+        training_frame,
+        feature_columns=feature_columns,
+        train_start_date=train_start_date,
+        train_end_date=train_end_date,
+    )
+    dropped_feature_columns = tuple(
+        column for column in feature_columns if column not in active_feature_columns
+    )
+    bounded_rows = _bounded_rows(
+        training_frame,
+        train_start_date=train_start_date,
+        train_end_date=train_end_date,
+    )
+    complete_rows = (
+        bounded_rows[_complete_row_mask(bounded_rows, active_feature_columns)]
+        if active_feature_columns
+        else bounded_rows.iloc[0:0].copy()
+    )
+    infer_rows = _requested_inference_rows(
+        training_frame,
+        train_end_date=train_end_date,
+        inference_dates=inference_dates,
+    )
+    incomplete_inference_feature_gaps: dict[str, tuple[str, ...]] = {}
+    complete_inference_dates: list[str] = []
+    if len(infer_rows) > 0:
+        numeric = (
+            infer_rows.loc[:, list(active_feature_columns)].apply(pd.to_numeric, errors="coerce")
+            if active_feature_columns
+            else pd.DataFrame(index=infer_rows.index)
+        )
+        for row_index, row in infer_rows.reset_index(drop=True).iterrows():
+            date_text = str(row["date"])
+            if not active_feature_columns:
+                incomplete_inference_feature_gaps[date_text] = tuple(feature_columns)
+                continue
+            missing = tuple(
+                column
+                for column in active_feature_columns
+                if pd.isna(numeric.iloc[row_index][column])
+            )
+            if missing:
+                incomplete_inference_feature_gaps[date_text] = missing
+            else:
+                complete_inference_dates.append(date_text)
+    return HMMRegimeReadiness(
+        feature_columns=active_feature_columns,
+        dropped_feature_columns=dropped_feature_columns,
+        training_rows=len(bounded_rows),
+        complete_training_rows=len(complete_rows),
+        min_training_rows=active_config.min_training_rows,
+        inference_dates=tuple(str(value) for value in infer_rows["date"].tolist()),
+        complete_inference_dates=tuple(complete_inference_dates),
+        incomplete_inference_feature_gaps=incomplete_inference_feature_gaps,
     )
 
 
@@ -200,6 +304,59 @@ def regime_features_to_records(features: pd.DataFrame) -> list[FeatureRecord]:
             )
         )
     return records
+
+
+def validate_hmm_regime_probabilities(
+    features: pd.DataFrame,
+    *,
+    tolerance: float = REGIME_PROBABILITY_SUM_TOLERANCE,
+) -> list[str]:
+    """Return validation errors for populated HMM regime rows."""
+    _validate_regime_feature_frame(features)
+    errors: list[str] = []
+    for row in features.to_dict(orient="records"):
+        date_text = str(row["date"])
+        label = _normalize_optional_string(row.get("regime_label"))
+        confidence = _normalize_optional_float(row.get("regime_confidence"))
+        probabilities = {
+            label_name: _normalize_optional_float(row.get(column_name))
+            for label_name, column_name in zip(
+                REGIME_LABELS,
+                REGIME_PROBABILITY_COLUMNS,
+                strict=True,
+            )
+        }
+        present_count = sum(
+            value is not None for value in (label, confidence, *probabilities.values())
+        )
+        if present_count == 0:
+            continue
+        if present_count != len(HMM_REGIME_FEATURE_COLUMNS):
+            errors.append(f"{date_text}: partially populated regime fields")
+            continue
+        if label not in REGIME_LABELS:
+            errors.append(f"{date_text}: invalid regime label {label!r}")
+            continue
+        if confidence is None or any(value is None for value in probabilities.values()):
+            errors.append(f"{date_text}: regime fields must be fully populated or fully null")
+            continue
+        if confidence < 0.0 or confidence > 1.0:
+            errors.append(f"{date_text}: regime_confidence out of range")
+        if any(value < 0.0 or value > 1.0 for value in probabilities.values()):
+            errors.append(f"{date_text}: regime probabilities out of range")
+        probability_sum = sum(probabilities.values())
+        if abs(probability_sum - 1.0) > tolerance:
+            errors.append(f"{date_text}: regime probabilities sum to {probability_sum:.6f}")
+        max_label = max(probabilities, key=probabilities.get)
+        if label != max_label:
+            errors.append(
+                f"{date_text}: regime_label={label!r} does not match max probability {max_label!r}"
+            )
+        if abs(confidence - probabilities[label]) > tolerance:
+            errors.append(
+                f"{date_text}: regime_confidence does not match regime_prob_{label}"
+            )
+    return errors
 
 
 def _fit_gaussian_hmm(
@@ -465,6 +622,20 @@ def _bounded_complete_rows(
     return rows.sort_values("date").reset_index(drop=True)
 
 
+def _bounded_rows(
+    training_frame: pd.DataFrame,
+    *,
+    train_start_date: str | None,
+    train_end_date: str,
+) -> pd.DataFrame:
+    """Return all bounded training rows before completeness filtering."""
+    rows = training_frame.copy()
+    if train_start_date is not None:
+        rows = rows[rows["date"] >= train_start_date]
+    rows = rows[rows["date"] < train_end_date]
+    return rows.sort_values("date").reset_index(drop=True)
+
+
 def _active_feature_columns(
     training_frame: pd.DataFrame,
     *,
@@ -511,6 +682,28 @@ def _inference_rows(
     else:
         requested_dates = sorted(set(inference_dates))
         invalid = [date for date in requested_dates if date <= model.train_end_date]
+        if invalid:
+            raise ValueError(
+                "inference_dates must be strictly after train_end_date; "
+                f"invalid dates: {invalid}"
+            )
+        rows = rows[rows["date"].isin(requested_dates)]
+    return rows.sort_values("date").reset_index(drop=True)
+
+
+def _requested_inference_rows(
+    training_frame: pd.DataFrame,
+    *,
+    train_end_date: str,
+    inference_dates: list[str] | None,
+) -> pd.DataFrame:
+    """Return requested inference rows before a fitted HMM exists."""
+    rows = training_frame.copy()
+    if inference_dates is None:
+        rows = rows[rows["date"] > train_end_date]
+    else:
+        requested_dates = sorted(set(inference_dates))
+        invalid = [date for date in requested_dates if date <= train_end_date]
         if invalid:
             raise ValueError(
                 "inference_dates must be strictly after train_end_date; "

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -485,6 +485,13 @@ observations = [
 - Algorithm: Baum-Welch (Expectation-Maximization) — no manual labeling required
 - Read macro regime inputs such as Fed funds, CPI, and yield-curve measures from the
   Layer 0 FRED archive and market-state inputs such as SPY/VIX from the market data branch
+- HMM trainability is date-bounded. If the bounded train window has fewer than the minimum
+  complete rows, or if the target-date inference row is still incomplete because of rolling
+  warm-up, Layer 1.5 writes an explicit warning diagnostic plus null regime placeholders
+  instead of inventing a fallback label
+- When regime probabilities are populated, each probability must stay in `[0, 1]`, the
+  three probabilities must sum to `1.0` within tolerance `1e-4`, and
+  `regime_confidence` must equal the probability assigned to `regime_label`
 - **Lookahead bias:** never train HMM on full history and use its labels for backtesting.
   Correct approach: walk-forward (train on data up to T, label T, slide forward).
   Practical approximation: fit once on first few years, re-fit quarterly.
@@ -523,6 +530,12 @@ Use 5-day forward return as the prediction horizon. Test 1, 5, and 10 days and c
 **Regime-specific model architecture:**
 Train one XGBoost model per regime (bull, bear, sideways). At inference, the HMM identifies
 the current regime and the corresponding model is activated.
+
+Handoff rule:
+- Layer 2 may only consume a Layer 1 date when regime is fully populated and the Layer 1
+  readiness report says `ready_for_layer2=true`
+- During early-history warm-up, Layer 1 may still archive explicit null regime placeholders
+  for auditability, but that is a warning state, not a production-ready fallback path
 
 **Recommended XGBoost hyperparameters (starting point):**
 ```python

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -244,6 +244,16 @@ Input note:
 - historical backfills store FeatureRecord rows as one per-ticker Parquet history under
   `features/layer1/{ticker}.parquet`; daily incremental paths may still address a single
   `(date, ticker)` row through `features/layer1/{date}/{ticker}.parquet`
+- regime features (`regime_label`, `regime_confidence`, `regime_prob_bear`,
+  `regime_prob_sideways`, `regime_prob_bull`) follow a two-tier rule:
+  when the bounded HMM train window has enough complete history and the target-date
+  inference row is complete, those fields are required and must be non-null on every
+  validated Layer 1 row for that date; when the HMM is still in short-history warm-up,
+  Layer 1 may persist explicit null placeholders for those five keys, but the archive is
+  not `ready_for_layer2` until a later rerun fills them
+- populated regime probabilities must each lie in `[0.0, 1.0]` and must sum to `1.0`
+  within tolerance `1e-4`; `regime_confidence` must equal the probability of
+  `regime_label`
 
 Examples:
 - `returns_1d`
@@ -295,7 +305,8 @@ Interpretation:
   beta return forecast
 - `pos_prob`: calibrated probability of positive or relative outperformance
 - `rank_score`: normalized rank or cross-sectional ordering metric
-- `regime`: regime label used by the model
+- `regime`: regime label used by the model; consume this only when the upstream Layer 1
+  readiness report has `ready_for_layer2=true`
 - `confidence`: model or regime confidence
 - `model_version`: artifact/version that produced this score
 
@@ -306,6 +317,10 @@ Training note:
   cross-sectional rank. Raw forward returns may be tracked as diagnostics, but they should
   not become the primary target because they cause the model to learn market/sector beta
   instead of stock-specific alpha.
+- Layer 2 treats regime as required for production handoff, not optional. The only time
+  Layer 1 may archive explicit null regime placeholders is during HMM warm-up, and that
+  condition must surface as a readiness warning with `ready_for_layer2=false` rather than
+  silently routing a fallback model.
 
 ---
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -220,6 +220,10 @@ Operational notes for the readiness report:
 - The report records the authoritative manifest key/status plus sibling stale `running`
   manifests so operators can distinguish the successful run from interrupted attempts such as
   `...-v4` or `...-v6`.
+- The same report now distinguishes regime warm-up warnings from hard data-contract failures:
+  explicit null regime placeholders are acceptable only when Layer 1.5 diagnostics say the
+  bounded HMM window is still too short, and those warnings still keep
+  `ready_for_layer2=false` until a later rerun fills the regime fields.
 
 Operational notes for Layer 0 OHLCV provenance:
 - `python app/lab/data_pipelines/validate_layer0_archive.py ...` now fails closed when the

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -121,6 +121,10 @@ Execution chain:
    - Run final archive validation, persist the JSON report under
      `artifacts/reports/integration/layer1_archive_validation_{run_id}_{from}_to_{to}.json`,
      and return nonzero unless `ready_for_layer2=true`
+   - Validation distinguishes hard failures from regime warm-up warnings: explicit null
+     regime placeholders are allowed only when Layer 1.5 diagnostics show insufficient
+     bounded history, but that still leaves `ready_for_layer2=false` until a later rerun
+     produces non-null regime fields
    - Write `PipelineManifestRecord` (stage=layer1, statuses: running/completed/failed)
    - Modal runner entrypoints:
      `run_news_preprocessing.py`, `run_text_topics.py`, `run_finbert_sentiment.py`,
@@ -159,6 +163,10 @@ python app/lab/data_pipelines/validate_layer1_archive.py \
    - Run HMM to classify current regime (bull / bear / sideways)
    - Write market-wide regime probabilities to `features/layer1_5/regime/{run_id}.parquet`
    - Write `PipelineManifestRecord` (stage=layer1_5_regime)
+   - If the bounded HMM train window is too short or the inference row is still incomplete,
+     write explicit warning diagnostics plus null regime placeholders rather than failing
+     closed inside Layer 1.5 itself; the downstream Layer 1 validator then blocks Layer 2
+     handoff until a rerun has enough history
    - Layer 1 feature assembly broadcasts the regime label/probabilities onto ticker rows
 
 4. **Layer 2 inference** (Modal)

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -30,6 +30,7 @@ from app.lab.data_pipelines.validate_layer1_archive import Layer1ValidationRepor
 from core.contracts.schemas import PipelineManifestRecord, RunStatus
 from core.features.io import feature_records_to_parquet_bytes, read_feature_records
 from services.r2.paths import (
+    layer1_regime_path,
     layer1_sentiment_feature_path,
     layer1_validation_report_path,
     pipeline_manifest_path,
@@ -170,6 +171,78 @@ def test_run_daily_layer1_prefers_topic_sentence_count_when_sentiment_conflicts(
     assert result.ready_for_layer2 is True
     assert history[0].features["nlp_sentence_count"] == 1
     assert history[0].features["nlp_sentiment_score"] == pytest.approx(0.25)
+
+
+def test_run_daily_layer1_surfaces_regime_warmup_as_validation_warning(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Short-history regime diagnostics keep explicit nulls and fail Layer 2 readiness."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2024-01-03"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-regime-warmup",),
+    )
+
+    def warning_regime_runner(config, *, writer: R2Writer):
+        output_key = layer1_regime_path(config.run_id)
+        frame = pd.DataFrame(
+            [
+                {
+                    "date": config.inference_dates[0],
+                    "regime_label": None,
+                    "regime_confidence": float("nan"),
+                    "regime_prob_bear": float("nan"),
+                    "regime_prob_sideways": float("nan"),
+                    "regime_prob_bull": float("nan"),
+                    "regime_required_for_layer2": False,
+                    "regime_readiness_status": "warning",
+                    "regime_readiness_reason": "insufficient_training_history",
+                    "regime_missing_features": "",
+                    "regime_probability_sum": float("nan"),
+                    "training_rows": 15,
+                    "complete_training_rows": 15,
+                    "min_training_rows": 30,
+                }
+            ]
+        )
+        buffer = io.BytesIO()
+        frame.to_parquet(buffer, index=False)
+        writer.put_object(output_key, buffer.getvalue())
+        return daily_layer1_module.HMMRegimePipelineResult(
+            run_id=config.run_id,
+            output_key=output_key,
+            manifest_key=pipeline_manifest_path("layer1_5_regime", config.run_id),
+            training_rows=15,
+            complete_training_rows=15,
+            regime_rows=1,
+        )
+
+    with pytest.raises(Layer1ValidationError) as exc_info:
+        run_daily_layer1(
+            Layer1DailyConfig(
+                run_id="layer1-regime-warmup",
+                from_date="2024-01-03",
+                to_date="2024-01-03",
+            ),
+            writer=writer,
+            news_runner=fake_news_runner(writer, ["AAPL"]),
+            text_topic_runner=fake_topic_runner(writer, ["AAPL"]),
+            finbert_runner=fake_sentiment_runner(writer, ["AAPL"]),
+            regime_runner=warning_regime_runner,
+            validation_output_dir=tmp_path / "reports",
+            now=datetime(2024, 1, 4, 12, 0, tzinfo=UTC),
+        )
+
+    report = exc_info.value.report
+    history = read_feature_records("AAPL", writer=writer)
+
+    assert report.validation_status == "warning"
+    assert report.regime_warnings[0]["reason"] == "insufficient_training_history"
+    assert history[0].features["regime_label"] is None
+    assert history[0].features["regime_confidence"] is None
 
 
 def test_run_daily_layer1_computes_shared_macro_features_once(

--- a/tests/unit/test_hmm_regime_runner.py
+++ b/tests/unit/test_hmm_regime_runner.py
@@ -89,6 +89,39 @@ def test_run_hmm_regime_detection_writes_failure_manifest(
     assert manifest["metadata"]["error"]["type"] == "FileNotFoundError"
 
 
+def test_run_hmm_regime_detection_emits_warning_rows_for_short_history(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Short history writes explicit null regime rows instead of failing the stage."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    bars = _benchmark_bars(35)
+    macro = _macro_archive(60)
+    _write_parquet(writer, raw_price_path("SPY"), bars)
+    _write_parquet(writer, raw_macro_path("2023-01-02"), macro)
+
+    result = run_hmm_regime_detection(
+        HMMRegimePipelineConfig(
+            run_id="hmm-short-history",
+            train_end_date=str(bars.loc[20, "date"]),
+            inference_dates=(str(bars.loc[25, "date"]),),
+            min_training_rows=30,
+            max_iterations=20,
+        ),
+        writer=writer,
+    )
+
+    output = pd.read_parquet(io.BytesIO(writer.get_object(result.output_key)))
+    manifest = json.loads(writer.get_object(result.manifest_key))
+
+    assert output.loc[0, "regime_label"] is None or pd.isna(output.loc[0, "regime_label"])
+    assert pd.isna(output.loc[0, "regime_confidence"])
+    assert output.loc[0, "regime_readiness_status"] == "warning"
+    assert output.loc[0, "regime_readiness_reason"] == "insufficient_training_history"
+    assert manifest["status"] == RunStatus.COMPLETED
+    assert manifest["metadata"]["regime_layer2_ready"] is False
+
+
 def test_load_modal_runtime_config_reads_repo_config() -> None:
     """Modal app and secret names live in config rather than code constants."""
     config = load_modal_runtime_config()

--- a/tests/unit/test_regime_detection.py
+++ b/tests/unit/test_regime_detection.py
@@ -9,6 +9,8 @@ from core.features.regime_detection import (
     emit_hmm_regime_features,
     fit_and_emit_hmm_regime_features,
     fit_hmm_regime_model,
+    inspect_hmm_regime_readiness,
+    validate_hmm_regime_probabilities,
 )
 from core.features.regime_training import HMM_TRAINING_FEATURE_COLUMNS
 
@@ -132,3 +134,42 @@ def test_fit_hmm_regime_model_drops_all_nan_features_in_train_window() -> None:
 
     assert "high_yield_spread" not in model.feature_columns
     assert "spy_log_return_1d" in model.feature_columns
+
+
+def test_inspect_hmm_regime_readiness_marks_short_history_not_trainable() -> None:
+    """Short training windows surface explicit readiness diagnostics."""
+    training = _synthetic_training_frame().iloc[:20].copy()
+    train_end_date = str(training.iloc[15]["date"])
+    inference_date = str(training.iloc[19]["date"])
+
+    readiness = inspect_hmm_regime_readiness(
+        training,
+        train_end_date=train_end_date,
+        inference_dates=[inference_date],
+        config=HMMRegimeConfig(min_training_rows=30),
+    )
+
+    assert readiness.can_fit_model is False
+    assert readiness.complete_training_rows == 15
+    assert readiness.complete_inference_dates == (inference_date,)
+
+
+def test_validate_hmm_regime_probabilities_rejects_bad_probability_sums() -> None:
+    """Populated regime rows must stay normalized and internally consistent."""
+    features = pd.DataFrame(
+        [
+            {
+                "date": "2024-06-03",
+                "regime_label": "bull",
+                "regime_confidence": 0.75,
+                "regime_prob_bear": 0.1,
+                "regime_prob_sideways": 0.1,
+                "regime_prob_bull": 0.75,
+            }
+        ],
+        columns=list(HMM_REGIME_COLUMNS),
+    )
+
+    errors = validate_hmm_regime_probabilities(features)
+
+    assert errors == ["2024-06-03: regime probabilities sum to 0.950000"]

--- a/tests/unit/test_validate_layer1_archive.py
+++ b/tests/unit/test_validate_layer1_archive.py
@@ -19,6 +19,7 @@ from app.lab.data_pipelines.validate_layer1_archive import (
 from core.contracts.schemas import FeatureRecord, PipelineManifestRecord, RunStatus
 from core.features.io import feature_records_to_parquet_bytes
 from services.r2.paths import (
+    layer1_regime_path,
     layer1_ticker_history_path,
     layer1_validation_report_path,
     pipeline_manifest_path,
@@ -70,6 +71,25 @@ def _history_bytes(ticker: str, dates: list[str]) -> bytes:
         for as_of_date in dates
     ]
     return feature_records_to_parquet_bytes(records)
+
+
+def _history_bytes_with_features(
+    ticker: str,
+    rows: list[tuple[str, dict[str, object]]],
+) -> bytes:
+    """Return a Layer 1 history payload with explicit per-date feature maps."""
+    records = [
+        FeatureRecord(date=as_of_date, ticker=ticker, features=features)
+        for as_of_date, features in rows
+    ]
+    return feature_records_to_parquet_bytes(records)
+
+
+def _regime_artifact_bytes(rows: list[dict[str, object]]) -> bytes:
+    """Return a parquet payload for one Layer 1.5 regime artifact."""
+    buffer = io.BytesIO()
+    pd.DataFrame(rows).to_parquet(buffer, index=False)
+    return buffer.getvalue()
 
 
 def _manifest_bytes(run_id: str, status: RunStatus) -> bytes:
@@ -198,6 +218,110 @@ def test_validate_layer1_archive_flags_row_count_mismatch() -> None:
     assert report.ready_for_layer2 is False
     assert report.row_count_failures == 1
     assert report.row_count_failure_keys == [layer1_ticker_history_path("AAPL")]
+
+
+def test_validate_layer1_archive_marks_short_history_regime_as_warning() -> None:
+    """Explicit null regime placeholders become warnings when HMM history is insufficient."""
+    reader = _Reader(
+        {
+            layer1_ticker_history_path("AAPL"): _history_bytes_with_features(
+                "AAPL",
+                [
+                    (
+                        "2024-01-03",
+                        {
+                            "returns_1d": 0.01,
+                            "regime_label": None,
+                            "regime_confidence": None,
+                            "regime_prob_bear": None,
+                            "regime_prob_sideways": None,
+                            "regime_prob_bull": None,
+                        },
+                    )
+                ],
+            ),
+            layer1_regime_path("layer1-warmup-2024-01-03"): _regime_artifact_bytes(
+                [
+                    {
+                        "date": "2024-01-03",
+                        "regime_label": None,
+                        "regime_confidence": float("nan"),
+                        "regime_prob_bear": float("nan"),
+                        "regime_prob_sideways": float("nan"),
+                        "regime_prob_bull": float("nan"),
+                        "regime_required_for_layer2": False,
+                        "regime_readiness_status": "warning",
+                        "regime_readiness_reason": "insufficient_training_history",
+                        "regime_missing_features": "",
+                        "regime_probability_sum": float("nan"),
+                        "training_rows": 15,
+                        "complete_training_rows": 15,
+                        "min_training_rows": 30,
+                    }
+                ]
+            ),
+        }
+    )
+
+    report = validate_layer1_archive(
+        run_id="layer1-warmup",
+        from_date="2024-01-03",
+        to_date="2024-01-03",
+        universe={"2024-01-03": ["AAPL"]},
+        reader=reader,
+    )
+
+    assert report.ready_for_layer2 is False
+    assert report.validation_status == "warning"
+    assert report.regime_validation_status == "warning"
+    assert report.layer2_regime_optional_dates == ["2024-01-03"]
+    assert report.regime_failures == []
+    assert report.regime_warnings[0]["reason"] == "insufficient_training_history"
+
+
+def test_validate_layer1_archive_fails_when_required_regime_fields_are_missing() -> None:
+    """Null or absent regime fields fail readiness once Layer 1.5 says they are required."""
+    reader = _Reader(
+        {
+            layer1_ticker_history_path("AAPL"): _history_bytes_with_features(
+                "AAPL",
+                [("2024-01-03", {"returns_1d": 0.01})],
+            ),
+            layer1_regime_path("layer1-required-regime-2024-01-03"): _regime_artifact_bytes(
+                [
+                    {
+                        "date": "2024-01-03",
+                        "regime_label": "bull",
+                        "regime_confidence": 0.8,
+                        "regime_prob_bear": 0.1,
+                        "regime_prob_sideways": 0.1,
+                        "regime_prob_bull": 0.8,
+                        "regime_required_for_layer2": True,
+                        "regime_readiness_status": "ready",
+                        "regime_readiness_reason": "ready",
+                        "regime_missing_features": "",
+                        "regime_probability_sum": 1.0,
+                        "training_rows": 40,
+                        "complete_training_rows": 40,
+                        "min_training_rows": 30,
+                    }
+                ]
+            ),
+        }
+    )
+
+    report = validate_layer1_archive(
+        run_id="layer1-required-regime",
+        from_date="2024-01-03",
+        to_date="2024-01-03",
+        universe={"2024-01-03": ["AAPL"]},
+        reader=reader,
+    )
+
+    assert report.ready_for_layer2 is False
+    assert report.validation_status == "failed"
+    assert report.layer2_regime_required_dates == ["2024-01-03"]
+    assert report.regime_failures[0]["reason"] == "required_regime_fields_missing"
 
 
 def test_validate_layer1_archive_rejects_non_iso_dates() -> None:

--- a/tests/unit/test_validate_layer1_archive.py
+++ b/tests/unit/test_validate_layer1_archive.py
@@ -324,6 +324,79 @@ def test_validate_layer1_archive_fails_when_required_regime_fields_are_missing()
     assert report.regime_failures[0]["reason"] == "required_regime_fields_missing"
 
 
+def test_validate_layer1_archive_fails_when_required_regime_output_uses_nan() -> None:
+    """Required Layer 1.5 rows with NaN regime values fail readiness as missing output."""
+    reader = _Reader(
+        {
+            layer1_ticker_history_path("AAPL"): _history_bytes_with_features(
+                "AAPL",
+                [
+                    (
+                        "2024-01-03",
+                        {
+                            "returns_1d": 0.01,
+                            "regime_label": "bull",
+                            "regime_confidence": 0.8,
+                            "regime_prob_bear": 0.1,
+                            "regime_prob_sideways": 0.1,
+                            "regime_prob_bull": 0.8,
+                        },
+                    )
+                ],
+            ),
+            layer1_regime_path("layer1-required-regime-nan-2024-01-03"): _regime_artifact_bytes(
+                [
+                    {
+                        "date": "2024-01-03",
+                        "regime_label": "bull",
+                        "regime_confidence": float("nan"),
+                        "regime_prob_bear": float("nan"),
+                        "regime_prob_sideways": float("nan"),
+                        "regime_prob_bull": float("nan"),
+                        "regime_required_for_layer2": True,
+                        "regime_readiness_status": "ready",
+                        "regime_readiness_reason": "ready",
+                        "regime_missing_features": "",
+                        "regime_probability_sum": float("nan"),
+                        "training_rows": 40,
+                        "complete_training_rows": 40,
+                        "min_training_rows": 30,
+                    }
+                ]
+            ),
+        }
+    )
+
+    report = validate_layer1_archive(
+        run_id="layer1-required-regime-nan",
+        from_date="2024-01-03",
+        to_date="2024-01-03",
+        universe={"2024-01-03": ["AAPL"]},
+        reader=reader,
+    )
+
+    assert report.ready_for_layer2 is False
+    assert report.validation_status == "failed"
+    assert report.layer2_regime_required_dates == ["2024-01-03"]
+    assert report.regime_failures == [
+        {
+            "date": "2024-01-03",
+            "status": "failure",
+            "reason": "required_regime_output_is_null",
+            "required_for_layer2": True,
+            "output_key": layer1_regime_path("layer1-required-regime-nan-2024-01-03"),
+            "manifest_key": pipeline_manifest_path(
+                "layer1_5_regime",
+                "layer1-required-regime-nan-2024-01-03",
+            ),
+            "missing_features": [],
+            "complete_training_rows": 40,
+            "min_training_rows": 30,
+            "probability_sum": None,
+        }
+    ]
+
+
 def test_validate_layer1_archive_rejects_non_iso_dates() -> None:
     """Non-canonical YYYY-MM-DD inputs raise immediately."""
     reader = _Reader({})


### PR DESCRIPTION
## What this PR does
Hardens Layer 1.5 HMM regime handling so short-history windows emit explicit warning diagnostics and null regime placeholders instead of silent gaps, and upgrades Layer 1 readiness validation to distinguish warm-up warnings from real failures when regime should already be populated. The validator now checks non-null regime handoff semantics, probability normalization/confidence consistency, and writes those diagnostics into the readiness report and manifest metadata.

## Closes
Closes #153

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [x] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
None

## Notes for reviewer
Commands run:
- `./.venv/bin/pytest tests/unit/test_regime_detection.py tests/unit/test_hmm_regime_runner.py tests/unit/test_validate_layer1_archive.py tests/unit/test_daily_layer1_runner.py -v --tb=short`
- `./.venv/bin/pytest tests/integration/test_regime_detection_integration.py tests/integration/test_layer1_orchestration_integration.py tests/integration/test_layer1_readiness_report_integration.py -v --tb=short`
- `./.venv/bin/pytest tests/unit/ -v --tb=short`

Test result summary:
- Focused unit coverage: 51 passed
- Focused integration coverage: 4 passed
- Full required unit suite: 559 passed

Please pay particular attention to the new readiness semantics:
- `validation_status="warning"` means Layer 1 preserved explicit null regime placeholders because the bounded HMM window is still warming up.
- `ready_for_layer2` remains `false` for that warning state; Layer 2 now treats regime as required for handoff once enough history exists.
