### PR TITLE
Add optional Layer 1 order-book feature branch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,7 @@ ai-stock-trader/
 │   └── execution/                # Deterministic execution helpers
 ├── services/                     # External service adapters
 │   ├── alpaca/                   # Broker and market data integration
+│   ├── order_book/               # Optional Level 2/order-book config boundary
 │   ├── r2/                       # Object storage integration
 │   ├── modal/                    # Cloud job/deployment integration
 │   └── observability/            # Logging/metrics/alerts integration

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Future work that stays compatible with this baseline:
    - `app/cloud/` — Cloud Oracle inference service and contract handling
    - `app/pi/` — Edge Pi runtime for fetch, execution, reconciliation, and reporting
 - `core/` — shared business and domain logic
-- `services/` — external service integrations (Alpaca, R2, Modal, observability)
+- `services/` — external service integrations (Alpaca, optional order-book gating, R2, Modal, observability)
 - `config/` — non-secret configuration, schemas, examples, and requirement split notes
 - `docs/` — architecture notes, setup guides, and process docs
 - `tests/` — unit, integration, and pipeline tests

--- a/app/lab/data_pipelines/backfill_layer1.py
+++ b/app/lab/data_pipelines/backfill_layer1.py
@@ -147,7 +147,7 @@ class OptionalOrderBookBranch:
     provider: str | None
     records_by_ticker: dict[str, tuple[FeatureRecord, ...]]
     covered_dates: frozenset[str]
-    artifact_keys: tuple[str, ...]
+    archive_keys: tuple[str, ...]
     missing_dates: tuple[str, ...]
 
 
@@ -228,7 +228,7 @@ def backfill_layer1(
         provider=None,
         records_by_ticker={},
         covered_dates=frozenset(),
-        artifact_keys=(),
+        archive_keys=(),
         missing_dates=(),
     )
     try:
@@ -387,7 +387,7 @@ def backfill_layer1(
                 "topic_artifacts_loaded": len(topic_branch.artifact_keys),
                 "order_book_enabled": order_book_branch.enabled,
                 "order_book_provider": order_book_branch.provider,
-                "order_book_artifacts_loaded": len(order_book_branch.artifact_keys),
+                "order_book_artifacts_loaded": len(order_book_branch.archive_keys),
                 "missing_order_book_dates": len(order_book_branch.missing_dates),
                 "regime_artifacts_loaded": len(regime_branch.artifact_keys),
                 "missing_sentiment_dates": len(missing_sentiment_dates),
@@ -427,7 +427,7 @@ def backfill_layer1(
                 "topic_artifacts_loaded": len(topic_branch.artifact_keys),
                 "order_book_enabled": order_book_branch.enabled,
                 "order_book_provider": order_book_branch.provider,
-                "order_book_artifacts_loaded": len(order_book_branch.artifact_keys),
+                "order_book_artifacts_loaded": len(order_book_branch.archive_keys),
                 "regime_artifacts_loaded": len(regime_branch.artifact_keys),
             },
         )
@@ -790,13 +790,13 @@ def _load_optional_order_book_branch(
             provider=config.provider,
             records_by_ticker={},
             covered_dates=frozenset(),
-            artifact_keys=(),
+            archive_keys=(),
             missing_dates=(),
         )
 
     records_by_ticker: dict[str, list[FeatureRecord]] = {}
     covered_dates: set[str] = set()
-    artifact_keys: list[str] = []
+    archive_keys: list[str] = []
     missing_dates: set[str] = set()
     date_tickers_map: dict[str, set[str]] = {}
     for ticker, ohlcv in ohlcv_by_ticker.items():
@@ -808,7 +808,7 @@ def _load_optional_order_book_branch(
         if writer.exists(key):
             frame = load_order_book_frame(config.provider, date_text, writer=writer)
             covered_dates.add(date_text)
-            artifact_keys.append(key)
+            archive_keys.append(key)
         else:
             frame = _empty_order_book_source_frame()
             missing_dates.add(date_text)
@@ -831,7 +831,7 @@ def _load_optional_order_book_branch(
             for ticker, records in sorted(records_by_ticker.items())
         },
         covered_dates=frozenset(covered_dates),
-        artifact_keys=tuple(artifact_keys),
+        archive_keys=tuple(archive_keys),
         missing_dates=tuple(sorted(missing_dates)),
     )
 
@@ -877,8 +877,12 @@ def _empty_fundamentals_frame(ohlcv):
 
 def _empty_order_book_source_frame():
     """Return an empty provider-normalized order-book frame."""
-    import pandas as pd
-
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to build empty order-book frames."
+        ) from exc
     return pd.DataFrame(
         columns=[
             "date",

--- a/app/lab/data_pipelines/backfill_layer1.py
+++ b/app/lab/data_pipelines/backfill_layer1.py
@@ -51,10 +51,15 @@ from core.features.loaders import (  # noqa: E402
     load_fundamentals_frame,
     load_macro_frame,
     load_ohlcv_frame,
+    load_order_book_frame,
 )
 from core.features.market_features import (  # noqa: E402
     compute_market_features,
     market_features_to_records,
+)
+from core.features.order_book_features import (  # noqa: E402
+    compute_order_book_features,
+    order_book_features_to_records,
 )
 from core.features.regime_detection import HMM_REGIME_FEATURE_COLUMNS  # noqa: E402
 from core.features.sector_features import (  # noqa: E402
@@ -62,7 +67,13 @@ from core.features.sector_features import (  # noqa: E402
     load_sector_etf_config,
     sector_features_to_records,
 )
-from services.r2.paths import build_r2_key, layer1_regime_path, pipeline_manifest_path  # noqa: E402
+from services.order_book.config import load_order_book_feature_config  # noqa: E402
+from services.r2.paths import (  # noqa: E402
+    build_r2_key,
+    layer1_regime_path,
+    pipeline_manifest_path,
+    raw_order_book_path,
+)
 from services.r2.writer import R2Writer  # noqa: E402
 
 LAYER1_BACKFILL_STAGE = "layer1_backfill"
@@ -126,6 +137,18 @@ class OptionalRegimeBranch:
     features_by_date: dict[str, dict[str, object]]
     covered_dates: frozenset[str]
     artifact_keys: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class OptionalOrderBookBranch:
+    """Loaded order-book FeatureRecords keyed by ticker."""
+
+    enabled: bool
+    provider: str | None
+    records_by_ticker: dict[str, tuple[FeatureRecord, ...]]
+    covered_dates: frozenset[str]
+    artifact_keys: tuple[str, ...]
+    missing_dates: tuple[str, ...]
 
 
 @dataclass(frozen=True)
@@ -200,6 +223,14 @@ def backfill_layer1(
         covered_dates=frozenset(),
         artifact_keys=(),
     )
+    order_book_branch = OptionalOrderBookBranch(
+        enabled=False,
+        provider=None,
+        records_by_ticker={},
+        covered_dates=frozenset(),
+        artifact_keys=(),
+        missing_dates=(),
+    )
     try:
         sentiment_branch = _load_optional_feature_branch(
             writer=active_writer,
@@ -243,6 +274,10 @@ def backfill_layer1(
                 sector_config=sector_config,
             ).items()
         }
+        order_book_branch = _load_optional_order_book_branch(
+            writer=active_writer,
+            ohlcv_by_ticker=ohlcv_by_ticker,
+        )
 
         for ticker in config.tickers:
             if ticker not in ohlcv_by_ticker:
@@ -301,6 +336,17 @@ def backfill_layer1(
             if topic_input is not None:
                 inputs.append(topic_input)
 
+            order_book_input = _optional_branch_input(
+                name="order_book",
+                records=_records_for_ticker_branch(
+                    order_book_branch,
+                    ticker=ticker,
+                    allowed_dates=ticker_dates,
+                ),
+            )
+            if order_book_input is not None:
+                inputs.append(order_book_input)
+
             regime_input = _optional_branch_input(
                 name="regime",
                 records=_regime_records_for_ticker(
@@ -322,6 +368,7 @@ def backfill_layer1(
         missing_regime_dates = _missing_branch_dates(processed_dates, regime_branch.covered_dates)
         _log_missing_optional_branch_dates("sentiment", missing_sentiment_dates)
         _log_missing_optional_branch_dates("topics", missing_topic_dates)
+        _log_missing_optional_branch_dates("order_book", order_book_branch.missing_dates)
         _log_missing_optional_branch_dates("regime", missing_regime_dates)
 
         finished = (now or datetime.now(UTC)).replace(microsecond=0)
@@ -338,6 +385,10 @@ def backfill_layer1(
                 "benchmark_ticker": config.benchmark_ticker,
                 "sentiment_artifacts_loaded": len(sentiment_branch.artifact_keys),
                 "topic_artifacts_loaded": len(topic_branch.artifact_keys),
+                "order_book_enabled": order_book_branch.enabled,
+                "order_book_provider": order_book_branch.provider,
+                "order_book_artifacts_loaded": len(order_book_branch.artifact_keys),
+                "missing_order_book_dates": len(order_book_branch.missing_dates),
                 "regime_artifacts_loaded": len(regime_branch.artifact_keys),
                 "missing_sentiment_dates": len(missing_sentiment_dates),
                 "missing_topic_dates": len(missing_topic_dates),
@@ -374,6 +425,9 @@ def backfill_layer1(
                 "benchmark_ticker": config.benchmark_ticker,
                 "sentiment_artifacts_loaded": len(sentiment_branch.artifact_keys),
                 "topic_artifacts_loaded": len(topic_branch.artifact_keys),
+                "order_book_enabled": order_book_branch.enabled,
+                "order_book_provider": order_book_branch.provider,
+                "order_book_artifacts_loaded": len(order_book_branch.artifact_keys),
                 "regime_artifacts_loaded": len(regime_branch.artifact_keys),
             },
         )
@@ -632,7 +686,7 @@ def _validate_daily_feature_records(
 
 
 def _records_for_ticker_branch(
-    branch: OptionalFeatureBranch,
+    branch: OptionalFeatureBranch | OptionalOrderBookBranch,
     *,
     ticker: str,
     allowed_dates: frozenset[str],
@@ -723,6 +777,65 @@ def _compute_context_records(
     return context_features_to_records(features)
 
 
+def _load_optional_order_book_branch(
+    *,
+    writer: ObjectStore,
+    ohlcv_by_ticker: dict[str, object],
+) -> OptionalOrderBookBranch:
+    """Load optional order-book records for every available OHLCV date in scope."""
+    config = load_order_book_feature_config()
+    if not config.is_active or config.provider is None:
+        return OptionalOrderBookBranch(
+            enabled=False,
+            provider=config.provider,
+            records_by_ticker={},
+            covered_dates=frozenset(),
+            artifact_keys=(),
+            missing_dates=(),
+        )
+
+    records_by_ticker: dict[str, list[FeatureRecord]] = {}
+    covered_dates: set[str] = set()
+    artifact_keys: list[str] = []
+    missing_dates: set[str] = set()
+    date_tickers_map: dict[str, set[str]] = {}
+    for ticker, ohlcv in ohlcv_by_ticker.items():
+        for date_value in ohlcv["date"].astype(str).tolist():
+            date_tickers_map.setdefault(str(date_value), set()).add(ticker)
+
+    for date_text, tickers in sorted(date_tickers_map.items()):
+        key = raw_order_book_path(config.provider, date_text)
+        if writer.exists(key):
+            frame = load_order_book_frame(config.provider, date_text, writer=writer)
+            covered_dates.add(date_text)
+            artifact_keys.append(key)
+        else:
+            frame = _empty_order_book_source_frame()
+            missing_dates.add(date_text)
+
+        day_records = order_book_features_to_records(
+            compute_order_book_features(
+                frame,
+                target_date=date_text,
+                tickers=sorted(tickers),
+            )
+        )
+        for record in day_records:
+            records_by_ticker.setdefault(record.ticker, []).append(record)
+
+    return OptionalOrderBookBranch(
+        enabled=True,
+        provider=config.provider,
+        records_by_ticker={
+            ticker: tuple(sorted(records, key=lambda record: record.date))
+            for ticker, records in sorted(records_by_ticker.items())
+        },
+        covered_dates=frozenset(covered_dates),
+        artifact_keys=tuple(artifact_keys),
+        missing_dates=tuple(sorted(missing_dates)),
+    )
+
+
 def _try_load_benchmark(writer: ObjectStore, ticker: str):
     """Return the benchmark OHLCV frame when available, else None."""
     try:
@@ -758,6 +871,23 @@ def _empty_fundamentals_frame(ohlcv):
             "fiscal_period",
             "raw_json",
             "earnings_date",
+        ]
+    )
+
+
+def _empty_order_book_source_frame():
+    """Return an empty provider-normalized order-book frame."""
+    import pandas as pd
+
+    return pd.DataFrame(
+        columns=[
+            "date",
+            "ticker",
+            "captured_at",
+            "bid_price",
+            "ask_price",
+            "bid_size",
+            "ask_size",
         ]
     )
 

--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -90,11 +90,16 @@ from core.features.loaders import (  # noqa: E402
     load_fundamentals_frame,
     load_macro_frame,
     load_ohlcv_frame,
+    load_order_book_frame,
 )
 from core.features.macro_features import compute_macro_features  # noqa: E402
 from core.features.market_features import (  # noqa: E402
     compute_market_features,
     market_features_to_records,
+)
+from core.features.order_book_features import (  # noqa: E402
+    compute_order_book_features,
+    order_book_features_to_records,
 )
 from core.features.regime_detection import regime_features_to_records  # noqa: E402
 from core.features.sector_features import (  # noqa: E402
@@ -102,11 +107,13 @@ from core.features.sector_features import (  # noqa: E402
     load_sector_etf_config,
     sector_features_to_records,
 )
+from services.order_book.config import load_order_book_feature_config  # noqa: E402
 from services.r2.paths import (  # noqa: E402
     layer1_ticker_history_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_news_path,
+    raw_order_book_path,
     raw_price_path,
     raw_universe_path,
 )
@@ -287,6 +294,17 @@ class ModalBatchedStageOutputs:
     regime_output_keys_by_date: dict[str, str]
 
 
+@dataclass(frozen=True)
+class OptionalOrderBookBranch:
+    """Loaded optional order-book FeatureRecords keyed by ticker."""
+
+    enabled: bool
+    provider: str | None
+    records_by_ticker: dict[str, tuple[FeatureRecord, ...]]
+    archive_keys: tuple[str, ...]
+    missing_dates: tuple[str, ...]
+
+
 class Layer1ValidationError(RuntimeError):
     """Raised when Layer 1 validation completes but is not ready for Layer 2."""
 
@@ -402,7 +420,11 @@ def run_daily_layer1(
             regime_runner=regime_runner,
         )
 
-        feature_rows_written, history_files_written = _assemble_and_write_histories(
+        (
+            feature_rows_written,
+            history_files_written,
+            order_book_branch,
+        ) = _assemble_and_write_histories(
             writer=active_writer,
             universe_by_date=universe_by_date,
             benchmark_ticker=config.benchmark_ticker,
@@ -438,6 +460,10 @@ def run_daily_layer1(
                 "regime_output_keys": {
                     date_text: result.output_key for date_text, result in regime_results.items()
                 },
+                "order_book_enabled": order_book_branch.enabled,
+                "order_book_provider": order_book_branch.provider,
+                "order_book_archive_keys": list(order_book_branch.archive_keys),
+                "order_book_missing_dates": list(order_book_branch.missing_dates),
             }
         )
         finished_at = (now or datetime.now(UTC)).replace(microsecond=0)
@@ -741,7 +767,7 @@ def _assemble_and_write_histories(
     topic_results: Mapping[str, TextTopicPipelineResult],
     sentiment_results: Mapping[str, FinBERTPipelineResult],
     regime_results: Mapping[str, HMMRegimePipelineResult],
-) -> tuple[int, int]:
+) -> tuple[int, int, OptionalOrderBookBranch]:
     """Assemble daily features and upsert per-ticker histories."""
     target_dates_by_ticker = _expected_dates_by_ticker(universe_by_date)
     benchmark_bars = load_ohlcv_frame(benchmark_ticker, writer=writer)  # type: ignore[arg-type]
@@ -789,6 +815,10 @@ def _assemble_and_write_histories(
             sector_config=sector_config,
         ).items()
     }
+    order_book_branch = _load_order_book_branch(
+        writer=writer,
+        target_dates_by_ticker=target_dates_by_ticker,
+    )
 
     feature_rows_written = 0
     history_files_written = 0
@@ -826,6 +856,10 @@ def _assemble_and_write_histories(
             sentiment_records.get(ticker, []),
             target_dates,
         )
+        order_book_daily_records = _records_for_target_dates(
+            order_book_branch.records_by_ticker.get(ticker, ()),
+            target_dates,
+        )
         regime_daily_records = _broadcast_regime_records(
             ticker=ticker,
             target_dates=target_dates,
@@ -859,6 +893,11 @@ def _assemble_and_write_histories(
                     as_of_timestamp=SENTINEL_ASSEMBLY_AS_OF,
                 ),
                 Layer1FeatureInput(
+                    name="order_book",
+                    records=order_book_daily_records,
+                    as_of_timestamp=SENTINEL_ASSEMBLY_AS_OF,
+                ),
+                Layer1FeatureInput(
                     name="regime",
                     records=regime_daily_records,
                     as_of_timestamp=SENTINEL_ASSEMBLY_AS_OF,
@@ -876,7 +915,95 @@ def _assemble_and_write_histories(
         feature_rows_written += len(assembled)
         history_files_written += 1
 
-    return feature_rows_written, history_files_written
+    return feature_rows_written, history_files_written, order_book_branch
+
+
+def _load_order_book_branch(
+    *,
+    writer: ObjectStore,
+    target_dates_by_ticker: Mapping[str, Sequence[str]],
+) -> OptionalOrderBookBranch:
+    """Load optional order-book FeatureRecords for the requested ticker/date scope."""
+    config = load_order_book_feature_config()
+    if not config.is_active or config.provider is None:
+        return OptionalOrderBookBranch(
+            enabled=False,
+            provider=config.provider,
+            records_by_ticker={},
+            archive_keys=(),
+            missing_dates=(),
+        )
+
+    records_by_ticker: dict[str, list[FeatureRecord]] = {}
+    archive_keys: list[str] = []
+    missing_dates: list[str] = []
+    all_dates = sorted({date_text for dates in target_dates_by_ticker.values() for date_text in dates})
+    for date_text in all_dates:
+        date_tickers = sorted(
+            ticker
+            for ticker, ticker_dates in target_dates_by_ticker.items()
+            if date_text in ticker_dates
+        )
+        key = raw_order_book_path(config.provider, date_text)
+        if writer.exists(key):
+            frame = load_order_book_frame(config.provider, date_text, writer=writer)  # type: ignore[arg-type]
+            archive_keys.append(key)
+        else:
+            missing_dates.append(date_text)
+            frame = _empty_order_book_source_frame()
+
+        day_records = order_book_features_to_records(
+            compute_order_book_features(
+                frame,
+                target_date=date_text,
+                tickers=date_tickers,
+            )
+        )
+        for record in day_records:
+            records_by_ticker.setdefault(record.ticker, []).append(record)
+
+    if missing_dates:
+        sample = ", ".join(missing_dates[:5])
+        suffix = "" if len(missing_dates) <= 5 else ", ..."
+        logger.warning(
+            "Order-book branch enabled for provider={} but archives were missing for {} dates: {}{}",
+            config.provider,
+            len(missing_dates),
+            sample,
+            suffix,
+        )
+
+    return OptionalOrderBookBranch(
+        enabled=True,
+        provider=config.provider,
+        records_by_ticker={
+            ticker: tuple(sorted(records, key=lambda record: record.date))
+            for ticker, records in sorted(records_by_ticker.items())
+        },
+        archive_keys=tuple(archive_keys),
+        missing_dates=tuple(missing_dates),
+    )
+
+
+def _empty_order_book_source_frame():
+    """Return an empty provider-normalized order-book frame."""
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to build empty order-book frames."
+        ) from exc
+    return pd.DataFrame(
+        columns=[
+            "date",
+            "ticker",
+            "captured_at",
+            "bid_price",
+            "ask_price",
+            "bid_size",
+            "ask_size",
+        ]
+    )
 
 
 def _load_feature_records_by_key(

--- a/config/README.md
+++ b/config/README.md
@@ -44,6 +44,8 @@ Use an R2 token/access key with read/write access to the bucket. Do not use the 
 - `config/fred_series.json` controls the default FRED macro/rate series and historical backfill date range.
 - `config/sector_etf_mapping.json` controls sector-name normalization and the
   sector-to-ETF mapping used by Layer 1 sector/factor features.
+- `config/order_book_features.json` gates the optional Layer 1 Level 2/order-book branch;
+  it stays disabled by default until an explicit provider name is configured.
 - `config/source_credibility.json` controls source credibility weights used for
   FinBERT sentiment aggregation.
 - `config/finbert_sentiment.json` controls the Modal app, model identity, batch size,

--- a/config/order_book_features.json
+++ b/config/order_book_features.json
@@ -1,0 +1,4 @@
+{
+  "enabled": false,
+  "provider": null
+}

--- a/core/features/__init__.py
+++ b/core/features/__init__.py
@@ -36,17 +36,17 @@ from core.features.market_features import (
     compute_market_features,
     market_features_to_records,
 )
-from core.features.order_book_features import (
-    ORDER_BOOK_FEATURE_COLUMNS,
-    compute_order_book_features,
-    order_book_features_to_records,
-)
 from core.features.news_preprocessing import (
     NewsPreprocessingConfig,
     news_sentiment_frame_to_records,
     preprocess_news_articles,
     records_to_news_sentiment_frame,
     split_article_sentences,
+)
+from core.features.order_book_features import (
+    ORDER_BOOK_FEATURE_COLUMNS,
+    compute_order_book_features,
+    order_book_features_to_records,
 )
 from core.features.regime_detection import (
     HMM_REGIME_COLUMNS,

--- a/core/features/__init__.py
+++ b/core/features/__init__.py
@@ -36,6 +36,11 @@ from core.features.market_features import (
     compute_market_features,
     market_features_to_records,
 )
+from core.features.order_book_features import (
+    ORDER_BOOK_FEATURE_COLUMNS,
+    compute_order_book_features,
+    order_book_features_to_records,
+)
 from core.features.news_preprocessing import (
     NewsPreprocessingConfig,
     news_sentiment_frame_to_records,
@@ -110,6 +115,7 @@ __all__ = [
     "MACRO_FEATURE_COLUMNS",
     "MARKET_FEATURE_COLUMNS",
     "NewsPreprocessingConfig",
+    "ORDER_BOOK_FEATURE_COLUMNS",
     "SECTOR_FEATURE_COLUMNS",
     "SENTIMENT_AGGREGATE_COLUMNS",
     "SentimentScore",
@@ -127,6 +133,7 @@ __all__ = [
     "compute_fundamentals_features",
     "compute_macro_features",
     "compute_market_features",
+    "compute_order_book_features",
     "compute_sector_features",
     "compute_sentence_embeddings",
     "compute_text_topics",
@@ -148,6 +155,7 @@ __all__ = [
     "macro_features_to_records",
     "market_features_to_records",
     "news_sentiment_frame_to_records",
+    "order_book_features_to_records",
     "parquet_bytes_to_feature_record",
     "parquet_bytes_to_feature_records",
     "preprocess_news_articles",

--- a/core/features/catalog.py
+++ b/core/features/catalog.py
@@ -8,6 +8,7 @@ from typing import Literal
 from core.features.fundamentals_features import FUNDAMENTAL_FEATURE_COLUMNS
 from core.features.macro_features import MACRO_FEATURE_COLUMNS
 from core.features.market_features import MARKET_FEATURE_COLUMNS
+from core.features.order_book_features import ORDER_BOOK_FEATURE_COLUMNS
 from core.features.regime_detection import HMM_REGIME_FEATURE_COLUMNS
 from core.features.sector_features import SECTOR_FEATURE_COLUMNS
 from core.features.sentiment_features import SENTIMENT_FEATURE_COLUMNS
@@ -52,7 +53,9 @@ FEATURE_FAMILY_SPECS: tuple[FeatureFamilySpec, ...] = (
     FeatureFamilySpec(
         key="market",
         label="Market",
-        feature_names=_unique_feature_names((*MARKET_FEATURE_COLUMNS, *SECTOR_FEATURE_COLUMNS)),
+        feature_names=_unique_feature_names(
+            (*MARKET_FEATURE_COLUMNS, *SECTOR_FEATURE_COLUMNS, *ORDER_BOOK_FEATURE_COLUMNS)
+        ),
     ),
     FeatureFamilySpec(
         key="macro_context",
@@ -87,6 +90,8 @@ def feature_catalog() -> dict[str, FeatureRule]:
     rules: dict[str, FeatureRule] = {}
     for name in MARKET_FEATURE_COLUMNS:
         rules[name] = FeatureRule(owner="market", kind="number", required=True)
+    for name in ORDER_BOOK_FEATURE_COLUMNS:
+        rules[name] = FeatureRule(owner="order_book", kind="number", required=False)
     for name in SECTOR_FEATURE_COLUMNS:
         if name == "sector_relative_strength":
             continue
@@ -119,6 +124,31 @@ def feature_catalog() -> dict[str, FeatureRule]:
         required=True,
         minimum=0.0,
         maximum=1.0,
+    )
+    rules["l2_bid_ask_spread"] = FeatureRule(
+        owner="order_book",
+        kind="number",
+        required=False,
+        minimum=0.0,
+    )
+    rules["l2_quoted_spread_bps"] = FeatureRule(
+        owner="order_book",
+        kind="number",
+        required=False,
+        minimum=0.0,
+    )
+    rules["l2_book_imbalance"] = FeatureRule(
+        owner="order_book",
+        kind="number",
+        required=False,
+        minimum=-1.0,
+        maximum=1.0,
+    )
+    rules["l2_snapshot_count"] = FeatureRule(
+        owner="order_book",
+        kind="number",
+        required=False,
+        minimum=0.0,
     )
 
     for name in FUNDAMENTAL_FEATURE_COLUMNS:

--- a/core/features/loaders.py
+++ b/core/features/loaders.py
@@ -19,6 +19,7 @@ from services.r2.paths import (
     is_canonical_raw_macro_key,
     raw_fundamentals_path,
     raw_macro_date_from_key,
+    raw_order_book_path,
     raw_price_path,
 )
 from services.r2.writer import R2Writer
@@ -117,6 +118,19 @@ def load_macro_frame(
             .reset_index(drop=True)
         )
         return frame
+    return frame.reset_index(drop=True)
+
+
+def load_order_book_frame(
+    provider: str,
+    as_of_date: str,
+    writer: R2Writer | None = None,
+) -> pd.DataFrame:
+    """Return one provider/day raw order-book archive frame from R2."""
+    pd = _require_pandas()
+    active_writer = writer or R2Writer()
+    payload = active_writer.get_object(raw_order_book_path(provider, as_of_date))
+    frame = pd.read_parquet(io.BytesIO(payload))
     return frame.reset_index(drop=True)
 
 

--- a/core/features/order_book_features.py
+++ b/core/features/order_book_features.py
@@ -1,0 +1,207 @@
+"""Optional Layer 1 order-book feature computation from archived pre-open snapshots.
+
+The branch is provider-agnostic and expects normalized rows with:
+- `date`
+- `ticker`
+- `captured_at`
+- `bid_price`
+- `ask_price`
+- `bid_size`
+- `ask_size`
+
+Rows captured at or after the target market open are ignored so the emitted
+FeatureRecords remain safe to join on the target `(date, ticker)`.
+"""
+from __future__ import annotations
+
+import importlib
+import math
+from collections.abc import Sequence
+from datetime import time
+from typing import TYPE_CHECKING, Any
+
+from core.contracts.schemas import FeatureRecord
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+ORDER_BOOK_FEATURE_COLUMNS: tuple[str, ...] = (
+    "l2_bid_ask_spread",
+    "l2_quoted_spread_bps",
+    "l2_book_imbalance",
+    "l2_snapshot_count",
+)
+
+REQUIRED_ORDER_BOOK_COLUMNS: frozenset[str] = frozenset(
+    {"date", "ticker", "captured_at", "bid_price", "ask_price", "bid_size", "ask_size"}
+)
+
+
+def compute_order_book_features(
+    frame: pd.DataFrame,
+    *,
+    target_date: str,
+    tickers: Sequence[str],
+    market_timezone: str = "America/New_York",
+    market_open: time = time(9, 30),
+) -> pd.DataFrame:
+    """Aggregate one day of archived order-book rows into per-ticker features.
+
+    Invalid snapshots (missing values, negative sizes, non-positive prices,
+    or crossed quotes) are ignored. Tickers with no usable pre-open rows still
+    get one output row with null numeric features and `l2_snapshot_count=0`.
+    """
+    pd = _require_pandas()
+    _validate_columns(frame)
+    if market_open.tzinfo is not None:
+        raise ValueError("market_open must be a naive local market time")
+
+    normalized_tickers = tuple(
+        sorted({str(ticker).strip().upper() for ticker in tickers if str(ticker).strip()})
+    )
+    if not normalized_tickers:
+        return _empty_frame(pd)
+
+    base = pd.DataFrame({"ticker": list(normalized_tickers)})
+    base.insert(0, "date", target_date)
+    base["l2_bid_ask_spread"] = float("nan")
+    base["l2_quoted_spread_bps"] = float("nan")
+    base["l2_book_imbalance"] = float("nan")
+    base["l2_snapshot_count"] = 0
+
+    if len(frame.index) == 0:
+        return base[["date", "ticker", *ORDER_BOOK_FEATURE_COLUMNS]]
+
+    working = frame.copy()
+    working["date"] = working["date"].astype(str)
+    working["ticker"] = working["ticker"].astype(str).str.strip().str.upper()
+    working = working[
+        working["date"].eq(target_date) & working["ticker"].isin(normalized_tickers)
+    ].reset_index(drop=True)
+    if len(working.index) == 0:
+        return base[["date", "ticker", *ORDER_BOOK_FEATURE_COLUMNS]]
+
+    captured_at = pd.to_datetime(working["captured_at"], utc=True, errors="coerce")
+    local_captured_at = captured_at.dt.tz_convert(market_timezone)
+    market_open_at = pd.Timestamp(f"{target_date} {market_open.isoformat()}").tz_localize(
+        market_timezone
+    )
+    working = working.assign(_captured_at=captured_at, _local_captured_at=local_captured_at)
+    working = working[working["_local_captured_at"] < market_open_at].reset_index(drop=True)
+    if len(working.index) == 0:
+        return base[["date", "ticker", *ORDER_BOOK_FEATURE_COLUMNS]]
+
+    numeric_columns = ("bid_price", "ask_price", "bid_size", "ask_size")
+    for column in numeric_columns:
+        working[column] = pd.to_numeric(working[column], errors="coerce")
+    working = working.dropna(subset=["_captured_at", *numeric_columns]).reset_index(drop=True)
+    if len(working.index) == 0:
+        return base[["date", "ticker", *ORDER_BOOK_FEATURE_COLUMNS]]
+
+    working = working[
+        (working["bid_price"] > 0.0)
+        & (working["ask_price"] > 0.0)
+        & (working["bid_size"] >= 0.0)
+        & (working["ask_size"] >= 0.0)
+        & (working["ask_price"] >= working["bid_price"])
+        & ((working["bid_size"] + working["ask_size"]) > 0.0)
+    ].reset_index(drop=True)
+    if len(working.index) == 0:
+        return base[["date", "ticker", *ORDER_BOOK_FEATURE_COLUMNS]]
+
+    working["l2_bid_ask_spread"] = working["ask_price"] - working["bid_price"]
+    working["l2_quoted_spread_bps"] = (
+        working["l2_bid_ask_spread"] / ((working["ask_price"] + working["bid_price"]) / 2.0)
+    ) * 10_000.0
+    working["l2_book_imbalance"] = (
+        (working["bid_size"] - working["ask_size"])
+        / (working["bid_size"] + working["ask_size"])
+    )
+    working = working.sort_values(["ticker", "_captured_at"]).reset_index(drop=True)
+
+    latest = working.groupby("ticker", sort=True).tail(1).copy()
+    counts = (
+        working.groupby("ticker", sort=True)
+        .size()
+        .rename("l2_snapshot_count")
+        .reset_index()
+    )
+    latest = latest.merge(counts, on="ticker", how="left")
+    latest = latest[
+        [
+            "ticker",
+            "l2_bid_ask_spread",
+            "l2_quoted_spread_bps",
+            "l2_book_imbalance",
+            "l2_snapshot_count",
+        ]
+    ]
+
+    result = base.merge(latest, on="ticker", how="left", suffixes=("", "_latest"))
+    for column in ORDER_BOOK_FEATURE_COLUMNS:
+        latest_column = f"{column}_latest"
+        if latest_column in result.columns:
+            result[column] = result[latest_column].combine_first(result[column])
+            result = result.drop(columns=[latest_column])
+    return result[["date", "ticker", *ORDER_BOOK_FEATURE_COLUMNS]]
+
+
+def order_book_features_to_records(features: pd.DataFrame) -> list[FeatureRecord]:
+    """Convert a per-ticker order-book feature frame into FeatureRecords."""
+    records: list[FeatureRecord] = []
+    for row in features.to_dict(orient="records"):
+        feature_values = {
+            name: _normalize_feature_value(row.get(name)) for name in ORDER_BOOK_FEATURE_COLUMNS
+        }
+        records.append(
+            FeatureRecord(
+                date=str(row["date"]),
+                ticker=str(row["ticker"]),
+                features=feature_values,
+            )
+        )
+    return records
+
+
+def _validate_columns(frame: pd.DataFrame) -> None:
+    """Raise when the raw order-book archive is missing required columns."""
+    missing = sorted(REQUIRED_ORDER_BOOK_COLUMNS - set(frame.columns))
+    if missing:
+        raise ValueError(f"Order-book frame missing required columns: {missing}")
+
+
+def _empty_frame(pd: Any) -> pd.DataFrame:
+    """Return an empty order-book feature frame with canonical columns."""
+    return pd.DataFrame(columns=["date", "ticker", *ORDER_BOOK_FEATURE_COLUMNS])
+
+
+def _normalize_feature_value(value: Any) -> float | int | bool | None:
+    """Convert a pandas/numpy scalar to a FeatureRecord-compatible primitive."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    if float(numeric).is_integer():
+        return int(numeric)
+    return numeric
+
+
+def _require_pandas() -> Any:
+    """Import pandas/pyarrow lazily with a clear dependency error."""
+    try:
+        import pandas as pd
+
+        importlib.import_module("pyarrow")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to compute order-book features."
+        ) from exc
+    return pd

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,7 @@ This is not just a switch in the optimizer. It requires:
 | S&P 500 universe membership | Wikipedia edit history | Point-in-time constituent list; never use today's snapshot for history |
 | Fundamentals / earnings dates | SimFin | As-reported filing data to avoid future restatements leaking backward |
 | Macro / rates | FRED | Fed funds, Treasury yields, CPI, and other regime/context inputs |
+| Optional Level 2 / order-book snapshots | Explicit provider config only | Disabled by default; Layer 1 reads provider-normalized pre-open archives from R2 only when they are explicitly staged and configured |
 | Live daily prices / broker state / execution | Alpaca Market Data + Trading API | Current-day bar snapshot, reconciliation source of truth, and order routing |
 
 ### Universe construction note
@@ -188,6 +189,7 @@ r2/
     universe/         # Daily eligibility masks as CSV
     fundamentals/     # SimFin as-reported point-in-time fundamentals per ticker parquet
     macro/            # FRED per-run-date point-in-time macro snapshots
+    order_book/       # Optional provider-normalized pre-open Level 2 snapshots
     reference/        # Symbol/security-reference snapshots
   features/
     layer1/           # Layer 1 feature histories as Parquet (one file per ticker)
@@ -233,6 +235,7 @@ Any artifact that must survive a Pi restart or be accessed by Modal must be writ
 | News raw archive | JSON Lines | One article per line; easy to stream |
 | Fundamentals archive | Parquet (per ticker history) | Point-in-time company fundamentals at `raw/fundamentals/{ticker}.parquet`; efficient ticker/date joins and targeted recovery |
 | Macro/rates archive | Parquet | `raw/macro/{run_date}.parquet` snapshot; preserve the latest available row per series plus row-level observation/realtime metadata |
+| Order-book archive | Parquet | Optional provider-normalized pre-open snapshots at `raw/order_book/{provider}/{run_date}.parquet`; disabled by default and read only when explicit config enables the branch |
 | Sentiment scores | Parquet | Processed output from FinBERT pipeline |
 | Universe eligibility masks | CSV | Small; human-inspectable |
 | Daily order files | CSV | Human-readable for debugging |
@@ -263,6 +266,8 @@ Responsibilities:
 - detect stale, missing, or corrupted market data
 - generate daily eligibility masks and quality flags
 - persist every external data source needed by Layer 1 into R2 before feature generation runs
+- when an explicit Level 2 provider is enabled, stage its normalized pre-open order-book
+  snapshots in R2 before Layer 1 tries to consume them
 
 **Layer 0 operates in two distinct modes:**
 
@@ -313,6 +318,7 @@ Market-cap policy:
 - raw news archive (JSON Lines) for Layer 1 processing
 - raw SimFin fundamentals and earnings-date archive for Layer 1 context features
 - raw FRED macro/rate archive for Layer 1 context and regime features
+- optional raw order-book archive for Layer 1 spread / book-imbalance features
 
 ### Layer 1 — Feature Generation
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -187,6 +187,26 @@ Notes:
 - no schema changes in `core/contracts/schemas.py` are required unless the project decides
   to promote macro observations into a typed inter-layer contract later
 
+### Layer 0 raw order-book archive (non-contract artifact)
+
+Purpose:
+- preserve optional pre-open Level 2 snapshots for spread and book-imbalance features
+- keep Layer 1 provider-agnostic by consuming only normalized R2 archives
+- allow the branch to remain disabled by default until an explicit provider/config exists
+
+Notes:
+- raw order-book observations, when provisioned, are stored under
+  `raw/order_book/{provider}/{run_date}.parquet`
+- the normalized archive is provider-agnostic and must include at least:
+  `date`, `ticker`, `captured_at`, `bid_price`, `ask_price`, `bid_size`, and `ask_size`
+- Layer 1 uses only snapshots available before the target market open and aggregates them
+  into optional per-ticker daily spread / imbalance features
+- missing order-book archives must not break the base Layer 1 run; when the branch is
+  explicitly enabled, missing coverage resolves to null order-book features instead
+- this archive is not a replacement for `FeatureRecord`
+- no schema changes in `core/contracts/schemas.py` are required unless the project decides
+  to promote raw order-book observations into a typed inter-layer contract later
+
 ---
 
 ## Layer 1 contracts
@@ -233,14 +253,16 @@ Required identity fields:
 
 Feature groups may include:
 - market features
+- optional order-book / market-microstructure features
 - text/sentiment features
 - context/fundamental features
 - regime features
 
 Input note:
 - generated from Layer 0 R2 archives/manifests plus the latest completed Layer 1.5
-  regime artifacts/manifests already persisted in R2; Layer 1 must not call external
-  data providers for feature inputs
+  regime artifacts/manifests already persisted in R2, plus any explicitly configured
+  provider-normalized order-book archives already staged in R2; Layer 1 must not call
+  external data providers for feature inputs
 - historical backfills store FeatureRecord rows as one per-ticker Parquet history under
   `features/layer1/{ticker}.parquet`; daily incremental paths may still address a single
   `(date, ticker)` row through `features/layer1/{date}/{ticker}.parquet`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,6 +71,10 @@ Expected execution chain:
      instead of falling back to local heavy-ML execution
    - The command derives ticker scope from Layer 0 universe masks and fails closed on
      missing upstream manifests or archives
+   - Optional Level 2 features stay disabled unless `config/order_book_features.json`
+     explicitly enables a provider; when enabled, Layer 1 reads only the staged R2 archive
+     `raw/order_book/{provider}/{run_date}.parquet` and treats missing per-date coverage as
+     a null-feature condition instead of breaking the rest of Layer 1
 5. Deploy cloud oracle with fixed contracts
 6. Validate edge-to-cloud handshake plus Alpaca live-market-data normalization
 7. Dry-run risk and execution path

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -103,6 +103,10 @@ Execution chain:
    - Read FRED macro context series from the `raw/macro/{run_date}.parquet` point-in-time
      snapshot (with backward-compatible legacy-vintage recovery when older observation-date
      shards still exist)
+   - When `config/order_book_features.json` explicitly enables a provider, read the
+     provider-normalized pre-open Level 2 snapshot from
+     `raw/order_book/{provider}/{run_date}.parquet`; if the archive is missing for a date,
+     keep the branch non-fatal and emit null order-book features for that date/ticker scope
    - Fail closed if the required Layer 0 raw archives or manifests are missing
    - Derive the ticker scope from Layer 0 universe masks; optional ticker filters may only
      narrow that scope, never replace it with a hand-maintained production list
@@ -115,7 +119,7 @@ Execution chain:
      `features/layer1/news_sentiment_scored/{YYYY-MM-DD}/{run_id}.parquet` and aggregate
      ticker-day sentiment FeatureRecords into
      `features/layer1/sentiment_features/{YYYY-MM-DD}/{run_id}.parquet`
-   - Compute market, NLP, and context features for today
+   - Compute market, NLP, context, and optional order-book spread / imbalance features for today
    - Refresh aligned per-ticker feature histories at `features/layer1/TICKER.parquet` in R2
      while preserving daily single-record shard support for incremental runs
    - Run final archive validation, persist the JSON report under

--- a/services/README.md
+++ b/services/README.md
@@ -15,6 +15,7 @@ Out of scope:
 
 Subfolders:
 - `alpaca/` — delayed SIP OHLCV, historical/live news, live market data, broker state, and execution integrations
+- `order_book/` — optional Level 2 provider gating and non-secret config ownership
 - `r2/` — Cloudflare R2 object storage interfaces, canonical paths, and manifests
 - `modal/` — cloud job and deployment integrations
 - `observability/` — logging, metrics, and alert glue

--- a/services/order_book/README.md
+++ b/services/order_book/README.md
@@ -1,0 +1,15 @@
+# order_book
+
+Optional Layer 1 order-book configuration and provider boundary.
+
+Owner: Market data integration boundary.
+
+Responsibilities:
+- Own the non-secret repository config that gates optional Layer 1 Level 2 features
+- Keep provider naming and enablement rules outside `core/`
+- Preserve the disabled-by-default default until an explicit provider and archive exist
+
+Out of scope:
+- Live provider credentials
+- Layer 1 feature computation logic
+- Trading or model policy

--- a/services/order_book/__init__.py
+++ b/services/order_book/__init__.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from services.order_book.config import (
+    DEFAULT_ORDER_BOOK_FEATURE_CONFIG_PATH,
+    OrderBookFeatureConfig,
+    load_order_book_feature_config,
+)
+
+__all__ = [
+    "DEFAULT_ORDER_BOOK_FEATURE_CONFIG_PATH",
+    "OrderBookFeatureConfig",
+    "load_order_book_feature_config",
+]

--- a/services/order_book/config.py
+++ b/services/order_book/config.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_ORDER_BOOK_FEATURE_CONFIG_PATH = (
+    Path(__file__).resolve().parents[2] / "config" / "order_book_features.json"
+)
+_PROVIDER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+@dataclass(frozen=True)
+class OrderBookFeatureConfig:
+    """Repository-owned runtime gate for optional Layer 1 order-book features."""
+
+    enabled: bool = False
+    provider: str | None = None
+
+    @property
+    def is_active(self) -> bool:
+        """Return True only when the branch is explicitly enabled and a provider exists."""
+        return self.enabled and self.provider is not None
+
+
+def load_order_book_feature_config(
+    path: Path = DEFAULT_ORDER_BOOK_FEATURE_CONFIG_PATH,
+) -> OrderBookFeatureConfig:
+    """Load the optional Layer 1 order-book feature config from repository state."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    enabled = bool(payload.get("enabled", False))
+    raw_provider = payload.get("provider")
+    if raw_provider is None:
+        provider = None
+    elif not isinstance(raw_provider, str):
+        raise ValueError("order_book_features.provider must be a string or null")
+    else:
+        provider = raw_provider.strip().lower() or None
+        if provider is not None and _PROVIDER_RE.fullmatch(provider) is None:
+            raise ValueError(
+                "order_book_features.provider must contain only letters, digits, '-' or '_'"
+            )
+
+    return OrderBookFeatureConfig(enabled=enabled, provider=provider)

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -67,6 +67,17 @@ def raw_macro_path(archive_date: str | Date | datetime) -> str:
     return build_r2_key("raw", "macro", f"{_format_date(archive_date)}.parquet")
 
 
+def raw_order_book_path(provider: str, archive_date: str | Date | datetime) -> str:
+    """Return the canonical raw order-book Parquet path for one provider/date pair."""
+    safe_provider = _validate_key_part(provider).lower()
+    return build_r2_key(
+        "raw",
+        "order_book",
+        safe_provider,
+        f"{_format_date(archive_date)}.parquet",
+    )
+
+
 def is_canonical_raw_macro_key(key: str) -> bool:
     """Return True when a raw macro key follows the one-file-per-day pattern."""
     if not isinstance(key, str):

--- a/tests/unit/test_backfill_layer1.py
+++ b/tests/unit/test_backfill_layer1.py
@@ -348,12 +348,17 @@ def test_backfill_layer1_adds_optional_order_book_features_with_null_fallbacks(
         lambda: OrderBookFeatureConfig(enabled=True, provider="alpaca"),
     )
 
-    backfill_layer1(Layer1BackfillConfig(run_id="layer1-order-book", tickers=("AAPL",)), writer=writer)
+    backfill_layer1(
+        Layer1BackfillConfig(run_id="layer1-order-book", tickers=("AAPL",)),
+        writer=writer,
+    )
 
     records = read_feature_records("AAPL", writer=writer)
     by_date = {record.date: record.features for record in records}
     manifest = PipelineManifestRecord.model_validate_json(
-        writer.get_object(pipeline_manifest_path(LAYER1_BACKFILL_STAGE, "layer1-order-book"))
+        writer.get_object(
+            pipeline_manifest_path(LAYER1_BACKFILL_STAGE, "layer1-order-book")
+        )
     )
 
     assert by_date["2024-01-02"]["l2_bid_ask_spread"] == pytest.approx(0.05)

--- a/tests/unit/test_backfill_layer1.py
+++ b/tests/unit/test_backfill_layer1.py
@@ -20,6 +20,7 @@ from app.lab.data_pipelines.backfill_layer1 import (
 )
 from core.contracts.schemas import FeatureRecord, PipelineManifestRecord, RunStatus
 from core.features.io import feature_records_to_parquet_bytes, read_feature_records
+from services.order_book.config import OrderBookFeatureConfig
 from services.r2.client import (
     R2_ACCESS_KEY_ENV,
     R2_BUCKET_ENV,
@@ -34,6 +35,7 @@ from services.r2.paths import (
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_macro_path,
+    raw_order_book_path,
     raw_price_path,
 )
 from services.r2.writer import R2Writer
@@ -313,6 +315,53 @@ def test_backfill_layer1_merges_optional_branch_outputs_into_final_histories(
     assert by_date["2024-01-02"]["nlp_dominant_topic_id"] == 7
     assert by_date["2024-01-02"]["regime_label"] == "bull"
     assert by_date["2024-01-04"]["regime_prob_bear"] == 0.90
+
+
+def test_backfill_layer1_adds_optional_order_book_features_with_null_fallbacks(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Historical Layer 1 assembly stays stable when order-book coverage is partial."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    _write_synthetic_ohlcv(writer, "AAPL", num_bars=3)
+    _write_synthetic_ohlcv(writer, "SPY", num_bars=3)
+    _write_empty_macro_shard(writer)
+    _write_empty_fundamentals(writer, "AAPL")
+    archive = pd.DataFrame(
+        [
+            {
+                "date": "2024-01-02",
+                "ticker": "AAPL",
+                "captured_at": "2024-01-02T14:25:00+00:00",
+                "bid_price": 100.01,
+                "ask_price": 100.06,
+                "bid_size": 700,
+                "ask_size": 300,
+            }
+        ]
+    )
+    buffer = io.BytesIO()
+    archive.to_parquet(buffer, index=False)
+    writer.put_object(raw_order_book_path("alpaca", "2024-01-02"), buffer.getvalue())
+    monkeypatch.setattr(
+        "app.lab.data_pipelines.backfill_layer1.load_order_book_feature_config",
+        lambda: OrderBookFeatureConfig(enabled=True, provider="alpaca"),
+    )
+
+    backfill_layer1(Layer1BackfillConfig(run_id="layer1-order-book", tickers=("AAPL",)), writer=writer)
+
+    records = read_feature_records("AAPL", writer=writer)
+    by_date = {record.date: record.features for record in records}
+    manifest = PipelineManifestRecord.model_validate_json(
+        writer.get_object(pipeline_manifest_path(LAYER1_BACKFILL_STAGE, "layer1-order-book"))
+    )
+
+    assert by_date["2024-01-02"]["l2_bid_ask_spread"] == pytest.approx(0.05)
+    assert by_date["2024-01-02"]["l2_snapshot_count"] == 1
+    assert by_date["2024-01-03"]["l2_bid_ask_spread"] is None
+    assert by_date["2024-01-03"]["l2_snapshot_count"] == 0
+    assert manifest.metadata["order_book_enabled"] is True
+    assert manifest.metadata["order_book_provider"] == "alpaca"
 
 
 def test_backfill_layer1_skips_tickers_with_no_ohlcv(

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -29,12 +29,14 @@ from app.lab.data_pipelines.run_text_topics import TEXT_TOPICS_STAGE
 from app.lab.data_pipelines.validate_layer1_archive import Layer1ValidationReport
 from core.contracts.schemas import PipelineManifestRecord, RunStatus
 from core.features.io import feature_records_to_parquet_bytes, read_feature_records
+from services.order_book.config import OrderBookFeatureConfig
 from services.r2.paths import (
     layer1_regime_path,
     layer1_sentiment_feature_path,
     layer1_validation_report_path,
     pipeline_manifest_path,
     raw_macro_path,
+    raw_order_book_path,
     raw_price_path,
 )
 from services.r2.writer import R2Writer
@@ -88,6 +90,7 @@ def test_run_daily_layer1_happy_path_writes_history_and_completed_manifest(
     assert history[0].features["nlp_sentiment_score"] == pytest.approx(0.25)
     assert history[0].features["regime_label"] == "bull"
     assert "sector_etf_ret" in history[0].features
+    assert "l2_bid_ask_spread" not in history[0].features
     assert history[0].features["sector_relative_strength"] is None
     assert writer.exists("features/layer1/2024-01-03/AAPL.parquet") is True
     assert writer.exists(
@@ -171,6 +174,70 @@ def test_run_daily_layer1_prefers_topic_sentence_count_when_sentiment_conflicts(
     assert result.ready_for_layer2 is True
     assert history[0].features["nlp_sentence_count"] == 1
     assert history[0].features["nlp_sentiment_score"] == pytest.approx(0.25)
+
+
+def test_run_daily_layer1_adds_optional_order_book_features_without_breaking_missing_dates(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An enabled order-book branch writes features when present and nulls when absent."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2024-01-03", "2024-01-04"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-order-book",),
+    )
+    archive = pd.DataFrame(
+        [
+            {
+                "date": "2024-01-03",
+                "ticker": "AAPL",
+                "captured_at": "2024-01-03T14:25:00+00:00",
+                "bid_price": 100.01,
+                "ask_price": 100.06,
+                "bid_size": 700,
+                "ask_size": 300,
+            }
+        ]
+    )
+    buffer = io.BytesIO()
+    archive.to_parquet(buffer, index=False)
+    writer.put_object(raw_order_book_path("alpaca", "2024-01-03"), buffer.getvalue())
+    monkeypatch.setattr(
+        daily_layer1_module,
+        "load_order_book_feature_config",
+        lambda: OrderBookFeatureConfig(enabled=True, provider="alpaca"),
+    )
+
+    result = run_daily_layer1(
+        Layer1DailyConfig(
+            run_id="layer1-order-book",
+            from_date="2024-01-03",
+            to_date="2024-01-04",
+        ),
+        writer=writer,
+        news_runner=fake_news_runner(writer, ["AAPL"]),
+        text_topic_runner=fake_topic_runner(writer, ["AAPL"]),
+        finbert_runner=fake_sentiment_runner(writer, ["AAPL"]),
+        regime_runner=fake_regime_runner(writer),
+        validation_output_dir=tmp_path / "reports",
+        now=datetime(2024, 1, 5, 12, 0, tzinfo=UTC),
+    )
+
+    manifest = PipelineManifestRecord.model_validate_json(writer.get_object(result.manifest_key))
+    history = read_feature_records("AAPL", writer=writer)
+    by_date = {record.date: record.features for record in history}
+
+    assert result.ready_for_layer2 is True
+    assert by_date["2024-01-03"]["l2_bid_ask_spread"] == pytest.approx(0.05)
+    assert by_date["2024-01-03"]["l2_book_imbalance"] == pytest.approx(0.4)
+    assert by_date["2024-01-03"]["l2_snapshot_count"] == 1
+    assert by_date["2024-01-04"]["l2_bid_ask_spread"] is None
+    assert by_date["2024-01-04"]["l2_snapshot_count"] == 0
+    assert manifest.metadata["order_book_enabled"] is True
+    assert manifest.metadata["order_book_provider"] == "alpaca"
+    assert manifest.metadata["order_book_missing_dates"] == ["2024-01-04"]
 
 
 def test_run_daily_layer1_surfaces_regime_warmup_as_validation_warning(

--- a/tests/unit/test_feature_catalog.py
+++ b/tests/unit/test_feature_catalog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from core.features.catalog import feature_catalog, validate_feature_value
+from core.features.order_book_features import ORDER_BOOK_FEATURE_COLUMNS
 from core.features.sector_features import SECTOR_FEATURE_COLUMNS
 
 
@@ -24,3 +25,17 @@ def test_sector_relative_strength_has_bounded_catalog_rule() -> None:
     assert validate_feature_value("sector_relative_strength", -0.01, rule) is not None
     assert validate_feature_value("sector_relative_strength", 1.01, rule) is not None
     assert validate_feature_value("sector_relative_strength", 0.5, rule) is None
+
+
+def test_feature_catalog_registers_optional_order_book_features() -> None:
+    """Order-book columns remain optional and use bounded numeric rules."""
+    catalog = feature_catalog()
+
+    for feature_name in ORDER_BOOK_FEATURE_COLUMNS:
+        assert feature_name in catalog
+        assert catalog[feature_name].owner == "order_book"
+        assert catalog[feature_name].required is False
+
+    assert validate_feature_value("l2_bid_ask_spread", -0.01, catalog["l2_bid_ask_spread"]) is not None
+    assert validate_feature_value("l2_book_imbalance", 1.1, catalog["l2_book_imbalance"]) is not None
+    assert validate_feature_value("l2_book_imbalance", 0.2, catalog["l2_book_imbalance"]) is None

--- a/tests/unit/test_feature_catalog.py
+++ b/tests/unit/test_feature_catalog.py
@@ -36,6 +36,15 @@ def test_feature_catalog_registers_optional_order_book_features() -> None:
         assert catalog[feature_name].owner == "order_book"
         assert catalog[feature_name].required is False
 
-    assert validate_feature_value("l2_bid_ask_spread", -0.01, catalog["l2_bid_ask_spread"]) is not None
-    assert validate_feature_value("l2_book_imbalance", 1.1, catalog["l2_book_imbalance"]) is not None
-    assert validate_feature_value("l2_book_imbalance", 0.2, catalog["l2_book_imbalance"]) is None
+    assert (
+        validate_feature_value("l2_bid_ask_spread", -0.01, catalog["l2_bid_ask_spread"])
+        is not None
+    )
+    assert (
+        validate_feature_value("l2_book_imbalance", 1.1, catalog["l2_book_imbalance"])
+        is not None
+    )
+    assert (
+        validate_feature_value("l2_book_imbalance", 0.2, catalog["l2_book_imbalance"])
+        is None
+    )

--- a/tests/unit/test_feature_loaders.py
+++ b/tests/unit/test_feature_loaders.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import pandas as pd
 import pytest
 
-from core.features.loaders import load_macro_frame
-from services.r2.paths import raw_macro_path
+from core.features.loaders import load_macro_frame, load_order_book_frame
+from services.r2.paths import raw_macro_path, raw_order_book_path
 from tests.fixtures.layer1_support import local_writer
 
 
@@ -48,3 +48,32 @@ def test_load_macro_frame_deduplicates_equivalent_vintages_across_archive_dates(
     assert frame.loc[0, "snapshot_date"] == "2026-05-13"
     assert frame.loc[0, "observation_date"] == "2026-05-12"
     assert frame.loc[0, "retrieved_at"] == "2026-05-13T20:00:00+00:00"
+
+
+def test_load_order_book_frame_reads_one_provider_day_archive(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Layer 1 order-book loading stays R2-backed and provider/date scoped."""
+    writer = local_writer(tmp_path, monkeypatch)
+    archive = pd.DataFrame(
+        [
+            {
+                "date": "2026-05-13",
+                "ticker": "AAPL",
+                "captured_at": "2026-05-13T14:15:00+00:00",
+                "bid_price": 100.0,
+                "ask_price": 100.05,
+                "bid_size": 600,
+                "ask_size": 400,
+            }
+        ]
+    )
+    buffer = io.BytesIO()
+    archive.to_parquet(buffer, index=False)
+    writer.put_object(raw_order_book_path("alpaca", "2026-05-13"), buffer.getvalue())
+
+    frame = load_order_book_frame("alpaca", "2026-05-13", writer=writer)
+
+    assert len(frame.index) == 1
+    assert frame.loc[0, "ticker"] == "AAPL"

--- a/tests/unit/test_order_book_features.py
+++ b/tests/unit/test_order_book_features.py
@@ -68,7 +68,15 @@ def test_compute_order_book_features_aggregates_latest_pre_open_snapshot() -> No
 def test_compute_order_book_features_empty_frame_returns_null_rows() -> None:
     """Missing archives produce explicit null feature rows without failing assembly."""
     empty = pd.DataFrame(
-        columns=["date", "ticker", "captured_at", "bid_price", "ask_price", "bid_size", "ask_size"]
+        columns=[
+            "date",
+            "ticker",
+            "captured_at",
+            "bid_price",
+            "ask_price",
+            "bid_size",
+            "ask_size",
+        ]
     )
 
     features = compute_order_book_features(
@@ -168,3 +176,33 @@ def test_load_order_book_feature_config_reads_repo_owned_gate(tmp_path: Path) ->
 
     assert config == OrderBookFeatureConfig(enabled=True, provider="alpaca")
     assert config.is_active is True
+
+
+def test_load_order_book_feature_config_rejects_non_string_provider(tmp_path: Path) -> None:
+    """Provider must be a string or null in repository-owned config."""
+    path = tmp_path / "order_book_features.json"
+    path.write_text(
+        json.dumps({"enabled": True, "provider": 123}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="order_book_features.provider must be a string or null",
+    ):
+        load_order_book_feature_config(path)
+
+
+def test_load_order_book_feature_config_rejects_invalid_provider_name(tmp_path: Path) -> None:
+    """Provider names must match the path-safe repository validation rule."""
+    path = tmp_path / "order_book_features.json"
+    path.write_text(
+        json.dumps({"enabled": True, "provider": "alpaca!"}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="order_book_features.provider must contain only letters, digits, '-' or '_'",
+    ):
+        load_order_book_feature_config(path)

--- a/tests/unit/test_order_book_features.py
+++ b/tests/unit/test_order_book_features.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from core.features.order_book_features import (
+    ORDER_BOOK_FEATURE_COLUMNS,
+    compute_order_book_features,
+    order_book_features_to_records,
+)
+from services.order_book.config import OrderBookFeatureConfig, load_order_book_feature_config
+
+
+def _order_book_rows() -> pd.DataFrame:
+    """Return a minimal normalized order-book archive for one trade date."""
+    return pd.DataFrame(
+        [
+            {
+                "date": "2024-01-03",
+                "ticker": "AAPL",
+                "captured_at": "2024-01-03T14:15:00+00:00",
+                "bid_price": 100.00,
+                "ask_price": 100.05,
+                "bid_size": 600,
+                "ask_size": 400,
+            },
+            {
+                "date": "2024-01-03",
+                "ticker": "AAPL",
+                "captured_at": "2024-01-03T14:25:00+00:00",
+                "bid_price": 100.01,
+                "ask_price": 100.06,
+                "bid_size": 700,
+                "ask_size": 300,
+            },
+            {
+                "date": "2024-01-03",
+                "ticker": "MSFT",
+                "captured_at": "2024-01-03T14:20:00+00:00",
+                "bid_price": 200.00,
+                "ask_price": 200.10,
+                "bid_size": 500,
+                "ask_size": 500,
+            },
+        ]
+    )
+
+
+def test_compute_order_book_features_aggregates_latest_pre_open_snapshot() -> None:
+    """Each ticker emits one daily row using the latest valid pre-open snapshot."""
+    features = compute_order_book_features(
+        _order_book_rows(),
+        target_date="2024-01-03",
+        tickers=("AAPL", "MSFT"),
+    )
+
+    assert list(features.columns) == ["date", "ticker", *ORDER_BOOK_FEATURE_COLUMNS]
+    aapl = features.loc[features["ticker"] == "AAPL"].iloc[0]
+    assert aapl["l2_bid_ask_spread"] == pytest.approx(0.05)
+    assert aapl["l2_quoted_spread_bps"] == pytest.approx(4.99875, rel=1e-4)
+    assert aapl["l2_book_imbalance"] == pytest.approx(0.4)
+    assert aapl["l2_snapshot_count"] == 2
+
+
+def test_compute_order_book_features_empty_frame_returns_null_rows() -> None:
+    """Missing archives produce explicit null feature rows without failing assembly."""
+    empty = pd.DataFrame(
+        columns=["date", "ticker", "captured_at", "bid_price", "ask_price", "bid_size", "ask_size"]
+    )
+
+    features = compute_order_book_features(
+        empty,
+        target_date="2024-01-03",
+        tickers=("AAPL",),
+    )
+
+    row = features.iloc[0]
+    assert row["ticker"] == "AAPL"
+    assert pd.isna(row["l2_bid_ask_spread"])
+    assert pd.isna(row["l2_quoted_spread_bps"])
+    assert pd.isna(row["l2_book_imbalance"])
+    assert row["l2_snapshot_count"] == 0
+
+
+def test_compute_order_book_features_rejects_missing_columns() -> None:
+    """The normalized archive contract must include the required provider columns."""
+    rows = _order_book_rows().drop(columns=["ask_size"])
+
+    with pytest.raises(ValueError, match="ask_size"):
+        compute_order_book_features(rows, target_date="2024-01-03", tickers=("AAPL",))
+
+
+def test_compute_order_book_features_ignores_invalid_and_post_open_rows() -> None:
+    """Bad quotes and post-open rows are dropped instead of breaking the branch."""
+    rows = pd.DataFrame(
+        [
+            {
+                "date": "2024-01-03",
+                "ticker": "AAPL",
+                "captured_at": "2024-01-03T14:31:00+00:00",
+                "bid_price": 100.00,
+                "ask_price": 100.05,
+                "bid_size": 600,
+                "ask_size": 400,
+            },
+            {
+                "date": "2024-01-03",
+                "ticker": "AAPL",
+                "captured_at": "2024-01-03T14:20:00+00:00",
+                "bid_price": 100.00,
+                "ask_price": float("nan"),
+                "bid_size": 600,
+                "ask_size": 400,
+            },
+        ]
+    )
+
+    features = compute_order_book_features(
+        rows,
+        target_date="2024-01-03",
+        tickers=("AAPL",),
+    )
+
+    row = features.iloc[0]
+    assert pd.isna(row["l2_bid_ask_spread"])
+    assert row["l2_snapshot_count"] == 0
+
+
+def test_order_book_features_to_records_coerces_nan_to_none() -> None:
+    """FeatureRecord serialization keeps missing order-book values contract-safe."""
+    features = compute_order_book_features(
+        pd.DataFrame(
+            columns=[
+                "date",
+                "ticker",
+                "captured_at",
+                "bid_price",
+                "ask_price",
+                "bid_size",
+                "ask_size",
+            ]
+        ),
+        target_date="2024-01-03",
+        tickers=("AAPL",),
+    )
+
+    records = order_book_features_to_records(features)
+
+    assert len(records) == 1
+    assert records[0].date == "2024-01-03"
+    assert records[0].ticker == "AAPL"
+    assert records[0].features["l2_bid_ask_spread"] is None
+    assert records[0].features["l2_snapshot_count"] == 0
+
+
+def test_load_order_book_feature_config_reads_repo_owned_gate(tmp_path: Path) -> None:
+    """The optional branch is controlled by repository config rather than code defaults."""
+    path = tmp_path / "order_book_features.json"
+    path.write_text(
+        json.dumps({"enabled": True, "provider": "alpaca"}),
+        encoding="utf-8",
+    )
+
+    config = load_order_book_feature_config(path)
+
+    assert config == OrderBookFeatureConfig(enabled=True, provider="alpaca")
+    assert config.is_active is True

--- a/tests/unit/test_r2_paths.py
+++ b/tests/unit/test_r2_paths.py
@@ -25,6 +25,7 @@ from services.r2.paths import (
     raw_macro_date_from_key,
     raw_macro_path,
     raw_news_path,
+    raw_order_book_path,
     raw_price_path,
     raw_reference_path,
     raw_security_master_path,
@@ -45,6 +46,7 @@ def test_layer0_raw_path_builders_return_canonical_keys() -> None:
     assert raw_universe_path(date(2025, 1, 2)) == "raw/universe/2025-01-02.csv"
     assert raw_fundamentals_path("AAPL") == "raw/fundamentals/AAPL.parquet"
     assert raw_macro_path(date(2025, 1, 2)) == "raw/macro/2025-01-02.parquet"
+    assert raw_order_book_path("alpaca", "2025-01-02") == "raw/order_book/alpaca/2025-01-02.parquet"
     assert raw_macro_path("2025-01-02") == "raw/macro/2025-01-02.parquet"
     assert is_canonical_raw_macro_key("raw/macro/2025-01-02.parquet") is True
     assert raw_macro_date_from_key("raw/macro/2025-01-02.parquet") == "2025-01-02"


### PR DESCRIPTION
## What this PR does
Adds a provider-gated, disabled-by-default Layer 1 order-book feature branch that reads normalized R2 Level 2 archives when explicitly configured, computes spread and book-imbalance features for both daily and backfill Layer 1 assembly, and leaves existing Layer 1 generation non-fatal when order-book coverage is missing.

## Closes
Closes #151

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Not applicable.

## Notes for reviewer
The new branch is controlled by `config/order_book_features.json` and stays off by default. When enabled with an explicit provider, Layer 1 reads `raw/order_book/{provider}/{YYYY-MM-DD}.parquet`, computes optional `l2_*` features, and emits null order-book values instead of failing when daily coverage is missing.