### PR TITLE
Fix Layer 1 carry-forward branch filtering

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -1058,10 +1058,18 @@ def _load_feature_records_by_key(
     writer: ObjectStore,
     keys_by_date: Mapping[str, str],
 ) -> dict[str, list[FeatureRecord]]:
-    """Load ticker-day feature records from existing branch output parquet objects."""
+    """Load ticker-day feature records from existing branch output parquet objects.
+
+    Some branch outputs may include historical carry-forward rows in addition to the
+    requested target date. Only keep rows matching the date encoded by the caller's
+    `keys_by_date` mapping so multi-date assembly does not re-ingest earlier dates from
+    later branch outputs.
+    """
     grouped: dict[str, list[FeatureRecord]] = {}
-    for key in keys_by_date.values():
+    for date_text, key in keys_by_date.items():
         for record in parquet_bytes_to_feature_records(writer.get_object(key)):
+            if record.date != date_text:
+                continue
             grouped.setdefault(record.ticker, []).append(record)
     return grouped
 

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -686,6 +686,69 @@ def test_run_daily_layer1_rerun_replaces_target_dates_without_duplicates(
     assert second_history == first_history
 
 
+def test_run_daily_layer1_filters_carry_forward_rows_from_branch_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Per-date branch outputs only contribute rows for their requested target date."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2024-01-03", "2024-01-04"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-carry-forward",),
+    )
+    seen_dates: list[str] = []
+
+    def cumulative_sentiment_runner(config, *, writer: R2Writer):
+        seen_dates.append(config.as_of_date)
+        output_key = layer1_sentiment_feature_path(config.as_of_date, config.run_id)
+        records = [
+            daily_layer1_module.FeatureRecord(
+                date=date_text,
+                ticker="AAPL",
+                features={
+                    "nlp_sentiment_score": 0.25 if date_text == "2024-01-03" else 0.5,
+                    "nlp_article_count": 1,
+                    "nlp_sentence_count": 1,
+                },
+            )
+            for date_text in seen_dates
+        ]
+        writer.put_object(output_key, feature_records_to_parquet_bytes(records))
+        return daily_layer1_module.FinBERTPipelineResult(
+            run_id=config.run_id,
+            scored_news_key="unused",
+            sentiment_feature_key=output_key,
+            manifest_key=pipeline_manifest_path("layer1_finbert_sentiment", config.run_id),
+            input_rows=len(records),
+            scored_rows=len(records),
+            feature_rows=len(records),
+        )
+
+    result = run_daily_layer1(
+        Layer1DailyConfig(
+            run_id="layer1-carry-forward",
+            from_date="2024-01-03",
+            to_date="2024-01-04",
+        ),
+        writer=writer,
+        news_runner=fake_news_runner(writer, ["AAPL"]),
+        text_topic_runner=fake_topic_runner(writer, ["AAPL"]),
+        finbert_runner=cumulative_sentiment_runner,
+        regime_runner=fake_regime_runner(writer),
+        validation_output_dir=tmp_path / "reports",
+        now=datetime(2024, 1, 5, 12, 0, tzinfo=UTC),
+    )
+
+    history = read_feature_records("AAPL", writer=writer)
+
+    assert result.ready_for_layer2 is True
+    assert [record.date for record in history] == ["2024-01-03", "2024-01-04"]
+    assert history[0].features["nlp_sentiment_score"] == pytest.approx(0.25)
+    assert history[1].features["nlp_sentiment_score"] == pytest.approx(0.5)
+
+
 def test_run_daily_layer1_reuses_completed_branch_outputs_when_precomputed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## What this PR does
Fixes batched Layer 1 assembly so per-date branch outputs cannot reintroduce carry-forward rows from earlier dates and create duplicate `(date, ticker)` `FeatureRecord`s during multi-date readiness runs. The PR also adds a regression test that exercises cumulative sentiment branch outputs across multiple dates.

## Closes
Advances #143

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [ ] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [ ] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Not applicable.

## Notes for reviewer
- Full unit suite passed locally: `HOME=/home/juyoungoh ./.venv/bin/pytest tests/unit/ -v --tb=short`
- Targeted regression suite passed locally: `HOME=/home/juyoungoh ./.venv/bin/pytest tests/unit/test_daily_layer1_runner.py -v --tb=short`
- Operational readiness evidence for Layer 0/1 through the latest completed market date (`2026-05-28`) was posted back to Issue `#143` with durable R2 manifest/report keys.
- I intentionally left Issue `#143` in `in-progress` per explicit operator instruction for this task.