### PR TITLE
Repair BNY fundamentals archive alias for readiness reruns

### DIFF
--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -1116,6 +1116,7 @@ def _write_fundamentals_archive(
     ]
 
     for batch_index, batch in enumerate(batches, start=1):
+        aliased_in_batch = 0
         if not overwrite:
             for ticker in batch:
                 target_key = raw_fundamentals_path(ticker)
@@ -1137,6 +1138,7 @@ def _write_fundamentals_archive(
                 output_keys.append(target_key)
                 written += 1
                 total_rows += len(aliased_rows)
+                aliased_in_batch += 1
                 aliased_tickers.append(ticker)
                 logger.info(
                     "Seeded fundamentals archive for {} from alias {}",
@@ -1150,7 +1152,7 @@ def _write_fundamentals_archive(
             if overwrite or not writer.exists(raw_fundamentals_path(ticker))
         ]
         if not remaining:
-            skipped += len(batch)
+            skipped += len(batch) - aliased_in_batch
             logger.info(
                 "SimFin batch {}/{} fully cached — skipping",
                 batch_index,
@@ -1179,7 +1181,7 @@ def _write_fundamentals_archive(
             ticker = _canonicalize_ticker(str(row.get("ticker") or ""))
             if ticker in rows_by_ticker:
                 rows_by_ticker[ticker].append(row)
-        skipped += len(batch) - len(remaining)
+        skipped += len(batch) - len(remaining) - aliased_in_batch
         for ticker in remaining:
             ticker_rows = _sort_raw_rows(rows_by_ticker.get(ticker, []), ("report_date",))
             if not ticker_rows:

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -35,6 +35,7 @@ from services.r2.paths import (
     raw_security_master_path,
     raw_universe_path,
 )
+from services.simfin.fundamentals_fetcher import canonical_fundamentals_source_ticker
 
 
 class ObjectWriter(Protocol):
@@ -421,6 +422,7 @@ def run_historical_layer0_backfill(
             fetcher=fundamentals_fetcher,
             writer=cached_writer,
             serializer=fundamentals_serializer or _raw_rows_to_parquet_bytes,
+            deserializer=fundamentals_deserializer or _parquet_bytes_to_raw_rows,
         )
         output_keys.extend(fundamentals_result.output_keys)
         metadata["fundamentals"] = fundamentals_result.metadata
@@ -611,6 +613,7 @@ def run_daily_layer0_incremental(
             fetcher=fundamentals_fetcher,
             writer=writer,
             serializer=fundamentals_serializer or _raw_rows_to_parquet_bytes,
+            deserializer=fundamentals_deserializer or _parquet_bytes_to_raw_rows,
         )
         output_keys.extend(fundamentals_result.output_keys)
         metadata["fundamentals"] = fundamentals_result.metadata
@@ -1094,6 +1097,7 @@ def _write_fundamentals_archive(
     fetcher: FundamentalsFetcher,
     writer: ObjectWriter,
     serializer: RawRowSerializer,
+    deserializer: RawRowsDeserializer,
 ) -> _WriteResult:
     """Fetch and persist SimFin fundamentals per-ticker so partial progress survives failures."""
     normalized_tickers = [_canonicalize_ticker(ticker) for ticker in tickers]
@@ -1103,6 +1107,7 @@ def _write_fundamentals_archive(
     empty = 0
     total_rows = 0
     missing_tickers: list[str] = []
+    aliased_tickers: list[str] = []
     retrieved_at = datetime.now(UTC)
     batch_size = 50
     batches = [
@@ -1111,6 +1116,34 @@ def _write_fundamentals_archive(
     ]
 
     for batch_index, batch in enumerate(batches, start=1):
+        if not overwrite:
+            for ticker in batch:
+                target_key = raw_fundamentals_path(ticker)
+                if writer.exists(target_key):
+                    continue
+                source_ticker = canonical_fundamentals_source_ticker(ticker)
+                if source_ticker == ticker:
+                    continue
+                source_key = raw_fundamentals_path(source_ticker)
+                if not writer.exists(source_key):
+                    continue
+                aliased_rows = _rewrite_fundamentals_alias_rows(
+                    deserializer(writer.get_object(source_key)),
+                    target_ticker=ticker,
+                )
+                if not aliased_rows:
+                    continue
+                writer.put_object(target_key, serializer(aliased_rows))
+                output_keys.append(target_key)
+                written += 1
+                total_rows += len(aliased_rows)
+                aliased_tickers.append(ticker)
+                logger.info(
+                    "Seeded fundamentals archive for {} from alias {}",
+                    ticker,
+                    source_ticker,
+                )
+
         remaining = [
             ticker
             for ticker in batch
@@ -1175,9 +1208,31 @@ def _write_fundamentals_archive(
             "empty": empty,
             "missing_tickers": missing_tickers,
             "total_rows": total_rows,
+            "aliased_tickers": aliased_tickers,
             "output_keys": output_keys,
         },
     )
+
+
+def _rewrite_fundamentals_alias_rows(
+    rows: Sequence[Mapping[str, object]],
+    *,
+    target_ticker: str,
+) -> list[dict[str, object]]:
+    """Rewrite one existing fundamentals archive onto the canonical target ticker."""
+    rewritten: list[dict[str, object]] = []
+    for row in rows:
+        updated_row = dict(row)
+        updated_row["ticker"] = target_ticker
+        raw_payload = updated_row.get("raw")
+        if isinstance(raw_payload, Mapping):
+            updated_raw = dict(raw_payload)
+            for key in ("ticker", "Ticker", "symbol", "Symbol"):
+                if key in updated_raw:
+                    updated_raw[key] = target_ticker
+            updated_row["raw"] = updated_raw
+        rewritten.append(updated_row)
+    return rewritten
 
 
 def _write_macro_archive(

--- a/services/simfin/fundamentals_fetcher.py
+++ b/services/simfin/fundamentals_fetcher.py
@@ -34,6 +34,7 @@ SEC_COMPANY_TICKERS_URL = "https://www.sec.gov/files/company_tickers.json"
 SEC_COMPANYFACTS_URL_TEMPLATE = "https://data.sec.gov/api/xbrl/companyfacts/CIK{cik}.json"
 _SEC_ALLOWED_FORMS = frozenset({"10-K", "10-K/A", "10-Q", "10-Q/A", "20-F", "20-F/A", "40-F"})
 _SIMFIN_REQUEST_TICKER_OVERRIDES: dict[str, str] = {
+    "BNY": "BK",
     # Current S&P 500 ticker aliases that SimFin still serves under an older
     # vendor symbol or the economic share-class peer with identical company fundamentals.
     "CPAY": "FLT",
@@ -995,6 +996,11 @@ def _simfin_vendor_ticker(ticker: str) -> str:
     """Return the normalized SimFin vendor symbol for one canonical archive ticker."""
     normalized = _normalize_ticker(ticker)
     return _SIMFIN_REQUEST_TICKER_OVERRIDES.get(normalized, normalized)
+
+
+def canonical_fundamentals_source_ticker(ticker: str) -> str:
+    """Return the archive ticker that can seed one canonical fundamentals history."""
+    return _simfin_vendor_ticker(ticker)
 
 
 def _normalize_tokens(values: Sequence[str], field_name: str) -> tuple[str, ...]:

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -83,12 +83,29 @@ class _UniverseProvider:
         return {"AAPL", "MSFT"}
 
 
+class _BnyUniverseProvider:
+    def get_constituents(self, as_of_date: str) -> list[str]:
+        return ["BNY"]
+
+    def get_historical_tickers(self, from_date: str, to_date: str) -> set[str]:
+        return {"BNY"}
+
+
 class _SecurityMaster:
     def resolve_all(self, ticker: str) -> list[_Security]:
         if ticker == "AAPL":
             return [_Security(ticker="AAPL", security_id="perm-aapl", start_date="2020-01-01")]
         if ticker == "MSFT":
             return [_Security(ticker="MSFT", security_id="perm-msft", start_date="2020-01-01")]
+        if ticker == "SPY":
+            return [_Security(ticker="SPY", security_id="perm-spy", start_date="2020-01-01")]
+        raise KeyError(ticker)
+
+
+class _BnySecurityMaster:
+    def resolve_all(self, ticker: str) -> list[_Security]:
+        if ticker == "BNY":
+            return [_Security(ticker="BNY", security_id="perm-bny", start_date="2020-01-01")]
         if ticker == "SPY":
             return [_Security(ticker="SPY", security_id="perm-spy", start_date="2020-01-01")]
         raise KeyError(ticker)
@@ -182,6 +199,9 @@ class _FundamentalsFetcher:
 
 
 class _EmptyFundamentalsFetcher:
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
     def fetch_all_fundamentals(
         self,
         *,
@@ -193,6 +213,17 @@ class _EmptyFundamentalsFetcher:
         retrieved_at: datetime | None,
         limit: int,
     ) -> list[dict[str, object]]:
+        self.calls.append(
+            {
+                "tickers": tuple(tickers),
+                "start_date": start_date,
+                "end_date": end_date,
+                "statements": tuple(statements),
+                "periods": tuple(periods),
+                "retrieved_at": retrieved_at,
+                "limit": limit,
+            }
+        )
         return []
 
 
@@ -1056,6 +1087,61 @@ def test_daily_layer0_incremental_skips_new_empty_fundamentals_archives() -> Non
     manifest = _manifest(writer, "test-empty-fundamentals")
     assert manifest["metadata"]["fundamentals"]["empty"] == 1
     assert manifest["metadata"]["fundamentals"]["missing_tickers"] == ["AAPL"]
+
+
+def test_historical_layer0_backfill_seeds_missing_canonical_fundamentals_from_alias() -> None:
+    writer = _Writer()
+    writer.put_object(
+        raw_fundamentals_path("BK"),
+        _bytes_serializer(
+            [
+                {
+                    "ticker": "BK",
+                    "report_date": "2024-03-31",
+                    "availability_date": "2024-05-01",
+                    "raw": {"ticker": "BK", "Revenue": 1},
+                }
+            ]
+        ),
+    )
+    fundamentals_fetcher = _EmptyFundamentalsFetcher()
+
+    run_historical_layer0_backfill(
+        config=HistoricalLayer0Config(
+            from_date=date(2024, 5, 2),
+            to_date=date(2024, 5, 2),
+            fred_series_ids=("DGS10",),
+            run_id="test-bny-alias-fundamentals",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        universe_provider=_BnyUniverseProvider(),
+        price_fetcher=_HistoricalPriceFetcher(),
+        security_master=_BnySecurityMaster(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=fundamentals_fetcher,
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        price_deserializer=_bytes_deserializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        fundamentals_deserializer=_raw_rows_deserializer,
+        macro_serializer=_bytes_serializer,
+    )
+
+    bny_rows = _raw_rows_deserializer(writer.objects[raw_fundamentals_path("BNY")])
+    assert bny_rows == [
+        {
+            "ticker": "BNY",
+            "report_date": "2024-03-31",
+            "availability_date": "2024-05-01",
+            "raw": {"ticker": "BNY", "Revenue": 1},
+        }
+    ]
+    assert fundamentals_fetcher.calls == []
+    manifest = _manifest(writer, "test-bny-alias-fundamentals")
+    assert manifest["metadata"]["fundamentals"]["aliased_tickers"] == ["BNY"]
+    assert manifest["metadata"]["fundamentals"]["missing_tickers"] == []
 
 
 def test_daily_layer0_incremental_repairs_missing_target_date_and_rewrites_universe_mask() -> None:

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -1142,6 +1142,78 @@ def test_historical_layer0_backfill_seeds_missing_canonical_fundamentals_from_al
     manifest = _manifest(writer, "test-bny-alias-fundamentals")
     assert manifest["metadata"]["fundamentals"]["aliased_tickers"] == ["BNY"]
     assert manifest["metadata"]["fundamentals"]["missing_tickers"] == []
+    assert manifest["metadata"]["fundamentals"]["written"] == 1
+    assert manifest["metadata"]["fundamentals"]["skipped"] == 0
+    assert manifest["metadata"]["fundamentals"]["empty"] == 0
+    assert (
+        manifest["metadata"]["fundamentals"]["written"]
+        + manifest["metadata"]["fundamentals"]["skipped"]
+        + manifest["metadata"]["fundamentals"]["empty"]
+        == manifest["metadata"]["fundamentals"]["requested_tickers"]
+    )
+
+
+def test_daily_layer0_incremental_seeds_missing_canonical_fundamentals_from_alias() -> None:
+    writer = _Writer()
+    writer.put_object(
+        raw_fundamentals_path("BK"),
+        _bytes_serializer(
+            [
+                {
+                    "ticker": "BK",
+                    "report_date": "2024-03-31",
+                    "availability_date": "2024-05-01",
+                    "raw": {"ticker": "BK", "Revenue": 1},
+                }
+            ]
+        ),
+    )
+    fundamentals_fetcher = _EmptyFundamentalsFetcher()
+
+    run_daily_layer0_incremental(
+        config=DailyLayer0Config(
+            as_of_date=date(2024, 5, 2),
+            tickers=("BNY",),
+            fred_series_ids=("DGS10",),
+            run_id="test-daily-bny-alias-fundamentals",
+            quality_config=QualityFilterConfig(rolling_window_days=1),
+        ),
+        live_price_fetcher=_LivePriceFetcher(),
+        news_fetcher=_NewsFetcher(),
+        fundamentals_fetcher=fundamentals_fetcher,
+        macro_fetcher=_MacroFetcher(),
+        writer=writer,
+        price_serializer=_bytes_serializer,
+        price_deserializer=_bytes_deserializer,
+        news_serializer=_bytes_serializer,
+        fundamentals_serializer=_bytes_serializer,
+        fundamentals_deserializer=_raw_rows_deserializer,
+        macro_serializer=_bytes_serializer,
+        universe_serializer=_universe_serializer,
+    )
+
+    bny_rows = _raw_rows_deserializer(writer.objects[raw_fundamentals_path("BNY")])
+    assert bny_rows == [
+        {
+            "ticker": "BNY",
+            "report_date": "2024-03-31",
+            "availability_date": "2024-05-01",
+            "raw": {"ticker": "BNY", "Revenue": 1},
+        }
+    ]
+    assert fundamentals_fetcher.calls == []
+    manifest = _manifest(writer, "test-daily-bny-alias-fundamentals")
+    assert manifest["metadata"]["fundamentals"]["aliased_tickers"] == ["BNY"]
+    assert manifest["metadata"]["fundamentals"]["missing_tickers"] == []
+    assert manifest["metadata"]["fundamentals"]["written"] == 1
+    assert manifest["metadata"]["fundamentals"]["skipped"] == 0
+    assert manifest["metadata"]["fundamentals"]["empty"] == 0
+    assert (
+        manifest["metadata"]["fundamentals"]["written"]
+        + manifest["metadata"]["fundamentals"]["skipped"]
+        + manifest["metadata"]["fundamentals"]["empty"]
+        == manifest["metadata"]["fundamentals"]["requested_tickers"]
+    )
 
 
 def test_daily_layer0_incremental_repairs_missing_target_date_and_rewrites_universe_mask() -> None:

--- a/tests/unit/test_simfin_fundamentals_fetcher.py
+++ b/tests/unit/test_simfin_fundamentals_fetcher.py
@@ -26,6 +26,7 @@ from services.simfin.fundamentals_fetcher import (
     DEFAULT_SIMFIN_STATEMENTS,
     SimFinClientConfig,
     SimFinFundamentalsFetcher,
+    canonical_fundamentals_source_ticker,
     normalize_simfin_fundamental_rows,
 )
 
@@ -735,6 +736,42 @@ def test_fetch_statement_rows_maps_provider_rename_aliases_back_to_canonical_tic
 
     assert session.calls[0]["params"]["ticker"] == "FLT"
     assert [row["ticker"] for row in page.rows] == ["CPAY"]
+
+
+def test_canonical_fundamentals_source_ticker_uses_vendor_alias_for_bny() -> None:
+    """Canonical fundamentals archives can seed BNY from the existing BK history."""
+    assert canonical_fundamentals_source_ticker("BNY") == "BK"
+
+
+def test_fetch_statement_rows_maps_bny_vendor_alias_back_to_canonical_ticker() -> None:
+    """BNY requests use BK upstream but archive rows stay canonicalized as BNY."""
+    payload = [
+        {
+            "ticker": "BK",
+            "currency": "USD",
+            "statements": [
+                {
+                    "statement": "PL",
+                    "columns": ["Fiscal Period", "Fiscal Year", "Report Date", "Publish Date"],
+                    "data": [["Q1", 2024, "2024-03-31", "2024-05-03"]],
+                }
+            ],
+        }
+    ]
+    session = _FakeSession([_FakeResponse(payload)])
+    fetcher = SimFinFundamentalsFetcher(
+        SimFinClientConfig(api_key="test-key", retry_sleep_seconds=0),
+        session=session,  # type: ignore[arg-type]
+    )
+
+    page = fetcher.fetch_statement_rows(
+        tickers=["BNY"],
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+    )
+
+    assert session.calls[0]["params"]["ticker"] == "BK"
+    assert [row["ticker"] for row in page.rows] == ["BNY"]
 
 
 def test_fetch_all_fundamentals_uses_sec_companyfacts_fallback_for_missing_ticker(


### PR DESCRIPTION
## What this PR does
Repairs the Layer 0 fundamentals archive path for the `BK -> BNY` rename boundary that was blocking Issue #143 after PR #198. When the canonical ticker archive is missing but an existing vendor/source alias archive already exists, Layer 0 now seeds the canonical archive from that alias and rewrites the archived rows to the canonical ticker. The SimFin request alias map also now treats `BNY` as `BK`, and regression tests cover both the request mapping and the archive seeding path.

## Closes
Advances #143

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
None

## Notes for reviewer
This is the next readiness blocker after the merged `SEC_USER_AGENT` fix in PR #198. I verified the original live failure on `layer1-daily-2026-05-06`: Layer 0 completed, but Layer 1 failed because `raw/fundamentals/BNY.parquet` was missing while `raw/fundamentals/BK.parquet` already existed. After this PR, I am resuming the live Issue #143 catch-up run from `2026-05-06`.
