### PR TITLE
Fix Layer 1.5 required regime rows when only dropped HMM features are null

### DIFF
--- a/core/features/regime_detection.py
+++ b/core/features/regime_detection.py
@@ -239,7 +239,7 @@ def emit_hmm_regime_features(
     if len(infer_rows) == 0:
         return pd.DataFrame(columns=list(HMM_REGIME_COLUMNS))
 
-    complete_mask = infer_rows["is_complete"].astype(bool)
+    complete_mask = _complete_row_mask(infer_rows, model.feature_columns)
     result = pd.DataFrame({"date": infer_rows["date"].tolist()})
     result["regime_label"] = None
     for column in HMM_REGIME_FEATURE_COLUMNS[1:]:

--- a/tests/unit/test_hmm_regime_runner.py
+++ b/tests/unit/test_hmm_regime_runner.py
@@ -122,6 +122,67 @@ def test_run_hmm_regime_detection_emits_warning_rows_for_short_history(
     assert manifest["metadata"]["regime_layer2_ready"] is False
 
 
+def test_run_hmm_regime_detection_scores_inference_rows_when_only_dropped_features_are_null(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Runner emits non-null output when readiness is satisfied on the active feature subset."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    bars = _benchmark_bars(130)
+    macro = _macro_archive(150)
+    _write_parquet(writer, raw_price_path("SPY"), bars)
+    _write_parquet(writer, raw_macro_path("2023-01-02"), macro)
+
+    dates = pd.bdate_range("2024-01-02", periods=135)
+    training_rows: list[dict[str, object]] = []
+    for index, date in enumerate(dates):
+        training_rows.append(
+            {
+                "date": date.date().isoformat(),
+                "spy_log_return_1d": 0.01 + index * 0.0001,
+                "spy_return_5d": 0.03,
+                "spy_realized_vol_21d": 0.12,
+                "spy_realized_vol_63d": 0.10,
+                "spy_vol_ratio_21_63": 1.2,
+                "spy_drawdown_63d": -0.02,
+                "vix_level": 16.0,
+                "vix_change_5d": -0.1,
+                "yield_curve_slope_10y_2y": 0.3,
+                "yield_curve_slope_10y_3m": 0.4,
+                "high_yield_spread": float("nan"),
+                "is_complete": False,
+            }
+        )
+    synthetic_training = pd.DataFrame(training_rows)
+    monkeypatch.setattr(
+        "app.lab.data_pipelines.run_hmm_regime_detection.build_hmm_training_frame",
+        lambda benchmark, macro: synthetic_training,
+    )
+
+    inference_date = str(dates[110].date())
+    result = run_hmm_regime_detection(
+        HMMRegimePipelineConfig(
+            run_id="hmm-dropped-feature-ready",
+            train_end_date=str(dates[100].date()),
+            inference_dates=(inference_date,),
+            min_training_rows=90,
+            max_iterations=20,
+        ),
+        writer=writer,
+    )
+
+    output = pd.read_parquet(io.BytesIO(writer.get_object(result.output_key)))
+    manifest = json.loads(writer.get_object(result.manifest_key))
+
+    assert output.loc[0, "date"] == inference_date
+    assert output.loc[0, "regime_label"] in {"bear", "sideways", "bull"}
+    assert output.loc[0, "regime_readiness_status"] == "ready"
+    assert bool(output.loc[0, "regime_required_for_layer2"]) is True
+    assert output["regime_confidence"].notna().all()
+    assert manifest["status"] == RunStatus.COMPLETED
+    assert manifest["metadata"]["regime_layer2_ready"] is True
+
+
 def test_load_modal_runtime_config_reads_repo_config() -> None:
     """Modal app and secret names live in config rather than code constants."""
     config = load_modal_runtime_config()

--- a/tests/unit/test_regime_detection.py
+++ b/tests/unit/test_regime_detection.py
@@ -154,6 +154,45 @@ def test_inspect_hmm_regime_readiness_marks_short_history_not_trainable() -> Non
     assert readiness.complete_inference_dates == (inference_date,)
 
 
+def test_emit_hmm_regime_features_uses_active_feature_subset_for_inference_rows() -> None:
+    """Inference scoring should use the fitted feature subset, not stale is_complete flags."""
+    training = _synthetic_training_frame()
+    training["high_yield_spread"] = float("nan")
+    training["is_complete"] = False
+    train_end_date = str(training.loc[100, "date"])
+    inference_date = str(training.loc[110, "date"])
+
+    readiness = inspect_hmm_regime_readiness(
+        training,
+        train_end_date=train_end_date,
+        inference_dates=[inference_date],
+        config=HMMRegimeConfig(min_training_rows=90, max_iterations=20),
+    )
+    model = fit_hmm_regime_model(
+        training,
+        train_end_date=train_end_date,
+        config=HMMRegimeConfig(min_training_rows=90, max_iterations=20),
+    )
+    features = emit_hmm_regime_features(
+        training,
+        model=model,
+        inference_dates=[inference_date],
+    )
+
+    assert readiness.can_fit_model is True
+    assert readiness.complete_inference_dates == (inference_date,)
+    assert "high_yield_spread" not in model.feature_columns
+    assert features.loc[0, "date"] == inference_date
+    assert features.loc[0, "regime_label"] in {"bear", "sideways", "bull"}
+    assert features.loc[0, "regime_confidence"] == pytest.approx(
+        max(
+            features.loc[0, "regime_prob_bear"],
+            features.loc[0, "regime_prob_sideways"],
+            features.loc[0, "regime_prob_bull"],
+        )
+    )
+
+
 def test_validate_hmm_regime_probabilities_rejects_bad_probability_sums() -> None:
     """Populated regime rows must stay normalized and internally consistent."""
     features = pd.DataFrame(


### PR DESCRIPTION
## What this PR does
Fixes a Layer 1.5 regime inference bug that could emit all-null required regime rows when the bounded HMM window was fit-ready on its active feature subset but the broader precomputed `is_complete` flag stayed false. The HMM emission path now recomputes inference-row completeness from the fitted model's active feature columns, and the regression suite covers both the core scorer and the Layer 1.5 runner path that matches the 2026-04-14 authoritative rerun failure.

## Closes
Closes #189

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [ ] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
- Reproduced failure mode in regression coverage where `readiness.can_fit_model` is true and `complete_inference_dates` includes the requested date even though the stale broad `is_complete` flag is false.
- Relevant local verification:
  - `./.venv/bin/pytest tests/unit/ -v --tb=short`
  - `./.venv/bin/pytest tests/integration/test_regime_detection_integration.py tests/integration/test_layer1_orchestration_integration.py tests/integration/test_layer1_readiness_report_integration.py -v --tb=short`

## Notes for reviewer
- This is intentionally narrow: no schema or doc changes, and no live Modal/R2 rerun was performed in this PR.
- `#143` should remain blocked until the authoritative rerun is executed again on the merged code and the 2026-04-14+ readiness window is revalidated.
