### PR TITLE
Resume Layer 1 topic runs after Modal timeouts

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -1738,42 +1738,77 @@ def modal_main(
         reference_date=as_of_date,
     )
     stage_run_id = _stage_run_id(run_id, as_of_date)
-    news_result = _run_module_modal_remote(
-        news_module,
-        "modal_run_news_preprocessing",
+    writer = R2Writer()
+    preprocessed_news_key = _load_completed_stage_output(
+        writer=writer,
+        stage=NLP_PREPROCESSING_STAGE,
         run_id=stage_run_id,
         as_of_date=as_of_date,
-        min_sentence_chars=min_sentence_chars,
     )
-    preprocessed_news_key = _require_result_key(news_result, "output_key")
+    if preprocessed_news_key is None:
+        news_result = _run_module_modal_remote(
+            news_module,
+            "modal_run_news_preprocessing",
+            run_id=stage_run_id,
+            as_of_date=as_of_date,
+            min_sentence_chars=min_sentence_chars,
+        )
+        preprocessed_news_key = _require_result_key(news_result, "output_key")
     # Keep stage dispatch synchronous here. In production readiness runs, `.spawn()`
     # against imported stage apps can leave the daily manifest stuck in `running`
     # without ever producing downstream stage manifests.
-    topic_result = _run_module_modal_remote(
-        text_topics_module,
-        "modal_run_text_topics",
+    topic_feature_key = _load_completed_stage_output(
+        writer=writer,
+        stage=TEXT_TOPICS_STAGE,
         run_id=stage_run_id,
         as_of_date=as_of_date,
-        preprocessed_news_key=preprocessed_news_key,
     )
-    sentiment_result = _run_module_modal_remote(
-        finbert_module,
-        "modal_run_finbert_sentiment",
+    if topic_feature_key is None:
+        topic_result = _run_module_modal_remote(
+            text_topics_module,
+            "modal_run_text_topics",
+            run_id=stage_run_id,
+            as_of_date=as_of_date,
+            preprocessed_news_key=preprocessed_news_key,
+        )
+        topic_feature_key = _require_result_key(topic_result, "topic_feature_key")
+    sentiment_feature_key = _load_completed_stage_output(
+        writer=writer,
+        stage=FINBERT_SENTIMENT_STAGE,
         run_id=stage_run_id,
         as_of_date=as_of_date,
-        preprocessed_news_key=preprocessed_news_key,
     )
-    regime_result = _run_module_modal_remote(
-        regime_module,
-        "modal_run_hmm_regime_detection",
+    if sentiment_feature_key is None:
+        sentiment_result = _run_module_modal_remote(
+            finbert_module,
+            "modal_run_finbert_sentiment",
+            run_id=stage_run_id,
+            as_of_date=as_of_date,
+            preprocessed_news_key=preprocessed_news_key,
+        )
+        sentiment_feature_key = _require_result_key(
+            sentiment_result,
+            "sentiment_feature_key",
+        )
+    regime_output_key = _load_completed_stage_output(
+        writer=writer,
+        stage=REGIME_STAGE,
         run_id=stage_run_id,
-        train_start_date=resolved_hmm_train_start_date,
-        train_end_date=_previous_business_day(as_of_date),
-        inference_dates=as_of_date,
-        benchmark_ticker=benchmark_ticker.strip().upper(),
-        max_iterations=hmm_max_iterations,
-        min_training_rows=hmm_min_training_rows,
+        as_of_date=as_of_date,
     )
+    if regime_output_key is None:
+        regime_result = _run_module_modal_remote(
+            regime_module,
+            "modal_run_hmm_regime_detection",
+            run_id=stage_run_id,
+            train_start_date=resolved_hmm_train_start_date,
+            train_end_date=_previous_business_day(as_of_date),
+            inference_dates=as_of_date,
+            benchmark_ticker=benchmark_ticker.strip().upper(),
+            max_iterations=hmm_max_iterations,
+            min_training_rows=hmm_min_training_rows,
+        )
+        regime_output_key = _require_result_key(regime_result, "output_key")
     _run_modal_remote_function(
         _modal_run_daily_layer1,
         owning_app=app,
@@ -1787,9 +1822,9 @@ def modal_main(
         hmm_max_iterations=hmm_max_iterations,
         hmm_min_training_rows=hmm_min_training_rows,
         preprocessed_news_key=preprocessed_news_key,
-        topic_feature_key=_require_result_key(topic_result, "topic_feature_key"),
-        sentiment_feature_key=_require_result_key(sentiment_result, "sentiment_feature_key"),
-        regime_output_key=_require_result_key(regime_result, "output_key"),
+        topic_feature_key=topic_feature_key,
+        sentiment_feature_key=sentiment_feature_key,
+        regime_output_key=regime_output_key,
     )
 
 
@@ -2042,6 +2077,35 @@ def _require_result_key(result: Mapping[str, object], field_name: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise RuntimeError(f"Stage result is missing required field {field_name!r}: {result!r}")
     return value
+
+
+def _load_completed_stage_output(
+    *,
+    writer: ObjectStore,
+    stage: str,
+    run_id: str,
+    as_of_date: str,
+) -> str | None:
+    """Return a completed stage output key when an exact single-date stage already succeeded."""
+    manifest_key = pipeline_manifest_path(stage, run_id)
+    if not writer.exists(manifest_key):
+        return None
+    try:
+        manifest = PipelineManifestRecord.model_validate_json(writer.get_object(manifest_key))
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Ignoring unreadable stage manifest {}: {}", manifest_key, exc)
+        return None
+    if manifest.status is not RunStatus.COMPLETED:
+        return None
+    manifest_date = str(manifest.metadata.get("as_of_date", "")).strip()
+    if manifest_date and manifest_date != as_of_date:
+        return None
+    if manifest.output_path is None or not manifest.output_path.strip():
+        return None
+    if not writer.exists(manifest.output_path):
+        return None
+    logger.info("Reusing completed {} artifact for {}: {}", stage, as_of_date, manifest.output_path)
+    return manifest.output_path
 
 
 def _existing_news_runner(

--- a/app/lab/data_pipelines/run_text_topics.py
+++ b/app/lab/data_pipelines/run_text_topics.py
@@ -93,6 +93,9 @@ class TextModelRuntimeConfig:
     embedding_config: TextEmbeddingConfig
     topic_config: TopicModelConfig
     min_topic_size: int
+    embedding_batch_size: int | None = None
+    topic_batch_size: int | None = None
+    max_document_characters: int | None = None
 
     def __post_init__(self) -> None:
         """Validate runtime topic-model settings."""
@@ -108,6 +111,12 @@ class TextModelRuntimeConfig:
             raise ValueError("requirements_path cannot be empty")
         if self.min_topic_size <= 0:
             raise ValueError("min_topic_size must be positive")
+        if self.embedding_batch_size is not None and self.embedding_batch_size <= 0:
+            raise ValueError("embedding_batch_size must be positive when provided")
+        if self.topic_batch_size is not None and self.topic_batch_size <= 0:
+            raise ValueError("topic_batch_size must be positive when provided")
+        if self.max_document_characters is not None and self.max_document_characters <= 0:
+            raise ValueError("max_document_characters must be positive when provided")
 
 
 @dataclass(frozen=True)
@@ -154,6 +163,9 @@ def run_text_topics(
         "embedding_revision": runtime.embedding_config.model_revision,
         "topic_model": runtime.topic_config.model_name,
         "topic_model_version": runtime.topic_config.model_version,
+        "embedding_batch_size": runtime.embedding_batch_size,
+        "topic_batch_size": runtime.topic_batch_size,
+        "max_document_characters": runtime.max_document_characters,
     }
 
     try:
@@ -164,6 +176,9 @@ def run_text_topics(
             topic_labeler=active_labeler,
             embedding_config=runtime.embedding_config,
             topic_config=runtime.topic_config,
+            embedding_batch_size=runtime.embedding_batch_size,
+            topic_batch_size=runtime.topic_batch_size,
+            max_document_characters=runtime.max_document_characters,
         )
         active_writer.put_object(embedding_key, _frame_to_parquet_bytes(result.embeddings))
         active_writer.put_object(topic_label_key, _frame_to_parquet_bytes(result.topic_labels))
@@ -280,6 +295,21 @@ def load_text_model_runtime_config(path: Path = TEXT_MODEL_CONFIG_PATH) -> TextM
             model_version=str(payload["topic_model_version"]),
         ),
         min_topic_size=int(payload["min_topic_size"]),
+        embedding_batch_size=(
+            int(payload["embedding_batch_size"])
+            if payload.get("embedding_batch_size") is not None
+            else None
+        ),
+        topic_batch_size=(
+            int(payload["topic_batch_size"])
+            if payload.get("topic_batch_size") is not None
+            else None
+        ),
+        max_document_characters=(
+            int(payload["max_document_characters"])
+            if payload.get("max_document_characters") is not None
+            else None
+        ),
     )
 
 

--- a/config/text_models.json
+++ b/config/text_models.json
@@ -1,7 +1,7 @@
 {
   "app_name": "ai-stock-trader-text-topics",
   "r2_secret_name": "ai-stock-trader-r2",
-  "timeout_seconds": 3600,
+  "timeout_seconds": 7200,
   "python_version": "3.11",
   "requirements_path": "requirements/modal.txt",
   "embedding_model_name": "sentence-transformers/all-mpnet-base-v2",
@@ -9,5 +9,8 @@
   "embedding_dimension": 768,
   "topic_model_name": "BERTopic",
   "topic_model_version": "bertopic-0.16.x",
-  "min_topic_size": 15
+  "min_topic_size": 15,
+  "embedding_batch_size": 2048,
+  "topic_batch_size": 2000,
+  "max_document_characters": 4096
 }

--- a/core/features/text_topics.py
+++ b/core/features/text_topics.py
@@ -111,18 +111,25 @@ def compute_text_topics(
     topic_labeler: TopicLabeler,
     embedding_config: TextEmbeddingConfig,
     topic_config: TopicModelConfig,
+    embedding_batch_size: int | None = None,
+    topic_batch_size: int | None = None,
+    max_document_characters: int | None = None,
 ) -> TextTopicResult:
     """Compute sentence embeddings, topic labels, and ticker-day topic features."""
     embeddings = compute_sentence_embeddings(
         records,
         embedder=embedder,
         config=embedding_config,
+        batch_size=embedding_batch_size,
+        max_document_characters=max_document_characters,
     )
     topic_labels = compute_topic_labels(
         records,
         embeddings,
         topic_labeler=topic_labeler,
         config=topic_config,
+        batch_size=topic_batch_size,
+        max_document_characters=max_document_characters,
     )
     return TextTopicResult(
         embeddings=embeddings,
@@ -136,33 +143,47 @@ def compute_sentence_embeddings(
     *,
     embedder: SentenceEmbedder,
     config: TextEmbeddingConfig,
+    batch_size: int | None = None,
+    max_document_characters: int | None = None,
 ) -> Any:
     """Return a deterministic embedding-cache DataFrame for unique sentence records."""
     pd = _require_pandas()
+    _validate_optional_positive(batch_size, field_name="batch_size")
+    _validate_optional_positive(
+        max_document_characters,
+        field_name="max_document_characters",
+    )
     sentence_records = _unique_sentence_records(records)
     if not sentence_records:
         return pd.DataFrame(columns=list(EMBEDDING_COLUMNS))
 
-    texts = [str(record.text) for record in sentence_records]
-    vectors = embedder.encode(texts)
-    if len(vectors) != len(sentence_records):
-        raise ValueError("Embedder returned a different number of vectors than input texts")
-
     rows: list[dict[str, object]] = []
-    for record, vector in zip(sentence_records, vectors, strict=True):
-        normalized_vector = _validate_embedding_vector(vector, config=config)
-        rows.append(
-            {
-                "date": record.date,
-                "article_id": _stable_article_id(record),
-                "sentence_index": record.sentence_index,
-                "text": record.text,
-                "embedding_model": config.model_name,
-                "embedding_revision": config.model_revision,
-                "embedding_cache_key": embedding_cache_key(record, config=config),
-                "embedding_json": json.dumps(normalized_vector, separators=(",", ":")),
-            }
-        )
+    for batch_records in _batched_records(sentence_records, batch_size):
+        texts = [
+            _prepare_document_text(
+                record.text,
+                max_document_characters=max_document_characters,
+            )
+            for record in batch_records
+        ]
+        vectors = embedder.encode(texts)
+        if len(vectors) != len(batch_records):
+            raise ValueError("Embedder returned a different number of vectors than input texts")
+
+        for record, vector in zip(batch_records, vectors, strict=True):
+            normalized_vector = _validate_embedding_vector(vector, config=config)
+            rows.append(
+                {
+                    "date": record.date,
+                    "article_id": _stable_article_id(record),
+                    "sentence_index": record.sentence_index,
+                    "text": record.text,
+                    "embedding_model": config.model_name,
+                    "embedding_revision": config.model_revision,
+                    "embedding_cache_key": embedding_cache_key(record, config=config),
+                    "embedding_json": json.dumps(normalized_vector, separators=(",", ":")),
+                }
+            )
     return pd.DataFrame(rows, columns=list(EMBEDDING_COLUMNS))
 
 
@@ -172,9 +193,16 @@ def compute_topic_labels(
     *,
     topic_labeler: TopicLabeler,
     config: TopicModelConfig,
+    batch_size: int | None = None,
+    max_document_characters: int | None = None,
 ) -> Any:
     """Return per-record BERTopic-style topic labels using the embedding cache."""
     pd = _require_pandas()
+    _validate_optional_positive(batch_size, field_name="batch_size")
+    _validate_optional_positive(
+        max_document_characters,
+        field_name="max_document_characters",
+    )
     if len(records) == 0:
         return pd.DataFrame(columns=list(TOPIC_LABEL_COLUMNS))
 
@@ -186,32 +214,44 @@ def compute_topic_labels(
     if not unique_records:
         return pd.DataFrame(columns=list(TOPIC_LABEL_COLUMNS))
 
-    documents: list[str] = []
-    vectors: list[list[float]] = []
-    for record in unique_records:
-        key = _embedding_cache_key_from_frame(record, embeddings)
-        if key not in embedding_by_key:
-            raise ValueError(f"Missing embedding cache row for sentence key {key}")
-        documents.append(str(record.text))
-        vectors.append(embedding_by_key[key])
+    topic_by_sentence: dict[str, tuple[int, float, str]] = {}
+    next_topic_offset = 0
+    for batch_records in _batched_records(unique_records, batch_size):
+        documents: list[str] = []
+        vectors: list[list[float]] = []
+        cache_keys: list[str] = []
+        for record in batch_records:
+            key = _embedding_cache_key_from_frame(record, embeddings)
+            if key not in embedding_by_key:
+                raise ValueError(f"Missing embedding cache row for sentence key {key}")
+            documents.append(
+                _prepare_document_text(
+                    record.text,
+                    max_document_characters=max_document_characters,
+                )
+            )
+            vectors.append(embedding_by_key[key])
+            cache_keys.append(key)
 
-    topics, probabilities = topic_labeler.fit_transform(documents, vectors)
-    if len(topics) != len(unique_records) or len(probabilities) != len(unique_records):
-        raise ValueError("Topic labeler returned a different number of labels than input texts")
-
-    topic_by_sentence = {
-        sentence_identity(record): (
-            int(topic),
-            _validate_probability(probability),
-            _embedding_cache_key_from_frame(record, embeddings),
-        )
-        for record, topic, probability in zip(
-            unique_records,
+        topics, probabilities = topic_labeler.fit_transform(documents, vectors)
+        if len(topics) != len(batch_records) or len(probabilities) != len(batch_records):
+            raise ValueError("Topic labeler returned a different number of labels than input texts")
+        adjusted_topics, next_topic_offset = _offset_batch_topic_ids(
             topics,
-            probabilities,
-            strict=True,
+            starting_offset=next_topic_offset,
         )
-    }
+        for record, topic, probability, cache_key in zip(
+            batch_records,
+            adjusted_topics,
+            probabilities,
+            cache_keys,
+            strict=True,
+        ):
+            topic_by_sentence[sentence_identity(record)] = (
+                int(topic),
+                _validate_probability(probability),
+                cache_key,
+            )
 
     rows: list[dict[str, object]] = []
     for record in records:
@@ -349,6 +389,52 @@ def _embedding_cache_key_from_frame(record: NewsSentimentRecord, embeddings: Any
     raise ValueError(f"Missing embedding cache key for sentence identity {identity}")
 
 
+def _batched_records(
+    records: Sequence[NewsSentimentRecord],
+    batch_size: int | None,
+) -> list[Sequence[NewsSentimentRecord]]:
+    """Split sentence records into deterministic batches when configured."""
+    if batch_size is None or batch_size >= len(records):
+        return [records]
+    return [records[index : index + batch_size] for index in range(0, len(records), batch_size)]
+
+
+def _prepare_document_text(
+    text: str | None,
+    *,
+    max_document_characters: int | None,
+) -> str:
+    """Trim one document to a configured character budget for embedding/topic work."""
+    value = str(text or "")
+    if max_document_characters is None or len(value) <= max_document_characters:
+        return value
+    return value[:max_document_characters]
+
+
+def _offset_batch_topic_ids(
+    topics: Sequence[int],
+    *,
+    starting_offset: int,
+) -> tuple[list[int], int]:
+    """Offset positive batch-local topic ids so merged aggregates do not collide across batches."""
+    adjusted_topics: list[int] = []
+    max_positive_topic: int | None = None
+    for topic in topics:
+        normalized = int(topic)
+        if normalized < 0:
+            adjusted_topics.append(normalized)
+            continue
+        adjusted_topics.append(normalized + starting_offset)
+        max_positive_topic = (
+            normalized
+            if max_positive_topic is None
+            else max(max_positive_topic, normalized)
+        )
+    if max_positive_topic is None:
+        return adjusted_topics, starting_offset
+    return adjusted_topics, starting_offset + max_positive_topic + 1
+
+
 def _stable_article_id(record: NewsSentimentRecord) -> str:
     """Return an article id or a deterministic fallback from sentence text."""
     if record.article_id:
@@ -371,6 +457,12 @@ def _validate_embedding_vector(
     if any(math.isnan(value) or math.isinf(value) for value in values):
         raise ValueError("Embedding vectors must contain only finite numeric values")
     return values
+
+
+def _validate_optional_positive(value: int | None, *, field_name: str) -> None:
+    """Require positive integers for optional batching and truncation settings."""
+    if value is not None and value <= 0:
+        raise ValueError(f"{field_name} must be positive when provided")
 
 
 def _embedding_from_json(value: object) -> list[float]:

--- a/tests/unit/test_modal_runner_entrypoints.py
+++ b/tests/unit/test_modal_runner_entrypoints.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 from dataclasses import dataclass, field
+from datetime import UTC, datetime
 
 import pytest
 
@@ -396,6 +397,15 @@ def test_daily_layer1_modal_main_orchestrates_stage_apps_before_final_assembly(
     )
 
     monkeypatch.setattr(run_daily_layer1, "_modal_run_daily_layer1", final_remote)
+    monkeypatch.setattr(
+        run_daily_layer1,
+        "R2Writer",
+        lambda: type(
+            "_MissingWriter",
+            (),
+            {"exists": staticmethod(lambda key: False), "get_object": staticmethod(lambda key: b"")},
+        )(),
+    )
     monkeypatch.setattr(run_daily_layer1.news_module, "modal_run_news_preprocessing", news_remote)
     monkeypatch.setattr(run_daily_layer1.text_topics_module, "modal_run_text_topics", topics_remote)
     monkeypatch.setattr(
@@ -482,6 +492,132 @@ def test_daily_layer1_modal_main_orchestrates_stage_apps_before_final_assembly(
             "regime_output_key": "features/layer1_5/regime/smoke-daily-2024-01-02.parquet",
         }
     ]
+
+
+def test_daily_layer1_modal_main_reuses_completed_stage_outputs_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The daily local entrypoint should resume from completed stage artifacts when possible."""
+
+    class _FakeStageRemote:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self.payload = payload
+            self.remote_calls: list[dict[str, object]] = []
+
+        def remote(self, **kwargs: object) -> dict[str, object]:
+            self.remote_calls.append(kwargs)
+            return dict(self.payload)
+
+    class _ExistingWriter:
+        def __init__(self) -> None:
+            self._payloads = {
+                run_daily_layer1.pipeline_manifest_path(
+                    run_daily_layer1.NLP_PREPROCESSING_STAGE,
+                    "resume-daily-2024-01-02",
+                ): run_daily_layer1.PipelineManifestRecord(
+                    run_id="resume-daily-2024-01-02",
+                    stage=run_daily_layer1.NLP_PREPROCESSING_STAGE,
+                    status=run_daily_layer1.RunStatus.COMPLETED,
+                    started_at=datetime.now(UTC),
+                    finished_at=datetime.now(UTC),
+                    input_path="raw/news/2024-01-02.jsonl",
+                    output_path="features/layer1/news_sentiment/2024-01-02/resume.parquet",
+                    metadata={"as_of_date": "2024-01-02"},
+                ).model_dump_json().encode("utf-8"),
+                run_daily_layer1.pipeline_manifest_path(
+                    run_daily_layer1.TEXT_TOPICS_STAGE,
+                    "resume-daily-2024-01-02",
+                ): run_daily_layer1.PipelineManifestRecord(
+                    run_id="resume-daily-2024-01-02",
+                    stage=run_daily_layer1.TEXT_TOPICS_STAGE,
+                    status=run_daily_layer1.RunStatus.COMPLETED,
+                    started_at=datetime.now(UTC),
+                    finished_at=datetime.now(UTC),
+                    input_path="features/layer1/news_sentiment/2024-01-02/resume.parquet",
+                    output_path="features/layer1/topic_features/2024-01-02/resume.parquet",
+                    metadata={"as_of_date": "2024-01-02"},
+                ).model_dump_json().encode("utf-8"),
+                "features/layer1/news_sentiment/2024-01-02/resume.parquet": b"news",
+                "features/layer1/topic_features/2024-01-02/resume.parquet": b"topics",
+            }
+
+        def exists(self, key: str) -> bool:
+            return key in self._payloads
+
+        def get_object(self, key: str) -> bytes:
+            return self._payloads[key]
+
+    final_remote = _FakeRegisteredFunction(name="modal_run_daily_layer1", options={})
+    news_remote = _FakeStageRemote({"output_key": "unexpected-news"})
+    topics_remote = _FakeStageRemote({"topic_feature_key": "unexpected-topics"})
+    finbert_remote = _FakeStageRemote(
+        {"sentiment_feature_key": "features/layer1/sentiment_features/2024-01-02/resume.parquet"}
+    )
+    regime_remote = _FakeStageRemote(
+        {"output_key": "features/layer1_5/regime/resume-daily-2024-01-02.parquet"}
+    )
+
+    monkeypatch.setattr(run_daily_layer1, "_modal_run_daily_layer1", final_remote)
+    monkeypatch.setattr(run_daily_layer1, "R2Writer", _ExistingWriter)
+    monkeypatch.setattr(
+        run_daily_layer1,
+        "load_modal_runtime_config",
+        lambda: run_daily_layer1.ModalRuntimeConfig(
+            app_name="layer1",
+            r2_secret_name="secret",
+            timeout_seconds=10,
+            batch_timeout_seconds=10,
+            batch_gpu_type="T4",
+            hmm_train_lookback_bdays=None,
+            python_version="3.11",
+            requirements_path="requirements/modal.txt",
+        ),
+    )
+    monkeypatch.setattr(run_daily_layer1.news_module, "modal_run_news_preprocessing", news_remote)
+    monkeypatch.setattr(run_daily_layer1.text_topics_module, "modal_run_text_topics", topics_remote)
+    monkeypatch.setattr(
+        run_daily_layer1.finbert_module,
+        "modal_run_finbert_sentiment",
+        finbert_remote,
+    )
+    monkeypatch.setattr(
+        run_daily_layer1.regime_module,
+        "modal_run_hmm_regime_detection",
+        regime_remote,
+    )
+
+    run_daily_layer1.modal_main(
+        "resume-daily",
+        "2024-01-02",
+        "layer0-daily-2024-01-02",
+    )
+
+    assert news_remote.remote_calls == []
+    assert topics_remote.remote_calls == []
+    assert finbert_remote.remote_calls == [
+        {
+            "run_id": "resume-daily-2024-01-02",
+            "as_of_date": "2024-01-02",
+            "preprocessed_news_key": "features/layer1/news_sentiment/2024-01-02/resume.parquet",
+        }
+    ]
+    assert regime_remote.remote_calls == [
+        {
+            "run_id": "resume-daily-2024-01-02",
+            "train_start_date": None,
+            "train_end_date": "2024-01-01",
+            "inference_dates": "2024-01-02",
+            "benchmark_ticker": "SPY",
+            "max_iterations": 100,
+            "min_training_rows": 30,
+        }
+    ]
+    assert final_remote.remote_calls[0]["preprocessed_news_key"] == (
+        "features/layer1/news_sentiment/2024-01-02/resume.parquet"
+    )
+    assert final_remote.remote_calls[0]["topic_feature_key"] == (
+        "features/layer1/topic_features/2024-01-02/resume.parquet"
+    )
 
 
 def test_daily_layer1_modal_range_main_dispatches_batched_remote_call(

--- a/tests/unit/test_text_topics.py
+++ b/tests/unit/test_text_topics.py
@@ -41,6 +41,30 @@ class _FakeTopicLabeler:
         return [index % 2 for index, _ in enumerate(documents)], [0.8, 0.6][: len(documents)]
 
 
+class _RecordingEmbedder:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def encode(self, sentences: Sequence[str]) -> Sequence[Sequence[float]]:
+        batch = list(sentences)
+        self.calls.append(batch)
+        return [[float(index), float(len(sentence))] for index, sentence in enumerate(batch)]
+
+
+class _ResettingTopicLabeler:
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def fit_transform(
+        self,
+        documents: Sequence[str],
+        embeddings: Sequence[Sequence[float]],
+    ) -> tuple[Sequence[int], Sequence[float]]:
+        batch = list(documents)
+        self.calls.append(batch)
+        return [0 for _ in batch], [0.75 for _ in batch]
+
+
 def test_compute_text_topics_caches_unique_sentence_embeddings_and_topic_features() -> None:
     """Sentence embeddings are cached once while topic labels remain ticker-specific."""
     records = [
@@ -115,6 +139,46 @@ def test_compute_topic_labels_rejects_missing_embedding_cache_row() -> None:
             topic_labeler=_FakeTopicLabeler(),
             config=_topic_config(),
         )
+
+
+def test_compute_text_topics_batches_and_offsets_topic_ids() -> None:
+    """Positive batch-local topic ids are offset so merged features do not collide."""
+    labeler = _ResettingTopicLabeler()
+    result = compute_text_topics(
+        [
+            _record(text="Alpha.", sentence_index=0),
+            _record(text="Beta.", sentence_index=1),
+            _record(text="Gamma.", sentence_index=2),
+            _record(text="Delta.", sentence_index=3),
+        ],
+        embedder=_FakeEmbedder(),
+        topic_labeler=labeler,
+        embedding_config=_embedding_config(),
+        topic_config=_topic_config(),
+        topic_batch_size=2,
+    )
+
+    assert labeler.calls == [["Alpha.", "Beta."], ["Gamma.", "Delta."]]
+    assert result.topic_labels["topic_id"].tolist() == [0, 0, 1, 1]
+    assert result.feature_records[0].features["nlp_topic_count"] == 2
+
+
+def test_compute_text_topics_truncates_documents_before_embedding_and_topic_labeling() -> None:
+    """Configured document truncation is applied consistently to embeddings and topic labels."""
+    embedder = _RecordingEmbedder()
+    labeler = _ResettingTopicLabeler()
+
+    compute_text_topics(
+        [_record(text="ABCDEFGHIJ", sentence_index=0)],
+        embedder=embedder,
+        topic_labeler=labeler,
+        embedding_config=_embedding_config(),
+        topic_config=_topic_config(),
+        max_document_characters=5,
+    )
+
+    assert embedder.calls == [["ABCDE"]]
+    assert labeler.calls == [["ABCDE"]]
 
 
 def test_topic_labels_to_feature_records_rejects_missing_columns() -> None:

--- a/tests/unit/test_text_topics_runner.py
+++ b/tests/unit/test_text_topics_runner.py
@@ -129,6 +129,9 @@ def test_load_text_model_runtime_config_reads_repo_config() -> None:
     assert config.embedding_config.model_revision
     assert config.embedding_config.embedding_dimension == 768
     assert config.topic_config.model_name == "BERTopic"
+    assert config.embedding_batch_size == 2048
+    assert config.topic_batch_size == 2000
+    assert config.max_document_characters == 4096
 
 
 def _local_writer(tmp_path: Path, monkeypatch) -> R2Writer:


### PR DESCRIPTION
## What this PR does
This hardens the single-date Layer 1 text-topic path against the exact 2026-04-23 failure profile. It raises the text-topic Modal timeout, adds bounded document truncation plus deterministic embedding/topic batching inside the topic runner, and lets the daily Layer 1 orchestrator reuse already-completed single-date stage artifacts so retries resume from the last durable stage instead of replaying preprocessing.

## Closes
Advances #143
Advances #189

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [ ] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
- Investigated failing 2026-04-23 preprocessing artifact: `features/layer1/news_sentiment/2026-04-23/layer1-daily-2026-04-23-2026-04-23.parquet`
- Observed 16,136 sentence rows, 13,471 unique texts, 488 articles, and max sentence length 24,416 characters before the timed-out text-topic stage.

## Notes for reviewer
- This PR does not claim the full readiness window is validated yet.
- The fix is targeted at the exact single-date timeout path and the missing safe-resume behavior that left 2026-04-23 stuck after preprocessing had already completed.
