### PR TITLE
[Bug] Fix false Layer 1.5 warm-up readiness

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -310,14 +310,43 @@ class OptionalOrderBookBranch:
 class Layer1ValidationError(RuntimeError):
     """Raised when Layer 1 validation completes but is not ready for Layer 2."""
 
-    def __init__(self, report: Layer1ValidationReport, report_path: Path) -> None:
+    def __init__(
+        self,
+        report: Layer1ValidationReport | str,
+        report_path: Path | str | None = None,
+    ) -> None:
         """Capture the failing validation report."""
-        summary = _validation_failure_summary(report)
-        super().__init__(
-            f"Layer 1 validation failed: {summary} (report={report_path})"
+        resolved_report: Layer1ValidationReport | None
+        resolved_report_path = (
+            Path(report_path) if isinstance(report_path, str) else report_path
         )
-        self.report = report
-        self.report_path = report_path
+        if isinstance(report, Layer1ValidationReport):
+            summary = _validation_failure_summary(report)
+            message = f"Layer 1 validation failed: {summary}"
+            if resolved_report_path is not None:
+                message += f" (report={resolved_report_path})"
+            resolved_report = report
+        else:
+            message = str(report)
+            resolved_report = None
+        super().__init__(message)
+        self.report = resolved_report
+        self.report_path = resolved_report_path
+
+    def __reduce__(
+        self,
+    ) -> tuple[
+        type[Layer1ValidationError],
+        tuple[Layer1ValidationReport | str, Path | None],
+    ]:
+        """Preserve structured report context across remote exception serialization."""
+        return (
+            type(self),
+            (
+                self.report if self.report is not None else str(self),
+                self.report_path,
+            ),
+        )
 
 
 def run_daily_layer1(

--- a/core/features/regime_detection.py
+++ b/core/features/regime_detection.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import importlib
 import math
 from dataclasses import dataclass
+from itertools import combinations
 from typing import TYPE_CHECKING, Any
 
 from core.contracts.schemas import FeatureRecord
@@ -119,6 +120,7 @@ def fit_hmm_regime_model(
         feature_columns=feature_columns,
         train_start_date=train_start_date,
         train_end_date=train_end_date,
+        min_training_rows=active_config.min_training_rows,
     )
     if not active_feature_columns:
         raise ValueError("HMM training window has no usable feature columns")
@@ -172,6 +174,7 @@ def inspect_hmm_regime_readiness(
         feature_columns=feature_columns,
         train_start_date=train_start_date,
         train_end_date=train_end_date,
+        min_training_rows=active_config.min_training_rows,
     )
     dropped_feature_columns = tuple(
         column for column in feature_columns if column not in active_feature_columns
@@ -642,17 +645,49 @@ def _active_feature_columns(
     feature_columns: tuple[str, ...],
     train_start_date: str | None,
     train_end_date: str,
+    min_training_rows: int,
 ) -> tuple[str, ...]:
-    """Return feature columns with at least one usable value inside the train window."""
+    """Return the broadest usable feature subset for the bounded train window."""
     rows = training_frame.copy()
     if train_start_date is not None:
         rows = rows[rows["date"] >= train_start_date]
     rows = rows[rows["date"] < train_end_date]
-    active: list[str] = []
-    for column in feature_columns:
-        if column in rows and _series_has_finite_value(rows[column]):
-            active.append(column)
-    return tuple(active)
+    candidates = tuple(
+        column
+        for column in feature_columns
+        if column in rows and _series_has_finite_value(rows[column])
+    )
+    if not candidates:
+        return ()
+
+    fallback_subset = candidates[:1]
+    fallback_complete_rows = _complete_row_count(rows, fallback_subset)
+    for subset_size in range(len(candidates), 0, -1):
+        best_subset_for_size: tuple[str, ...] | None = None
+        best_complete_rows_for_size = -1
+        for subset in combinations(candidates, subset_size):
+            complete_rows = _complete_row_count(rows, subset)
+            if complete_rows > fallback_complete_rows:
+                fallback_subset = subset
+                fallback_complete_rows = complete_rows
+            if complete_rows < min_training_rows:
+                continue
+            if complete_rows > best_complete_rows_for_size:
+                best_subset_for_size = subset
+                best_complete_rows_for_size = complete_rows
+        if best_subset_for_size is not None:
+            return best_subset_for_size
+    return fallback_subset
+
+
+def _complete_row_count(
+    frame: pd.DataFrame,
+    feature_columns: tuple[str, ...],
+) -> int:
+    """Return the number of fully populated rows for one feature subset."""
+    if not feature_columns:
+        return len(frame.index)
+    return int(_complete_row_mask(frame, feature_columns).sum())
 
 
 def _complete_row_mask(frame: pd.DataFrame, feature_columns: tuple[str, ...]):

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import json
+import pickle
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -954,6 +955,31 @@ def test_main_returns_nonzero_when_validation_is_not_ready(
 
     assert exit_code == 1
     assert logged_messages == [str(error)]
+
+
+def test_layer1_validation_error_round_trips_through_pickle(tmp_path: Path) -> None:
+    """Validation errors should preserve their structured state across pickling."""
+    report = Layer1ValidationReport(
+        run_id="layer1-cli-fail",
+        from_date="2024-01-03",
+        to_date="2024-01-03",
+        validation_status="failed",
+        expected_ticker_files=1,
+        present_ticker_files=0,
+        expected_rows=1,
+        present_rows=0,
+        schema_failures=0,
+        row_count_failures=0,
+        ready_for_layer2=False,
+    )
+    error = Layer1ValidationError(report, tmp_path / "report.json")
+
+    restored = pickle.loads(pickle.dumps(error))
+
+    assert str(restored) == str(error)
+    assert restored.report is not None
+    assert restored.report.run_id == report.run_id
+    assert restored.report_path == tmp_path / "report.json"
 
 
 def test_main_single_date_delegates_to_modal_orchestration_when_available(

--- a/tests/unit/test_hmm_regime_runner.py
+++ b/tests/unit/test_hmm_regime_runner.py
@@ -183,6 +183,71 @@ def test_run_hmm_regime_detection_scores_inference_rows_when_only_dropped_featur
     assert manifest["metadata"]["regime_layer2_ready"] is True
 
 
+def test_run_hmm_regime_detection_drops_sparse_late_starting_feature(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """One newly available macro feature should not trigger a false warm-up warning."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    bars = _benchmark_bars(130)
+    macro = _macro_archive(150)
+    _write_parquet(writer, raw_price_path("SPY"), bars)
+    _write_parquet(writer, raw_macro_path("2023-01-02"), macro)
+
+    dates = pd.bdate_range("2024-01-02", periods=135)
+    training_rows: list[dict[str, object]] = []
+    for index, date in enumerate(dates):
+        training_rows.append(
+            {
+                "date": date.date().isoformat(),
+                "spy_log_return_1d": 0.01 + index * 0.0001,
+                "spy_return_5d": 0.03,
+                "spy_realized_vol_21d": 0.12,
+                "spy_realized_vol_63d": 0.10,
+                "spy_vol_ratio_21_63": 1.2,
+                "spy_drawdown_63d": -0.02,
+                "vix_level": 16.0,
+                "vix_change_5d": -0.1,
+                "yield_curve_slope_10y_2y": 0.3,
+                "yield_curve_slope_10y_3m": 0.4,
+                "high_yield_spread": float("nan"),
+                "is_complete": False,
+            }
+        )
+    synthetic_training = pd.DataFrame(training_rows)
+    synthetic_training.loc[99, "high_yield_spread"] = 3.2
+    synthetic_training.loc[110, "high_yield_spread"] = 3.3
+    monkeypatch.setattr(
+        "app.lab.data_pipelines.run_hmm_regime_detection.build_hmm_training_frame",
+        lambda benchmark, macro: synthetic_training,
+    )
+
+    inference_date = str(dates[110].date())
+    result = run_hmm_regime_detection(
+        HMMRegimePipelineConfig(
+            run_id="hmm-sparse-feature-ready",
+            train_end_date=str(dates[100].date()),
+            inference_dates=(inference_date,),
+            min_training_rows=90,
+            max_iterations=20,
+        ),
+        writer=writer,
+    )
+
+    output = pd.read_parquet(io.BytesIO(writer.get_object(result.output_key)))
+    manifest = json.loads(writer.get_object(result.manifest_key))
+
+    assert output.loc[0, "date"] == inference_date
+    assert output.loc[0, "regime_label"] in {"bear", "sideways", "bull"}
+    assert output.loc[0, "regime_readiness_status"] == "ready"
+    assert output.loc[0, "regime_readiness_reason"] == "ready"
+    assert bool(output.loc[0, "regime_required_for_layer2"]) is True
+    assert output["regime_confidence"].notna().all()
+    assert manifest["status"] == RunStatus.COMPLETED
+    assert manifest["metadata"]["regime_layer2_ready"] is True
+    assert "high_yield_spread" in manifest["metadata"]["dropped_feature_columns"]
+
+
 def test_run_hmm_regime_detection_bounds_macro_load_to_train_and_inference_window(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/test_regime_detection.py
+++ b/tests/unit/test_regime_detection.py
@@ -193,6 +193,29 @@ def test_emit_hmm_regime_features_uses_active_feature_subset_for_inference_rows(
     )
 
 
+def test_inspect_hmm_regime_readiness_drops_sparse_late_starting_features() -> None:
+    """A newly sparse macro feature should not collapse an otherwise ready train window."""
+    training = _synthetic_training_frame()
+    training["high_yield_spread"] = float("nan")
+    train_end_date = str(training.loc[100, "date"])
+    inference_date = str(training.loc[110, "date"])
+    training.loc[99, "high_yield_spread"] = 3.2
+    training.loc[110, "high_yield_spread"] = 3.3
+
+    readiness = inspect_hmm_regime_readiness(
+        training,
+        train_end_date=train_end_date,
+        inference_dates=[inference_date],
+        config=HMMRegimeConfig(min_training_rows=90, max_iterations=20),
+    )
+
+    assert readiness.can_fit_model is True
+    assert readiness.complete_training_rows == 100
+    assert readiness.complete_inference_dates == (inference_date,)
+    assert "high_yield_spread" not in readiness.feature_columns
+    assert "high_yield_spread" in readiness.dropped_feature_columns
+
+
 def test_validate_hmm_regime_probabilities_rejects_bad_probability_sums() -> None:
     """Populated regime rows must stay normalized and internally consistent."""
     features = pd.DataFrame(


### PR DESCRIPTION
## What this PR does
Fixes the false Layer 1.5 readiness downgrade that started on 2026-04-17 after PR #194. The HMM readiness selector now keeps the largest feature subset that still preserves the configured minimum number of complete training rows, so a newly sparse macro feature such as `high_yield_spread` is dropped until it has enough as-of-safe history instead of collapsing the whole train window to `insufficient_training_history`. This PR also makes `Layer1ValidationError` round-trip safely through remote exception serialization so Modal surfaces the real validation error instead of a constructor mismatch.

## Closes
Advances #189

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [ ] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
- Real archive readiness check after the patch: `2026-04-15`, `2026-04-16`, and `2026-04-17` all resolve `can_fit_model=True` with `complete_training_rows=725`, while `high_yield_spread` is deferred in `dropped_feature_columns` until it has enough history.

## Notes for reviewer
The remaining gate for Issue #189 is an authoritative live R2 rerun of the affected readiness window. I did not run the full Modal/R2 catch-up in this PR step; the issue should stay open until that rerun produces passing readiness evidence.
