### PR TITLE
[Codex] De-scope unsupported Layer 1 options-derived features

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,10 @@
 - [x] FinBERT source credibility weighting missing from sentiment_features.py
 - [x] HMM regime detection needs training data pipeline before it can be fitted
 - [x] data/sample/ fixture files do not exist yet — needed for all unit tests
+- [x] Unsupported Layer 1 options-derived planning branch (`iv_rank`, `put_call_ratio`,
+  `iv_skew`) was removed from the current baseline in Issue `#150` because the repo has no
+  existing-stack point-in-time historical options-chain provider, archive contract, or
+  non-secret config surface for those inputs
 
 ## Technical debt
 <!-- Things that work but should be improved -->

--- a/config/README.md
+++ b/config/README.md
@@ -46,6 +46,9 @@ Use an R2 token/access key with read/write access to the bucket. Do not use the 
   sector-to-ETF mapping used by Layer 1 sector/factor features.
 - `config/order_book_features.json` gates the optional Layer 1 Level 2/order-book branch;
   it stays disabled by default until an explicit provider name is configured.
+- no repository config currently enables Layer 1 options-derived features; the baseline
+  stack defines no non-secret config or point-in-time historical options-chain archive
+  contract for `iv_rank`, `put_call_ratio`, or `iv_skew`
 - `config/source_credibility.json` controls source credibility weights used for
   FinBERT sentiment aggregation.
 - `config/finbert_sentiment.json` controls the Modal app, model identity, batch size,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -149,6 +149,12 @@ This is not just a switch in the optimizer. It requires:
 | Optional Level 2 / order-book snapshots | Explicit provider config only | Disabled by default; Layer 1 reads provider-normalized pre-open archives from R2 only when they are explicitly staged and configured |
 | Live daily prices / broker state / execution | Alpaca Market Data + Trading API | Current-day bar snapshot, reconciliation source of truth, and order routing |
 
+Current baseline omission:
+- the repository does not define a point-in-time historical options-chain provider,
+  raw options archive, or Layer 1 options-derived branch
+- `iv_rank`, `put_call_ratio`, and `iv_skew` are intentionally out of scope until an
+  existing-stack provider is adopted and documented end-to-end
+
 ### Universe construction note
 Wikipedia's S&P 500 page revision history provides historical constituent changes at no cost.
 The revision history — not the current page — must be scraped to obtain point-in-time membership.
@@ -272,6 +278,8 @@ Responsibilities:
 - persist every external data source needed by Layer 1 into R2 before feature generation runs
 - when an explicit Level 2 provider is enabled, stage its normalized pre-open order-book
   snapshots in R2 before Layer 1 tries to consume them
+- do not assume a raw options-chain archive exists in the current baseline; Layer 1 has no
+  point-in-time historical options inputs for `iv_rank`, `put_call_ratio`, or `iv_skew`
 
 **Layer 0 operates in two distinct modes:**
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -203,6 +203,9 @@ Notes:
   into optional per-ticker daily spread / imbalance features
 - missing order-book archives must not break the base Layer 1 run; when the branch is
   explicitly enabled, missing coverage resolves to null order-book features instead
+- this is the only optional market-data archive branch defined in the current baseline;
+  no raw options-chain archive contract exists for `iv_rank`, `put_call_ratio`, or
+  `iv_skew`
 - this archive is not a replacement for `FeatureRecord`
 - no schema changes in `core/contracts/schemas.py` are required unless the project decides
   to promote raw order-book observations into a typed inter-layer contract later
@@ -263,6 +266,9 @@ Input note:
   regime artifacts/manifests already persisted in R2, plus any explicitly configured
   provider-normalized order-book archives already staged in R2; Layer 1 must not call
   external data providers for feature inputs
+- the current baseline defines no Layer 0 raw options-chain archive and no Layer 1
+  options-derived feature branch, so `iv_rank`, `put_call_ratio`, and `iv_skew` are not
+  expected FeatureRecord keys
 - historical backfills store FeatureRecord rows as one per-ticker Parquet history under
   `features/layer1/{ticker}.parquet`; daily incremental paths may still address a single
   `(date, ticker)` row through `features/layer1/{date}/{ticker}.parquet`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -75,6 +75,10 @@ Expected execution chain:
      explicitly enables a provider; when enabled, Layer 1 reads only the staged R2 archive
      `raw/order_book/{provider}/{run_date}.parquet` and treats missing per-date coverage as
      a null-feature condition instead of breaking the rest of Layer 1
+   - The baseline stack does not define an options-chain archive or non-secret config for
+     `iv_rank`, `put_call_ratio`, or `iv_skew`; do not expect an options-derived Layer 1
+     branch unless a future task adds an existing-stack provider and documents the archive
+     contract
 5. Deploy cloud oracle with fixed contracts
 6. Validate edge-to-cloud handshake plus Alpaca live-market-data normalization
 7. Dry-run risk and execution path

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -107,6 +107,9 @@ Execution chain:
      provider-normalized pre-open Level 2 snapshot from
      `raw/order_book/{provider}/{run_date}.parquet`; if the archive is missing for a date,
      keep the branch non-fatal and emit null order-book features for that date/ticker scope
+   - No options-derived Layer 1 branch is part of the baseline daily flow; the repo does
+     not define a point-in-time historical options-chain archive or config for `iv_rank`,
+     `put_call_ratio`, or `iv_skew`
    - Fail closed if the required Layer 0 raw archives or manifests are missing
    - Derive the ticker scope from Layer 0 universe masks; optional ticker filters may only
      narrow that scope, never replace it with a hand-maintained production list

--- a/services/README.md
+++ b/services/README.md
@@ -23,3 +23,8 @@ Subfolders:
 - `tiingo/` — deprecated legacy historical OHLCV adapters; not a Layer 0 production dependency
 - `simfin/` — point-in-time fundamentals and earnings-date adapters
 - `fred/` — macro and rates context adapters
+
+The current baseline repo has no active options-chain adapter or archive contract. Layer 1
+options-derived features such as `iv_rank`, `put_call_ratio`, and `iv_skew` are therefore
+out of scope until a future task adds an existing-stack provider and the corresponding
+repository-owned archive/config surfaces.


### PR DESCRIPTION
## What this PR does
This PR resolves Issue #150 by removing the unsupported Layer 1 options-derived planning branch from repo-facing docs and config expectations. The current repo baseline has no implemented point-in-time historical options-chain provider, no raw options archive contract, and no non-secret config surface for `iv_rank`, `put_call_ratio`, or `iv_skew`, so the approved fallback was to de-scope those features rather than invent a new provider path.

## Closes
Closes #150

## Layer(s) affected
- [x] Layer 1 — Features
- [x] Infrastructure / services
- [x] Docs only

## Author
- [ ] Written by me
- [ ] Generated by Codex — reviewed and approved by me
Human review pending.

---

## Codex checklist

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] No unused imports

### Project hygiene
- [x] Branch named `codex/150-descope-options-features`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Notes for reviewer
Commands run:
- `./.venv/bin/python -m ruff check .`
- `./.venv/bin/pytest tests/unit/ -v --tb=short`

Test result summary:
- `ruff`: passed
- `pytest`: 579 passed

Known skipped/missing data:
- No point-in-time historical options-chain provider, raw archive contract, or non-secret config exists in the current repo baseline for `iv_rank`, `put_call_ratio`, or `iv_skew`.
- This PR intentionally resolves #150 by deleting that unsupported planning branch from repo docs/TODO/config expectations instead of adding a new provider.