### PR TITLE
Added XGBoost Ranker, Risk engine and Backtesting framework

### DIFF
--- a/core/backtesting/__init__.py
+++ b/core/backtesting/__init__.py
@@ -1,0 +1,19 @@
+from core.backtesting.engine import BacktestConfig, BacktestEngine, BacktestResult
+from core.backtesting.metrics import (
+    annual_return,
+    hit_rate,
+    information_coefficient,
+    max_drawdown,
+    sharpe_ratio,
+)
+
+__all__ = [
+    "BacktestConfig",
+    "BacktestEngine",
+    "BacktestResult",
+    "annual_return",
+    "hit_rate",
+    "information_coefficient",
+    "max_drawdown",
+    "sharpe_ratio",
+]

--- a/core/backtesting/engine.py
+++ b/core/backtesting/engine.py
@@ -1,0 +1,324 @@
+"""Walk-forward backtesting engine for Layer 2 model validation.
+
+The engine slices the feature/label archive into non-overlapping train and
+test folds, fits a fresh XGBoostRanker on each train window, and simulates
+an equal-weight top-N portfolio on each test date. All scoring is done with
+data available strictly before the test date, so no look-ahead leakage
+occurs.
+
+Typical usage::
+
+    from core.backtesting import BacktestEngine, BacktestConfig
+
+    engine = BacktestEngine(BacktestConfig(train_days=252, test_days=63, top_n=20))
+    result = engine.run(feature_histories, label_histories, trading_dates=dates)
+    print(f"Sharpe: {result.sharpe_ratio:.2f}  MaxDD: {result.max_drawdown:.1%}")
+"""
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from core.backtesting.metrics import (
+    annual_return,
+    hit_rate,
+    information_coefficient,
+    max_drawdown,
+    sharpe_ratio,
+    turnover,
+)
+from core.contracts.schemas import FeatureRecord, ScoreRecord
+
+TARGET_LABEL = "forward_return_5d"
+
+
+@dataclass(frozen=True)
+class BacktestConfig:
+    """Configuration for one walk-forward backtest run."""
+
+    train_days: int = 252
+    """Number of trading days in each rolling training window."""
+
+    test_days: int = 63
+    """Number of trading days in each out-of-sample test fold."""
+
+    top_n: int = 20
+    """Number of stocks held in the equal-weight portfolio on each test date."""
+
+    label_horizon: str = TARGET_LABEL
+    """Label key used both as the training target and for daily PnL realisation."""
+
+    min_train_samples: int = 50
+    """Minimum rows required to fit the model; folds with fewer rows are skipped."""
+
+
+@dataclass
+class FoldResult:
+    """Per-fold out-of-sample metrics."""
+
+    fold_index: int
+    train_start: str
+    train_end: str
+    test_start: str
+    test_end: str
+    daily_returns: list[float]
+    hit_rate: float
+    ic: float
+    avg_turnover: float
+    n_test_dates: int
+
+
+@dataclass
+class BacktestResult:
+    """Aggregated walk-forward backtest results."""
+
+    config: BacktestConfig
+    folds: list[FoldResult]
+    all_dates: list[str]
+    all_returns: list[float]
+    sharpe_ratio: float
+    max_drawdown: float
+    annual_return: float
+    hit_rate: float
+    ic: float
+    avg_turnover: float
+    n_folds: int
+
+
+class BacktestEngine:
+    """Walk-forward backtest engine that refits the model on each train window.
+
+    Args:
+        config: Backtest configuration (window sizes, portfolio size).
+        ranker_factory: Optional callable that returns a fresh unfitted ranker.
+            Defaults to ``XGBoostRanker`` with default config. Useful in tests
+            to inject a lightweight mock without requiring xgboost.
+    """
+
+    def __init__(
+        self,
+        config: BacktestConfig | None = None,
+        *,
+        ranker_factory: Callable[[], Any] | None = None,
+    ) -> None:
+        self.config = config or BacktestConfig()
+        self._ranker_factory = ranker_factory or _default_xgb_factory
+
+    def run(
+        self,
+        feature_histories: dict[str, list[FeatureRecord]],
+        label_histories: dict[str, list[FeatureRecord]],
+        *,
+        trading_dates: list[str],
+    ) -> BacktestResult:
+        """Execute the walk-forward simulation.
+
+        Args:
+            feature_histories: ``{ticker: [FeatureRecord, ...]}`` covering the
+                full evaluation period.
+            label_histories: ``{ticker: [FeatureRecord, ...]}`` from the label
+                archive; each record's ``features`` dict must contain the
+                ``label_horizon`` key (e.g. ``forward_return_5d``).
+            trading_dates: All trading calendar dates in the evaluation period,
+                sorted ascending (YYYY-MM-DD strings).
+
+        Returns:
+            A ``BacktestResult`` with per-fold and aggregate metrics.
+        """
+        dates = sorted(set(trading_dates))
+        n_dates = len(dates)
+
+        # Flatten histories to fast lookup: (date, ticker) -> features/labels
+        feat_lookup: dict[str, dict[str, FeatureRecord]] = _index_by_date(feature_histories)
+        label_lookup: dict[str, dict[str, FeatureRecord]] = _index_by_date(label_histories)
+
+        folds: list[FoldResult] = []
+        all_dates: list[str] = []
+        all_returns: list[float] = []
+
+        step = self.config.test_days
+        train_end_idx = self.config.train_days - 1
+
+        fold_index = 0
+        while train_end_idx < n_dates:
+            test_start_idx = train_end_idx + 1
+            test_end_idx = min(test_start_idx + step - 1, n_dates - 1)
+
+            if test_start_idx >= n_dates:
+                break
+
+            train_dates = dates[: train_end_idx + 1]
+            test_dates = dates[test_start_idx : test_end_idx + 1]
+
+            fold = self._run_fold(
+                fold_index=fold_index,
+                train_dates=train_dates,
+                test_dates=test_dates,
+                feat_lookup=feat_lookup,
+                label_lookup=label_lookup,
+            )
+            if fold is not None:
+                folds.append(fold)
+                all_dates.extend(test_dates[: len(fold.daily_returns)])
+                all_returns.extend(fold.daily_returns)
+
+            train_end_idx += step
+            fold_index += 1
+
+        if not all_returns:
+            return BacktestResult(
+                config=self.config,
+                folds=folds,
+                all_dates=[],
+                all_returns=[],
+                sharpe_ratio=0.0,
+                max_drawdown=0.0,
+                annual_return=0.0,
+                hit_rate=0.0,
+                ic=0.0,
+                avg_turnover=0.0,
+                n_folds=len(folds),
+            )
+
+        avg_ic = (
+            sum(f.ic for f in folds) / len(folds) if folds else 0.0
+        )
+        avg_to = (
+            sum(f.avg_turnover for f in folds) / len(folds) if folds else 0.0
+        )
+
+        return BacktestResult(
+            config=self.config,
+            folds=folds,
+            all_dates=all_dates,
+            all_returns=all_returns,
+            sharpe_ratio=sharpe_ratio(all_returns),
+            max_drawdown=max_drawdown(all_returns),
+            annual_return=annual_return(all_returns),
+            hit_rate=hit_rate(all_returns),
+            ic=avg_ic,
+            avg_turnover=avg_to,
+            n_folds=len(folds),
+        )
+
+    def _run_fold(
+        self,
+        *,
+        fold_index: int,
+        train_dates: list[str],
+        test_dates: list[str],
+        feat_lookup: dict[str, dict[str, FeatureRecord]],
+        label_lookup: dict[str, dict[str, FeatureRecord]],
+    ) -> FoldResult | None:
+        """Fit the model on the training window and simulate the test window."""
+        # Collect train feature and label records
+        train_features: list[FeatureRecord] = []
+        train_labels: list[FeatureRecord] = []
+        for d in train_dates:
+            for ticker, record in (feat_lookup.get(d) or {}).items():
+                train_features.append(record)
+                label_rec = (label_lookup.get(d) or {}).get(ticker)
+                if label_rec is not None:
+                    train_labels.append(label_rec)
+
+        if len(train_features) < self.config.min_train_samples:
+            return None
+
+        ranker = self._ranker_factory()
+        try:
+            ranker.fit(train_features, train_labels)
+        except (ValueError, RuntimeError):
+            return None
+
+        # Simulate portfolio on test dates
+        daily_returns: list[float] = []
+        all_scores_flat: list[float] = []
+        all_realized_flat: list[float] = []
+        daily_turnovers: list[float] = []
+        prev_tickers: set[str] = set()
+
+        for test_date in test_dates:
+            date_features = list((feat_lookup.get(test_date) or {}).values())
+            if not date_features:
+                continue
+
+            scores: list[ScoreRecord] = ranker.score(date_features, test_date)
+            if not scores:
+                continue
+
+            # Top-N by rank_score
+            scores.sort(key=lambda s: s.rank_score, reverse=True)
+            top_scores = scores[: self.config.top_n]
+            top_tickers = {s.ticker for s in top_scores}
+
+            # Compute portfolio return as equal-weight mean of realized returns
+            date_labels = label_lookup.get(test_date) or {}
+            position_returns: list[float] = []
+            for score in top_scores:
+                label_rec = date_labels.get(score.ticker)
+                if label_rec is None:
+                    continue
+                raw = label_rec.features.get(self.config.label_horizon)
+                if raw is None:
+                    continue
+                try:
+                    realized = float(raw)
+                except (TypeError, ValueError):
+                    continue
+                if not math.isfinite(realized):
+                    continue
+                position_returns.append(realized)
+                all_scores_flat.append(score.rank_score)
+                all_realized_flat.append(realized)
+
+            if not position_returns:
+                continue
+
+            port_return = sum(position_returns) / len(position_returns)
+            daily_returns.append(port_return)
+            daily_turnovers.append(turnover(prev_tickers, top_tickers))
+            prev_tickers = top_tickers
+
+        if not daily_returns:
+            return None
+
+        fold_ic = information_coefficient(all_scores_flat, all_realized_flat)
+        fold_to = sum(daily_turnovers) / len(daily_turnovers) if daily_turnovers else 0.0
+
+        return FoldResult(
+            fold_index=fold_index,
+            train_start=train_dates[0],
+            train_end=train_dates[-1],
+            test_start=test_dates[0],
+            test_end=test_dates[-1],
+            daily_returns=daily_returns,
+            hit_rate=hit_rate(daily_returns),
+            ic=fold_ic,
+            avg_turnover=fold_to,
+            n_test_dates=len(daily_returns),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _index_by_date(
+    histories: dict[str, list[FeatureRecord]],
+) -> dict[str, dict[str, FeatureRecord]]:
+    """Build a {date: {ticker: record}} lookup from ticker-keyed histories."""
+    by_date: dict[str, dict[str, FeatureRecord]] = {}
+    for ticker, records in histories.items():
+        for record in records:
+            by_date.setdefault(record.date, {})[ticker] = record
+    return by_date
+
+
+def _default_xgb_factory() -> Any:
+    """Lazy factory so importing engine.py never triggers the xgboost import chain."""
+    from core.models.xgboost_ranker import XGBoostRanker
+
+    return XGBoostRanker()

--- a/core/backtesting/metrics.py
+++ b/core/backtesting/metrics.py
@@ -19,8 +19,12 @@ def sharpe_ratio(daily_returns: list[float], annual_factor: float = 252.0) -> fl
         return 0.0
     mean = sum(daily_returns) / n
     variance = sum((r - mean) ** 2 for r in daily_returns) / (n - 1)
-    stdev = math.sqrt(variance)
+    stdev = math.sqrt(max(variance, 0.0))
     if stdev == 0.0:
+        return 0.0
+    # Suppress near-zero variance caused by floating-point accumulation on
+    # constant return streams (coefficient of variation below machine-noise floor).
+    if abs(mean) > 0.0 and stdev / abs(mean) < 1e-9:
         return 0.0
     return (mean / stdev) * math.sqrt(annual_factor)
 

--- a/core/backtesting/metrics.py
+++ b/core/backtesting/metrics.py
@@ -1,0 +1,126 @@
+"""Pure-Python performance metrics for backtesting.
+
+All functions operate on plain Python lists of floats so they can run in any
+environment without pandas or numpy. Inputs are daily portfolio returns
+(proportional, e.g. 0.01 = 1 % gain).
+"""
+from __future__ import annotations
+
+import math
+
+
+def sharpe_ratio(daily_returns: list[float], annual_factor: float = 252.0) -> float:
+    """Annualized Sharpe ratio (zero risk-free rate).
+
+    Returns 0.0 when there are fewer than 2 observations or zero variance.
+    """
+    n = len(daily_returns)
+    if n < 2:
+        return 0.0
+    mean = sum(daily_returns) / n
+    variance = sum((r - mean) ** 2 for r in daily_returns) / (n - 1)
+    stdev = math.sqrt(variance)
+    if stdev == 0.0:
+        return 0.0
+    return (mean / stdev) * math.sqrt(annual_factor)
+
+
+def max_drawdown(daily_returns: list[float]) -> float:
+    """Maximum peak-to-trough drawdown from a sequence of daily returns.
+
+    Returns a positive fraction (e.g. 0.15 = 15 % drawdown).
+    """
+    peak = 1.0
+    equity = 1.0
+    max_dd = 0.0
+    for r in daily_returns:
+        equity *= 1.0 + r
+        if equity > peak:
+            peak = equity
+        dd = (peak - equity) / peak if peak > 0 else 0.0
+        if dd > max_dd:
+            max_dd = dd
+    return max_dd
+
+
+def annual_return(daily_returns: list[float], annual_factor: float = 252.0) -> float:
+    """Annualized geometric return from daily returns.
+
+    Returns 0.0 for an empty sequence.
+    """
+    n = len(daily_returns)
+    if n == 0:
+        return 0.0
+    equity = 1.0
+    for r in daily_returns:
+        equity *= 1.0 + r
+    if equity <= 0:
+        return -1.0
+    return equity ** (annual_factor / n) - 1.0
+
+
+def hit_rate(daily_returns: list[float]) -> float:
+    """Fraction of trading days with a strictly positive portfolio return."""
+    if not daily_returns:
+        return 0.0
+    return sum(1 for r in daily_returns if r > 0.0) / len(daily_returns)
+
+
+def information_coefficient(
+    scores: list[float],
+    realized_returns: list[float],
+) -> float:
+    """Spearman rank correlation between model scores and realized returns.
+
+    The IC measures how well the model's cross-sectional ranking predicts
+    actual return ordering. Returns 0.0 when inputs are empty or mismatched.
+    """
+    n = len(scores)
+    if n < 2 or len(realized_returns) != n:
+        return 0.0
+
+    rank_s = _rank_values(scores)
+    rank_r = _rank_values(realized_returns)
+    mean_rank = (n - 1) / 2.0
+
+    cov = sum((rank_s[i] - mean_rank) * (rank_r[i] - mean_rank) for i in range(n)) / n
+    var = sum((rank_s[i] - mean_rank) ** 2 for i in range(n)) / n
+
+    return cov / var if var > 0.0 else 0.0
+
+
+def turnover(prev_tickers: set[str], next_tickers: set[str]) -> float:
+    """One-way portfolio turnover as a fraction of the portfolio.
+
+    Computed as the number of positions entered (or equivalently exited, since
+    a balanced rebalance has equal buys and sells) divided by the larger
+    portfolio size. A full replacement from N to N different stocks = 1.0.
+    """
+    total = max(len(prev_tickers), len(next_tickers))
+    if total == 0:
+        return 0.0
+    entered = len(next_tickers - prev_tickers)
+    return entered / total
+
+
+def _rank_values(values: list[float]) -> list[float]:
+    """Return average (midrank) ranks for a list of floats.
+
+    Tied values receive the mean of the ranks they would otherwise occupy,
+    so a list of identical values produces a constant rank equal to (n-1)/2.
+    This is the correct treatment for Spearman rank correlation.
+    """
+    n = len(values)
+    sorted_indices = sorted(range(n), key=lambda i: values[i])
+
+    ranks = [0.0] * n
+    i = 0
+    while i < n:
+        j = i
+        while j < n and values[sorted_indices[j]] == values[sorted_indices[i]]:
+            j += 1
+        avg_rank = (i + j - 1) / 2.0
+        for k in range(i, j):
+            ranks[sorted_indices[k]] = avg_rank
+        i = j
+    return ranks

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,0 +1,3 @@
+from core.models.xgboost_ranker import XGBoostRanker, XGBoostRankerConfig
+
+__all__ = ["XGBoostRanker", "XGBoostRankerConfig"]

--- a/core/models/xgboost_ranker.py
+++ b/core/models/xgboost_ranker.py
@@ -1,0 +1,406 @@
+"""Layer 2 XGBoost cross-sectional return ranker.
+
+Trains an XGBoost regressor on Layer 1 features and forward-return labels,
+producing cross-sectionally ranked ScoreRecords for daily inference. The
+model is serialized to a portable byte bundle for R2 storage.
+
+Typical usage:
+    ranker = XGBoostRanker().fit(feature_records, label_records)
+    scores = ranker.score(today_features, as_of_date="2025-01-10")
+    payload = ranker.to_bytes()  # store in R2
+    ranker2 = XGBoostRanker.from_bytes(payload)  # restore
+"""
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import math
+import pickle
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from core.contracts.schemas import FeatureRecord, ScoreRecord
+
+if TYPE_CHECKING:
+    pass
+
+TARGET_LABEL = "forward_return_5d"
+
+# Label columns that must never appear in the model feature matrix.
+# Mirrors LABEL_FEATURE_COLUMNS from core.labels.forward_returns (stable contract).
+_LABEL_COLUMNS: frozenset[str] = frozenset({
+    "forward_return_1d",
+    "forward_return_5d",
+    "forward_return_20d",
+    "forward_log_return_1d",
+    "forward_log_return_5d",
+    "forward_log_return_20d",
+    "survives_to_t1",
+    "survives_to_t5",
+    "survives_to_t20",
+})
+
+# Features excluded from the model input: labels and the string regime tag.
+_EXCLUDED_FEATURE_KEYS: frozenset[str] = _LABEL_COLUMNS | {"regime_label"}
+
+
+@dataclass(frozen=True)
+class XGBoostRankerConfig:
+    """Hyperparameters for the XGBoost return ranker."""
+
+    n_estimators: int = 200
+    max_depth: int = 4
+    learning_rate: float = 0.05
+    subsample: float = 0.8
+    colsample_bytree: float = 0.8
+    min_child_weight: int = 10
+    reg_alpha: float = 0.1
+    reg_lambda: float = 1.0
+    random_state: int = 42
+
+
+class XGBoostRanker:
+    """XGBoost regressor that scores stocks cross-sectionally within a date.
+
+    The ranker predicts 5-day forward returns for each stock in a given
+    universe, ranks them cross-sectionally to produce rank_score ∈ [0, 1],
+    and calibrates a logistic layer to emit pos_prob.
+    """
+
+    def __init__(self, config: XGBoostRankerConfig | None = None) -> None:
+        self.config = config or XGBoostRankerConfig()
+        self._model: Any = None
+        self._calibrator: Any = None
+        self._feature_columns: tuple[str, ...] = ()
+        self._model_version: str = ""
+
+    @property
+    def model_version(self) -> str:
+        return self._model_version
+
+    @property
+    def feature_columns(self) -> tuple[str, ...]:
+        return self._feature_columns
+
+    @property
+    def is_fitted(self) -> bool:
+        return self._model is not None
+
+    def fit(
+        self,
+        feature_records: Sequence[FeatureRecord],
+        label_records: Sequence[FeatureRecord],
+    ) -> XGBoostRanker:
+        """Fit the ranker on paired feature and label FeatureRecord sequences.
+
+        Args:
+            feature_records: Layer 1 FeatureRecords (any date range).
+            label_records: FeatureRecords from the label archive, each
+                containing ``forward_return_5d`` in their ``features`` dict.
+
+        Returns:
+            Self, for chaining.
+        """
+        xgb = _require_xgboost()
+        lr_cls = _require_sklearn_lr()
+        import numpy as np
+
+        X, y, feature_columns = _build_training_arrays(feature_records, label_records)
+        if len(X) == 0:
+            raise ValueError("No training samples after joining features with valid labels")
+
+        self._feature_columns = feature_columns
+
+        model = xgb.XGBRegressor(
+            n_estimators=self.config.n_estimators,
+            max_depth=self.config.max_depth,
+            learning_rate=self.config.learning_rate,
+            subsample=self.config.subsample,
+            colsample_bytree=self.config.colsample_bytree,
+            min_child_weight=self.config.min_child_weight,
+            reg_alpha=self.config.reg_alpha,
+            reg_lambda=self.config.reg_lambda,
+            random_state=self.config.random_state,
+            n_jobs=-1,
+            verbosity=0,
+        )
+        model.fit(X, y)
+        self._model = model
+
+        raw_preds = model.predict(X)
+        y_binary = (np.asarray(y) > 0).astype(int)
+        calibrator = lr_cls(max_iter=1000, C=1.0)
+        calibrator.fit(raw_preds.reshape(-1, 1), y_binary)
+        self._calibrator = calibrator
+
+        train_dates = sorted({r.date for r in feature_records})
+        self._model_version = _compute_version(
+            config=self.config,
+            feature_columns=self._feature_columns,
+            train_start=train_dates[0] if train_dates else "",
+            train_end=train_dates[-1] if train_dates else "",
+            n_samples=int(len(X)),
+        )
+        return self
+
+    def score(
+        self,
+        feature_records: Sequence[FeatureRecord],
+        as_of_date: str,
+    ) -> list[ScoreRecord]:
+        """Score all feature records for one date.
+
+        Args:
+            feature_records: All available FeatureRecords (any date).
+            as_of_date: YYYY-MM-DD date to score; only records matching
+                this date are evaluated.
+
+        Returns:
+            One ScoreRecord per ticker present on ``as_of_date``.
+        """
+        if not self.is_fitted:
+            raise RuntimeError("Call fit() before score()")
+
+        import numpy as np
+
+        records_on_date = [r for r in feature_records if r.date == as_of_date]
+        if not records_on_date:
+            return []
+
+        X = _build_inference_array(records_on_date, self._feature_columns)
+        raw_preds = self._model.predict(X)
+        pos_probs = self._calibrator.predict_proba(raw_preds.reshape(-1, 1))[:, 1]
+
+        n = len(raw_preds)
+        ranks = _rank_array(raw_preds)
+        rank_scores = ranks / max(n - 1, 1)
+
+        results: list[ScoreRecord] = []
+        for i, record in enumerate(records_on_date):
+            pos_prob = float(np.clip(pos_probs[i], 0.0, 1.0))
+            confidence = min(abs(pos_prob - 0.5) * 2.0, 1.0)
+            results.append(
+                ScoreRecord(
+                    date=as_of_date,
+                    ticker=record.ticker,
+                    return_score=float(raw_preds[i]),
+                    pos_prob=pos_prob,
+                    rank_score=float(rank_scores[i]),
+                    regime=_extract_regime(record),
+                    confidence=confidence,
+                    model_version=self._model_version,
+                )
+            )
+        return results
+
+    def to_bytes(self) -> bytes:
+        """Serialize the fitted model to a portable byte string for R2 storage."""
+        if not self.is_fitted:
+            raise RuntimeError("Cannot serialize an unfitted model")
+
+        xgb_buf = io.BytesIO()
+        self._model.save_model(xgb_buf)
+
+        bundle = {
+            "schema": "xgboost_ranker_v1",
+            "xgb_model_bytes": xgb_buf.getvalue(),
+            "calibrator_pkl": pickle.dumps(self._calibrator, protocol=4),
+            "feature_columns": list(self._feature_columns),
+            "config": _config_to_dict(self.config),
+            "model_version": self._model_version,
+        }
+        return pickle.dumps(bundle, protocol=4)
+
+    @classmethod
+    def from_bytes(cls, data: bytes) -> XGBoostRanker:
+        """Restore a serialized XGBoostRanker from bytes loaded from R2."""
+        xgb = _require_xgboost()
+
+        bundle = pickle.loads(data)  # noqa: S301
+        if bundle.get("schema") != "xgboost_ranker_v1":
+            raise ValueError(f"Unrecognized model bundle schema: {bundle.get('schema')!r}")
+
+        xgb_buf = io.BytesIO(bundle["xgb_model_bytes"])
+        model = xgb.XGBRegressor()
+        model.load_model(xgb_buf)
+
+        calibrator = pickle.loads(bundle["calibrator_pkl"])  # noqa: S301
+
+        ranker = cls(config=XGBoostRankerConfig(**bundle["config"]))
+        ranker._model = model
+        ranker._calibrator = calibrator
+        ranker._feature_columns = tuple(bundle["feature_columns"])
+        ranker._model_version = bundle["model_version"]
+        return ranker
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_training_arrays(
+    feature_records: Sequence[FeatureRecord],
+    label_records: Sequence[FeatureRecord],
+) -> tuple[Any, list[float], tuple[str, ...]]:
+    """Join features with labels and return (X_ndarray, y_list, feature_columns)."""
+    import numpy as np
+
+    # Build label lookup: (date, ticker) -> forward_return_5d
+    label_lookup: dict[tuple[str, str], float] = {}
+    for record in label_records:
+        raw = record.features.get(TARGET_LABEL)
+        if raw is None:
+            continue
+        try:
+            val = float(raw)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(val):
+            continue
+        label_lookup[(record.date, record.ticker)] = val
+
+    # Discover the union of numeric, non-excluded feature keys
+    all_keys: set[str] = set()
+    for record in feature_records:
+        if (record.date, record.ticker) not in label_lookup:
+            continue
+        for key, value in record.features.items():
+            if key in _EXCLUDED_FEATURE_KEYS:
+                continue
+            if not isinstance(value, (int, float)):
+                continue
+            if isinstance(value, float) and not math.isfinite(value):
+                continue
+            all_keys.add(key)
+
+    feature_columns: tuple[str, ...] = tuple(sorted(all_keys))
+    if not feature_columns:
+        return np.empty((0, 0)), [], ()
+
+    # Build X and y
+    rows: list[list[float]] = []
+    y_values: list[float] = []
+
+    for record in feature_records:
+        key = (record.date, record.ticker)
+        if key not in label_lookup:
+            continue
+        row = [
+            _safe_float(record.features.get(col)) for col in feature_columns
+        ]
+        rows.append(row)
+        y_values.append(label_lookup[key])
+
+    if not rows:
+        return np.empty((0, len(feature_columns))), [], feature_columns
+
+    X = np.array(rows, dtype=float)
+    return X, y_values, feature_columns
+
+
+def _build_inference_array(
+    records: Sequence[FeatureRecord],
+    feature_columns: tuple[str, ...],
+) -> Any:
+    """Build X matrix for inference using the training-time column order."""
+    import numpy as np
+
+    rows = [
+        [_safe_float(record.features.get(col)) for col in feature_columns]
+        for record in records
+    ]
+    return np.array(rows, dtype=float)
+
+
+def _rank_array(arr: Any) -> Any:
+    """Return 0-based ascending ranks (0 = lowest) as a float array."""
+    import numpy as np
+
+    arr = np.asarray(arr, dtype=float)
+    n = len(arr)
+    sorted_indices = np.argsort(arr)
+    ranks = np.empty(n, dtype=float)
+    ranks[sorted_indices] = np.arange(n, dtype=float)
+    return ranks
+
+
+def _extract_regime(record: FeatureRecord) -> str | None:
+    """Return the string regime label from a FeatureRecord if present."""
+    raw = record.features.get("regime_label")
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    return None
+
+
+def _safe_float(value: Any) -> float:
+    """Convert a feature value to float, returning 0.0 for missing or non-finite."""
+    if value is None:
+        return 0.0
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return 0.0
+    return f if math.isfinite(f) else 0.0
+
+
+def _config_to_dict(config: XGBoostRankerConfig) -> dict[str, Any]:
+    """Serialize config to a JSON-safe dict."""
+    return {
+        "n_estimators": config.n_estimators,
+        "max_depth": config.max_depth,
+        "learning_rate": config.learning_rate,
+        "subsample": config.subsample,
+        "colsample_bytree": config.colsample_bytree,
+        "min_child_weight": config.min_child_weight,
+        "reg_alpha": config.reg_alpha,
+        "reg_lambda": config.reg_lambda,
+        "random_state": config.random_state,
+    }
+
+
+def _compute_version(
+    *,
+    config: XGBoostRankerConfig,
+    feature_columns: tuple[str, ...],
+    train_start: str,
+    train_end: str,
+    n_samples: int,
+) -> str:
+    """Compute a short deterministic model version hash."""
+    payload = json.dumps(
+        {
+            "config": _config_to_dict(config),
+            "features": list(feature_columns),
+            "train_start": train_start,
+            "train_end": train_end,
+            "n_samples": n_samples,
+        },
+        sort_keys=True,
+    )
+    return "v1-" + hashlib.sha256(payload.encode()).hexdigest()[:12]
+
+
+def _require_xgboost() -> Any:
+    try:
+        import xgboost as xgb
+
+        return xgb
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "xgboost is required for Layer 2 model training and inference. "
+            "Install it via requirements/modal.txt."
+        ) from exc
+
+
+def _require_sklearn_lr() -> Any:
+    try:
+        from sklearn.linear_model import LogisticRegression
+
+        return LogisticRegression
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "scikit-learn is required for pos_prob calibration."
+        ) from exc

--- a/core/risk/__init__.py
+++ b/core/risk/__init__.py
@@ -1,0 +1,3 @@
+from core.risk.engine import RiskConfig, RiskEngine
+
+__all__ = ["RiskConfig", "RiskEngine"]

--- a/core/risk/engine.py
+++ b/core/risk/engine.py
@@ -1,0 +1,182 @@
+"""Layer 4 hard-rule risk engine.
+
+Applies deterministic position, exposure, sector, and liquidity constraints
+to a list of PortfolioRecord proposals and returns ApprovedOrderRecords. No
+ML is involved; all rules are threshold-based and auditable.
+
+Usage::
+
+    engine = RiskEngine(RiskConfig(max_position_pct=0.08))
+    approved = engine.apply(
+        proposals,
+        equity=100_000.0,
+        sector_map={"AAPL": "Technology", "JPM": "Financials"},
+        adv_map={"AAPL": 5_000_000.0, "JPM": 2_000_000.0},
+    )
+"""
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from core.contracts.schemas import ActionType, ApprovedOrderRecord, PortfolioRecord
+from core.risk.rules import check_adv_cap, check_max_position, check_min_position
+
+
+@dataclass(frozen=True)
+class RiskConfig:
+    """Configurable thresholds for all risk rules."""
+
+    max_position_pct: float = 0.10
+    """Maximum single-position weight as a fraction of total equity (default 10 %)."""
+
+    min_position_dollars: float = 100.0
+    """Minimum non-zero position size; smaller orders are rejected (default $100)."""
+
+    max_gross_exposure: float = 1.0
+    """Maximum sum of |target_dollars| / equity (default 1.0 = fully invested long-only)."""
+
+    max_sector_pct: float = 0.30
+    """Maximum weight of any single GICS sector as a fraction of equity (default 30 %)."""
+
+    max_adv_participation: float = 0.01
+    """Maximum order size as a fraction of average daily volume (default 1 %)."""
+
+
+class RiskEngine:
+    """Stateless risk engine that evaluates proposals against configurable hard rules.
+
+    The engine runs in two passes:
+    1. Per-proposal rules (position size, min size, ADV cap).
+    2. Portfolio-level rules (gross exposure, sector concentration) applied to
+       surviving proposals in descending |target_dollars| order, so the largest
+       positions are approved first and smaller ones are cut when limits are full.
+    """
+
+    def __init__(self, config: RiskConfig | None = None) -> None:
+        self.config = config or RiskConfig()
+
+    def apply(
+        self,
+        proposals: Sequence[PortfolioRecord],
+        *,
+        equity: float,
+        sector_map: dict[str, str] | None = None,
+        adv_map: dict[str, float] | None = None,
+    ) -> list[ApprovedOrderRecord]:
+        """Evaluate proposals and return one ApprovedOrderRecord per proposal.
+
+        Args:
+            proposals: Pre-risk portfolio targets from Layer 3.
+            equity: Total account equity in dollars.
+            sector_map: Optional ticker → sector string. Sector concentration
+                rules are skipped when not provided.
+            adv_map: Optional ticker → average daily dollar volume. ADV cap
+                is skipped when not provided.
+
+        Returns:
+            One ApprovedOrderRecord per input proposal. Rejected proposals
+            carry ``approved=False`` and the names of the rules that fired.
+        """
+        sector_map = sector_map or {}
+        adv_map = adv_map or {}
+
+        # Pass 1: per-proposal rules
+        survivors: list[tuple[PortfolioRecord, list[str]]] = []
+        rejected: list[ApprovedOrderRecord] = []
+
+        for proposal in proposals:
+            fired: list[str] = []
+
+            rule = check_max_position(proposal, equity, self.config.max_position_pct)
+            if rule:
+                fired.append(rule)
+
+            rule = check_min_position(proposal, self.config.min_position_dollars)
+            if rule:
+                fired.append(rule)
+
+            adv = adv_map.get(proposal.ticker, 0.0)
+            rule = check_adv_cap(proposal, adv, self.config.max_adv_participation)
+            if rule:
+                fired.append(rule)
+
+            if fired:
+                rejected.append(_make_order(proposal, approved=False, rules=fired))
+            else:
+                survivors.append((proposal, []))
+
+        # Pass 2: portfolio-level rules applied in descending size order
+        survivors.sort(key=lambda item: abs(item[0].target_dollars), reverse=True)
+
+        approved: list[ApprovedOrderRecord] = []
+        gross_dollars = 0.0
+        sector_dollars: dict[str, float] = defaultdict(float)
+
+        for proposal, rules in survivors:
+            extra_rules: list[str] = []
+
+            # Gross exposure check
+            if equity > 0:
+                projected_gross = gross_dollars + abs(proposal.target_dollars)
+                if projected_gross / equity > self.config.max_gross_exposure:
+                    extra_rules.append("max_gross_exposure")
+
+            # Sector concentration check
+            sector = sector_map.get(proposal.ticker)
+            if sector and equity > 0:
+                projected_sector = sector_dollars[sector] + abs(proposal.target_dollars)
+                if projected_sector / equity > self.config.max_sector_pct:
+                    extra_rules.append("max_sector_pct")
+
+            if extra_rules:
+                rejected.append(_make_order(proposal, approved=False, rules=extra_rules))
+            else:
+                gross_dollars += abs(proposal.target_dollars)
+                if sector:
+                    sector_dollars[sector] += abs(proposal.target_dollars)
+                approved.append(_make_order(proposal, approved=True, rules=[]))
+
+        # Maintain original input order in the output
+        ticker_to_order: dict[str, ApprovedOrderRecord] = {}
+        for order in rejected + approved:
+            ticker_to_order[order.ticker] = order
+
+        return [ticker_to_order[p.ticker] for p in proposals if p.ticker in ticker_to_order]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_order(
+    proposal: PortfolioRecord,
+    *,
+    approved: bool,
+    rules: list[str],
+) -> ApprovedOrderRecord:
+    """Convert a PortfolioRecord into an ApprovedOrderRecord."""
+    if not approved:
+        action = ActionType.REJECT
+        reason = "; ".join(rules) if rules else "rejected"
+    elif proposal.change_dollars > 0:
+        action = ActionType.BUY
+        reason = None
+    elif proposal.change_dollars < 0:
+        action = ActionType.SELL
+        reason = None
+    else:
+        action = ActionType.HOLD
+        reason = None
+
+    return ApprovedOrderRecord(
+        date=proposal.date,
+        ticker=proposal.ticker,
+        action=action,
+        target_dollars=proposal.target_dollars,
+        approved=approved,
+        rules_triggered=list(rules),
+        reason=reason,
+    )

--- a/core/risk/rules.py
+++ b/core/risk/rules.py
@@ -1,0 +1,90 @@
+"""Atomic risk-rule check functions for the Layer 4 risk engine.
+
+Each function evaluates one rule against a single proposal or the
+accumulated portfolio state. Functions return ``None`` when the rule
+passes or the string rule identifier when it fires.
+"""
+from __future__ import annotations
+
+from core.contracts.schemas import PortfolioRecord
+
+
+def check_max_position(
+    proposal: PortfolioRecord,
+    equity: float,
+    max_position_pct: float,
+) -> str | None:
+    """Fire when the proposed position exceeds ``max_position_pct`` of equity."""
+    if equity <= 0:
+        return "no_equity"
+    if abs(proposal.target_dollars) / equity > max_position_pct:
+        return "max_position_pct"
+    return None
+
+
+def check_min_position(
+    proposal: PortfolioRecord,
+    min_position_dollars: float,
+) -> str | None:
+    """Fire when a non-zero proposed position is below the minimum trade size."""
+    dollars = abs(proposal.target_dollars)
+    if 0.0 < dollars < min_position_dollars:
+        return "min_position_dollars"
+    return None
+
+
+def check_adv_cap(
+    proposal: PortfolioRecord,
+    adv_dollars: float,
+    max_adv_participation: float,
+) -> str | None:
+    """Fire when the order would exceed ``max_adv_participation`` of ADV.
+
+    Args:
+        proposal: Portfolio construction target for one ticker.
+        adv_dollars: Average daily dollar volume for the ticker.
+        max_adv_participation: Maximum fraction of ADV allowed (e.g. 0.01).
+    """
+    if adv_dollars <= 0:
+        return None
+    if abs(proposal.change_dollars) > adv_dollars * max_adv_participation:
+        return "adv_participation_cap"
+    return None
+
+
+def check_gross_exposure(
+    all_target_dollars: list[float],
+    equity: float,
+    max_gross_exposure: float,
+) -> bool:
+    """Return True when the combined gross exposure would exceed the limit."""
+    if equity <= 0:
+        return True
+    gross = sum(abs(d) for d in all_target_dollars)
+    return gross / equity > max_gross_exposure
+
+
+def check_sector_concentration(
+    ticker: str,
+    target_dollars: float,
+    sector_running_dollars: dict[str, float],
+    equity: float,
+    max_sector_pct: float,
+) -> str | None:
+    """Fire when adding this position would push its sector over the limit.
+
+    Args:
+        ticker: Ticker being evaluated.
+        target_dollars: Proposed dollar allocation.
+        sector_running_dollars: Mutable dict of {sector: dollars_already_approved}.
+        equity: Total portfolio equity.
+        max_sector_pct: Maximum fraction of equity per sector.
+
+    Returns:
+        Rule name if sector limit would be breached, else None. The caller
+        must update ``sector_running_dollars`` when the rule passes.
+    """
+    if equity <= 0:
+        return "no_equity"
+    _ = ticker
+    return None  # evaluated at portfolio level by the engine after sector lookup

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -225,6 +225,24 @@ def layer1_label_path(as_of_date: str | Date | datetime, ticker: str) -> str:
     return build_r2_key("labels", "layer1", _format_date(as_of_date), f"{safe_ticker}.parquet")
 
 
+def layer2_model_path(model_version: str) -> str:
+    """Return the canonical Layer 2 model artifact path for one version."""
+    safe_version = _validate_key_part(model_version)
+    return build_r2_key("models", "layer2", f"{safe_version}.pkl")
+
+
+def layer2_model_manifest_path(model_version: str) -> str:
+    """Return the canonical Layer 2 model manifest path for one version."""
+    safe_version = _validate_key_part(model_version)
+    return build_r2_key("models", "layer2", f"{safe_version}_manifest.json")
+
+
+def backtest_report_path(report_id: str) -> str:
+    """Return the canonical backtest report path for one run."""
+    safe_id = _validate_key_part(report_id)
+    return build_r2_key("artifacts", "reports", "backtests", f"{safe_id}.json")
+
+
 def pipeline_manifest_path(stage: str, run_id: str) -> str:
     """Return the canonical pipeline manifest path for one stage/run pair."""
     safe_stage = _validate_key_part(stage)

--- a/tests/unit/test_backtesting.py
+++ b/tests/unit/test_backtesting.py
@@ -1,0 +1,353 @@
+"""Unit tests for the backtesting framework.
+
+Metrics tests run without any ML dependencies. BacktestEngine tests use a
+lightweight mock ranker so xgboost is not required.
+"""
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from core.backtesting.engine import BacktestConfig, BacktestEngine, BacktestResult
+from core.backtesting.metrics import (
+    annual_return,
+    hit_rate,
+    information_coefficient,
+    max_drawdown,
+    sharpe_ratio,
+    turnover,
+)
+from core.contracts.schemas import FeatureRecord, ScoreRecord
+
+# ---------------------------------------------------------------------------
+# Metrics unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSharpeRatio:
+    def test_positive_returns_positive_sharpe(self) -> None:
+        import random
+
+        rng = random.Random(1)
+        returns = [0.002 + rng.uniform(-0.001, 0.001) for _ in range(252)]
+        assert sharpe_ratio(returns) > 0
+
+    def test_negative_returns_negative_sharpe(self) -> None:
+        import random
+
+        rng = random.Random(2)
+        returns = [-0.002 + rng.uniform(-0.001, 0.001) for _ in range(252)]
+        assert sharpe_ratio(returns) < 0
+
+    def test_zero_variance_returns_zero(self) -> None:
+        # Identical returns → zero sample variance → Sharpe undefined; returns 0.0.
+        returns = [0.005] * 100
+        assert sharpe_ratio(returns) == 0.0
+
+    def test_empty_returns_zero(self) -> None:
+        assert sharpe_ratio([]) == 0.0
+
+    def test_single_return_returns_zero(self) -> None:
+        assert sharpe_ratio([0.01]) == 0.0
+
+    def test_annual_factor_scales_result(self) -> None:
+        returns = [0.001, -0.002, 0.003, -0.001, 0.002]
+        s252 = sharpe_ratio(returns, annual_factor=252.0)
+        s365 = sharpe_ratio(returns, annual_factor=365.0)
+        assert s365 > s252
+
+
+class TestMaxDrawdown:
+    def test_monotone_upward_is_zero_drawdown(self) -> None:
+        returns = [0.01] * 10
+        assert max_drawdown(returns) == pytest.approx(0.0)
+
+    def test_single_loss_computes_correctly(self) -> None:
+        # 10% gain then 20% loss: peak = 1.1, trough = 0.88 → DD = (1.1-0.88)/1.1
+        returns = [0.10, -0.20]
+        dd = max_drawdown(returns)
+        expected = (1.1 - 1.1 * 0.80) / 1.1
+        assert dd == pytest.approx(expected, rel=1e-6)
+
+    def test_empty_returns_zero_drawdown(self) -> None:
+        assert max_drawdown([]) == 0.0
+
+    def test_drawdown_is_non_negative(self) -> None:
+        import random
+
+        rng = random.Random(0)
+        returns = [rng.uniform(-0.05, 0.05) for _ in range(100)]
+        assert max_drawdown(returns) >= 0.0
+
+
+class TestAnnualReturn:
+    def test_flat_returns_zero_annual_return(self) -> None:
+        returns = [0.0] * 100
+        assert annual_return(returns) == pytest.approx(0.0, abs=1e-9)
+
+    def test_positive_daily_implies_positive_annual(self) -> None:
+        returns = [0.001] * 252
+        ar = annual_return(returns, annual_factor=252.0)
+        assert ar > 0
+
+    def test_empty_returns_zero(self) -> None:
+        assert annual_return([]) == 0.0
+
+    def test_geometric_compounding(self) -> None:
+        # One year of exactly +1% daily → equity = 1.01^252
+        returns = [0.01] * 252
+        ar = annual_return(returns, annual_factor=252.0)
+        expected = 1.01**252 - 1.0
+        assert ar == pytest.approx(expected, rel=1e-6)
+
+
+class TestHitRate:
+    def test_all_positive_is_one(self) -> None:
+        assert hit_rate([0.01, 0.02, 0.001]) == pytest.approx(1.0)
+
+    def test_all_negative_is_zero(self) -> None:
+        assert hit_rate([-0.01, -0.02]) == pytest.approx(0.0)
+
+    def test_half_positive(self) -> None:
+        assert hit_rate([0.01, -0.01, 0.02, -0.02]) == pytest.approx(0.5)
+
+    def test_empty_is_zero(self) -> None:
+        assert hit_rate([]) == 0.0
+
+    def test_zero_returns_excluded(self) -> None:
+        assert hit_rate([0.0, 0.0, 0.0]) == 0.0
+
+
+class TestInformationCoefficient:
+    def test_perfect_rank_correlation(self) -> None:
+        scores = [1.0, 2.0, 3.0, 4.0]
+        realized = [10.0, 20.0, 30.0, 40.0]
+        assert information_coefficient(scores, realized) == pytest.approx(1.0, abs=1e-9)
+
+    def test_perfect_inverse_correlation(self) -> None:
+        scores = [4.0, 3.0, 2.0, 1.0]
+        realized = [10.0, 20.0, 30.0, 40.0]
+        assert information_coefficient(scores, realized) == pytest.approx(-1.0, abs=1e-9)
+
+    def test_zero_on_constant_scores(self) -> None:
+        # All scores tied → all midranks equal → zero variance → IC = 0.
+        scores = [1.0, 1.0, 1.0]
+        realized = [1.0, 2.0, 3.0]
+        assert information_coefficient(scores, realized) == pytest.approx(0.0)
+
+    def test_empty_is_zero(self) -> None:
+        assert information_coefficient([], []) == 0.0
+
+    def test_mismatched_lengths_is_zero(self) -> None:
+        assert information_coefficient([1.0, 2.0], [1.0]) == 0.0
+
+    def test_range_within_minus_one_to_one(self) -> None:
+        import random
+
+        rng = random.Random(7)
+        for _ in range(20):
+            n = rng.randint(2, 50)
+            s = [rng.random() for _ in range(n)]
+            r = [rng.random() for _ in range(n)]
+            ic = information_coefficient(s, r)
+            assert -1.0 - 1e-9 <= ic <= 1.0 + 1e-9
+
+
+class TestTurnover:
+    def test_no_change_is_zero(self) -> None:
+        tickers = {"AAPL", "MSFT", "GOOG"}
+        assert turnover(tickers, tickers) == 0.0
+
+    def test_complete_replacement_is_one(self) -> None:
+        # 2 new positions entered / 2 total = 1.0 one-way turnover.
+        prev = {"AAPL", "MSFT"}
+        next_ = {"GOOG", "AMZN"}
+        assert turnover(prev, next_) == pytest.approx(1.0)
+
+    def test_half_turnover(self) -> None:
+        # 1 new position entered (GOOG) / 2 total = 0.5.
+        prev = {"AAPL", "MSFT"}
+        next_ = {"AAPL", "GOOG"}
+        assert turnover(prev, next_) == pytest.approx(0.5)
+
+    def test_empty_sets_is_zero(self) -> None:
+        assert turnover(set(), set()) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# BacktestEngine tests (mock ranker — no xgboost required)
+# ---------------------------------------------------------------------------
+
+
+class _MockRanker:
+    """Deterministic ranker that scores tickers alphabetically for testing."""
+
+    def __init__(self) -> None:
+        self.is_fitted = False
+
+    def fit(self, feature_records: list[FeatureRecord], label_records: list[FeatureRecord]) -> _MockRanker:
+        if not label_records:
+            raise ValueError("No training samples")
+        self.is_fitted = True
+        return self
+
+    def score(self, feature_records: list[FeatureRecord], as_of_date: str) -> list[ScoreRecord]:
+        if not self.is_fitted:
+            raise RuntimeError("Not fitted")
+        records = [r for r in feature_records if r.date == as_of_date]
+        sorted_records = sorted(records, key=lambda r: r.ticker)
+        n = len(sorted_records)
+        scores = []
+        for i, record in enumerate(sorted_records):
+            rank = i / max(n - 1, 1)
+            scores.append(
+                ScoreRecord(
+                    date=as_of_date,
+                    ticker=record.ticker,
+                    return_score=rank,
+                    pos_prob=rank,
+                    rank_score=rank,
+                    regime=None,
+                    confidence=rank,
+                    model_version="mock-v1",
+                )
+            )
+        return scores
+
+
+def _make_histories(
+    n_tickers: int = 10,
+    n_dates: int = 100,
+    *,
+    daily_return: float = 0.001,
+) -> tuple[dict[str, list[FeatureRecord]], dict[str, list[FeatureRecord]], list[str]]:
+    """Build synthetic feature and label histories for backtest testing."""
+    import random
+
+    rng = random.Random(99)
+    tickers = [f"TK{i:02d}" for i in range(n_tickers)]
+
+    # Generate trading dates (weekdays only, roughly)
+    from datetime import date, timedelta
+
+    start = date(2023, 1, 3)
+    trading_dates: list[str] = []
+    current = start
+    while len(trading_dates) < n_dates:
+        if current.weekday() < 5:
+            trading_dates.append(current.isoformat())
+        current += timedelta(days=1)
+
+    feature_histories: dict[str, list[FeatureRecord]] = {}
+    label_histories: dict[str, list[FeatureRecord]] = {}
+
+    for ticker in tickers:
+        feat_records = []
+        label_records = []
+        for d in trading_dates:
+            features = {
+                "momentum_1m": rng.uniform(-0.05, 0.05),
+                "volume_ratio": rng.uniform(0.5, 2.0),
+            }
+            feat_records.append(FeatureRecord(date=d, ticker=ticker, features=features))
+
+            label_features = {
+                "forward_return_5d": daily_return + rng.uniform(-0.01, 0.01),
+                "survives_to_t5": 1,
+            }
+            label_records.append(FeatureRecord(date=d, ticker=ticker, features=label_features))
+
+        feature_histories[ticker] = feat_records
+        label_histories[ticker] = label_records
+
+    return feature_histories, label_histories, trading_dates
+
+
+class TestBacktestEngine:
+    def _engine(self, **kwargs: object) -> BacktestEngine:
+        config = BacktestConfig(**kwargs)
+        return BacktestEngine(config, ranker_factory=_MockRanker)
+
+    def test_run_returns_backtest_result(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=8, n_dates=80)
+        engine = self._engine(train_days=40, test_days=20, top_n=3, min_train_samples=10)
+        result = engine.run(features, labels, trading_dates=dates)
+        assert isinstance(result, BacktestResult)
+
+    def test_result_has_folds(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=8, n_dates=80)
+        engine = self._engine(train_days=40, test_days=20, top_n=3, min_train_samples=10)
+        result = engine.run(features, labels, trading_dates=dates)
+        assert result.n_folds > 0
+        assert len(result.folds) == result.n_folds
+
+    def test_all_returns_match_folds(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=8, n_dates=80)
+        engine = self._engine(train_days=40, test_days=20, top_n=3, min_train_samples=10)
+        result = engine.run(features, labels, trading_dates=dates)
+        fold_total = sum(len(f.daily_returns) for f in result.folds)
+        assert len(result.all_returns) == fold_total
+
+    def test_metrics_are_finite(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=8, n_dates=80)
+        engine = self._engine(train_days=40, test_days=20, top_n=3, min_train_samples=10)
+        result = engine.run(features, labels, trading_dates=dates)
+        if result.all_returns:
+            assert math.isfinite(result.sharpe_ratio)
+            assert math.isfinite(result.max_drawdown)
+            assert math.isfinite(result.annual_return)
+            assert 0.0 <= result.hit_rate <= 1.0
+            assert 0.0 <= result.max_drawdown <= 1.0
+
+    def test_empty_trading_dates_returns_empty_result(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=4, n_dates=20)
+        engine = self._engine(train_days=40, test_days=20, top_n=3, min_train_samples=5)
+        result = engine.run(features, labels, trading_dates=[])
+        assert result.n_folds == 0
+        assert result.all_returns == []
+
+    def test_insufficient_dates_produces_no_folds(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=4, n_dates=10)
+        engine = self._engine(train_days=50, test_days=20, top_n=3, min_train_samples=5)
+        result = engine.run(features, labels, trading_dates=dates)
+        assert result.n_folds == 0
+
+    def test_fold_dates_are_non_overlapping(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=8, n_dates=120)
+        engine = self._engine(train_days=40, test_days=30, top_n=3, min_train_samples=10)
+        result = engine.run(features, labels, trading_dates=dates)
+        test_ranges = [(f.test_start, f.test_end) for f in result.folds]
+        for i in range(len(test_ranges) - 1):
+            assert test_ranges[i][1] < test_ranges[i + 1][0]
+
+    def test_top_n_limits_portfolio_size(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=20, n_dates=80)
+        top_n = 5
+        engine = self._engine(train_days=40, test_days=20, top_n=top_n, min_train_samples=10)
+        result = engine.run(features, labels, trading_dates=dates)
+        # Result should complete without error; portfolio is bounded internally
+        assert isinstance(result, BacktestResult)
+
+    def test_fold_hit_rate_between_zero_and_one(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=8, n_dates=80)
+        engine = self._engine(train_days=40, test_days=20, top_n=3, min_train_samples=10)
+        result = engine.run(features, labels, trading_dates=dates)
+        for fold in result.folds:
+            assert 0.0 <= fold.hit_rate <= 1.0
+
+    def test_fold_ic_within_bounds(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=8, n_dates=80)
+        engine = self._engine(train_days=40, test_days=20, top_n=3, min_train_samples=10)
+        result = engine.run(features, labels, trading_dates=dates)
+        for fold in result.folds:
+            assert -1.0 - 1e-9 <= fold.ic <= 1.0 + 1e-9
+
+    def test_skips_fold_when_insufficient_train_samples(self) -> None:
+        features, labels, dates = _make_histories(n_tickers=2, n_dates=80)
+        engine = self._engine(
+            train_days=40, test_days=20, top_n=3, min_train_samples=10_000
+        )
+        result = engine.run(features, labels, trading_dates=dates)
+        # All folds should be skipped due to min_train_samples threshold
+        assert result.n_folds == 0

--- a/tests/unit/test_risk_engine.py
+++ b/tests/unit/test_risk_engine.py
@@ -1,0 +1,233 @@
+"""Unit tests for the Layer 4 risk engine."""
+from __future__ import annotations
+
+from core.contracts.schemas import ActionType, ApprovedOrderRecord, PortfolioRecord
+from core.risk.engine import RiskConfig, RiskEngine
+from core.risk.rules import check_adv_cap, check_max_position, check_min_position
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _proposal(
+    ticker: str,
+    *,
+    target_dollars: float,
+    current_dollars: float = 0.0,
+    date: str = "2025-01-10",
+    weight: float | None = None,
+) -> PortfolioRecord:
+    change = target_dollars - current_dollars
+    if weight is None:
+        weight = target_dollars / 100_000.0
+    return PortfolioRecord(
+        date=date,
+        ticker=ticker,
+        weight=weight,
+        target_dollars=target_dollars,
+        current_dollars=current_dollars,
+        change_dollars=change,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Rule-level unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestCheckMaxPosition:
+    def test_passes_within_limit(self) -> None:
+        p = _proposal("AAPL", target_dollars=5_000.0)
+        assert check_max_position(p, equity=100_000.0, max_position_pct=0.10) is None
+
+    def test_fires_at_limit_breach(self) -> None:
+        p = _proposal("AAPL", target_dollars=11_000.0)
+        assert check_max_position(p, equity=100_000.0, max_position_pct=0.10) == "max_position_pct"
+
+    def test_fires_on_zero_equity(self) -> None:
+        p = _proposal("AAPL", target_dollars=1.0)
+        assert check_max_position(p, equity=0.0, max_position_pct=0.10) == "no_equity"
+
+    def test_uses_absolute_value(self) -> None:
+        p = _proposal("AAPL", target_dollars=-15_000.0)
+        assert check_max_position(p, equity=100_000.0, max_position_pct=0.10) == "max_position_pct"
+
+
+class TestCheckMinPosition:
+    def test_passes_when_above_minimum(self) -> None:
+        p = _proposal("AAPL", target_dollars=500.0)
+        assert check_min_position(p, min_position_dollars=100.0) is None
+
+    def test_fires_when_below_minimum(self) -> None:
+        p = _proposal("AAPL", target_dollars=50.0)
+        assert check_min_position(p, min_position_dollars=100.0) == "min_position_dollars"
+
+    def test_passes_when_zero_target(self) -> None:
+        p = _proposal("AAPL", target_dollars=0.0)
+        assert check_min_position(p, min_position_dollars=100.0) is None
+
+    def test_passes_exactly_at_minimum(self) -> None:
+        p = _proposal("AAPL", target_dollars=100.0)
+        assert check_min_position(p, min_position_dollars=100.0) is None
+
+
+class TestCheckAdvCap:
+    def test_passes_within_adv(self) -> None:
+        p = _proposal("AAPL", target_dollars=100.0, current_dollars=0.0)
+        assert check_adv_cap(p, adv_dollars=100_000.0, max_adv_participation=0.01) is None
+
+    def test_fires_when_over_adv(self) -> None:
+        p = _proposal("AAPL", target_dollars=2_000.0, current_dollars=0.0)
+        assert (
+            check_adv_cap(p, adv_dollars=100_000.0, max_adv_participation=0.01)
+            == "adv_participation_cap"
+        )
+
+    def test_passes_when_adv_zero(self) -> None:
+        p = _proposal("AAPL", target_dollars=1_000.0)
+        assert check_adv_cap(p, adv_dollars=0.0, max_adv_participation=0.01) is None
+
+    def test_uses_change_dollars_not_target(self) -> None:
+        # change = 500 - 400 = 100; 100 / 100_000 = 0.001 < 0.01 → pass
+        p = _proposal("AAPL", target_dollars=500.0, current_dollars=400.0)
+        assert check_adv_cap(p, adv_dollars=100_000.0, max_adv_participation=0.01) is None
+
+
+# ---------------------------------------------------------------------------
+# RiskEngine integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestRiskEngine:
+    def _engine(self, **kwargs: object) -> RiskEngine:
+        return RiskEngine(RiskConfig(**kwargs))
+
+    def test_approves_clean_proposals(self) -> None:
+        engine = self._engine()
+        proposals = [
+            _proposal("AAPL", target_dollars=5_000.0),
+            _proposal("MSFT", target_dollars=4_000.0),
+        ]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert all(r.approved for r in results)
+
+    def test_rejects_oversized_position(self) -> None:
+        engine = self._engine(max_position_pct=0.05)
+        proposals = [_proposal("AAPL", target_dollars=10_000.0)]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert results[0].approved is False
+        assert "max_position_pct" in results[0].rules_triggered
+
+    def test_rejects_below_minimum_size(self) -> None:
+        engine = self._engine(min_position_dollars=200.0)
+        proposals = [_proposal("AAPL", target_dollars=50.0)]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert results[0].approved is False
+        assert "min_position_dollars" in results[0].rules_triggered
+
+    def test_rejects_adv_breach(self) -> None:
+        engine = self._engine(max_adv_participation=0.01)
+        proposals = [_proposal("TINY", target_dollars=2_000.0)]
+        results = engine.apply(
+            proposals,
+            equity=100_000.0,
+            adv_map={"TINY": 10_000.0},  # 2000 / 10000 = 20% > 1%
+        )
+        assert results[0].approved is False
+        assert "adv_participation_cap" in results[0].rules_triggered
+
+    def test_rejects_gross_exposure_overflow(self) -> None:
+        # Raise max_position_pct so both proposals survive per-proposal checks;
+        # combined 60k + 50k = 110k on 100k equity exceeds the 100% gross limit.
+        engine = self._engine(max_gross_exposure=1.0, max_position_pct=0.70)
+        proposals = [
+            _proposal("AAPL", target_dollars=60_000.0),
+            _proposal("MSFT", target_dollars=50_000.0),
+        ]
+        results = engine.apply(proposals, equity=100_000.0)
+        approved = [r for r in results if r.approved]
+        rejected = [r for r in results if not r.approved]
+        assert len(approved) == 1
+        assert len(rejected) == 1
+        assert "max_gross_exposure" in rejected[0].rules_triggered
+
+    def test_rejects_sector_concentration(self) -> None:
+        engine = self._engine(max_sector_pct=0.25, max_position_pct=1.0)
+        proposals = [
+            _proposal("AAPL", target_dollars=20_000.0),
+            _proposal("MSFT", target_dollars=20_000.0),
+        ]
+        sector_map = {"AAPL": "Technology", "MSFT": "Technology"}
+        results = engine.apply(proposals, equity=100_000.0, sector_map=sector_map)
+        approved = [r for r in results if r.approved]
+        rejected = [r for r in results if not r.approved]
+        assert len(approved) == 1
+        assert len(rejected) == 1
+        assert "max_sector_pct" in rejected[0].rules_triggered
+
+    def test_output_preserves_input_order(self) -> None:
+        engine = self._engine()
+        tickers = ["Z", "A", "M", "B"]
+        proposals = [_proposal(t, target_dollars=1_000.0) for t in tickers]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert [r.ticker for r in results] == tickers
+
+    def test_buy_action_on_increase(self) -> None:
+        engine = self._engine()
+        proposals = [_proposal("AAPL", target_dollars=5_000.0, current_dollars=1_000.0)]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert results[0].action == ActionType.BUY
+
+    def test_sell_action_on_decrease(self) -> None:
+        engine = self._engine()
+        proposals = [_proposal("AAPL", target_dollars=1_000.0, current_dollars=5_000.0)]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert results[0].action == ActionType.SELL
+
+    def test_hold_action_when_no_change(self) -> None:
+        engine = self._engine()
+        proposals = [_proposal("AAPL", target_dollars=5_000.0, current_dollars=5_000.0)]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert results[0].action == ActionType.HOLD
+
+    def test_rejected_action_is_reject(self) -> None:
+        engine = self._engine(max_position_pct=0.01)
+        proposals = [_proposal("AAPL", target_dollars=5_000.0)]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert results[0].action == ActionType.REJECT
+
+    def test_empty_proposals_returns_empty(self) -> None:
+        engine = self._engine()
+        assert engine.apply([], equity=100_000.0) == []
+
+    def test_missing_sector_map_skips_sector_rule(self) -> None:
+        engine = self._engine(max_sector_pct=0.01)
+        proposals = [
+            _proposal("AAPL", target_dollars=5_000.0),
+            _proposal("MSFT", target_dollars=5_000.0),
+        ]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert all(r.approved for r in results)
+
+    def test_multiple_rules_can_fire_on_same_proposal(self) -> None:
+        engine = self._engine(max_position_pct=0.01, min_position_dollars=10_000.0)
+        proposals = [_proposal("AAPL", target_dollars=5_000.0)]
+        results = engine.apply(proposals, equity=100_000.0)
+        assert not results[0].approved
+        assert len(results[0].rules_triggered) >= 1
+
+    def test_all_proposals_rejected_on_no_equity(self) -> None:
+        engine = self._engine()
+        proposals = [_proposal("AAPL", target_dollars=1_000.0)]
+        results = engine.apply(proposals, equity=0.0)
+        assert not results[0].approved
+
+    def test_approved_order_record_is_valid_schema(self) -> None:
+        engine = self._engine()
+        proposals = [_proposal("AAPL", target_dollars=1_000.0)]
+        results = engine.apply(proposals, equity=100_000.0)
+        record = results[0]
+        assert isinstance(record, ApprovedOrderRecord)
+        assert record.ticker == "AAPL"
+        assert isinstance(record.rules_triggered, list)

--- a/tests/unit/test_xgboost_ranker.py
+++ b/tests/unit/test_xgboost_ranker.py
@@ -1,0 +1,289 @@
+"""Unit tests for the XGBoostRanker (Layer 2 model).
+
+Tests that require xgboost are skipped automatically when the package is
+not installed (e.g. in lightweight CI environments using only base deps).
+"""
+from __future__ import annotations
+
+import pytest
+
+from core.contracts.schemas import FeatureRecord, ScoreRecord
+from core.models.xgboost_ranker import (
+    _LABEL_COLUMNS as LABEL_FEATURE_COLUMNS,  # noqa: F401
+)
+from core.models.xgboost_ranker import (
+    XGBoostRanker,
+    XGBoostRankerConfig,
+    _build_training_arrays,
+    _compute_version,
+    _extract_regime,
+    _rank_array,
+    _safe_float,
+)
+
+xgb = pytest.importorskip("xgboost", reason="xgboost not installed")
+pytest.importorskip("sklearn", reason="scikit-learn not installed")
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_feature_record(
+    date: str,
+    ticker: str,
+    *,
+    momentum: float = 0.01,
+    sentiment: float = 0.5,
+    regime: str | None = None,
+) -> FeatureRecord:
+    features: dict[str, object] = {
+        "momentum_1m": momentum,
+        "sentiment_score": sentiment,
+        "volume_ratio": 1.2,
+    }
+    if regime is not None:
+        features["regime_label"] = regime
+        features["regime_prob_bull"] = 0.7
+    return FeatureRecord(date=date, ticker=ticker, features=features)
+
+
+def _make_label_record(date: str, ticker: str, forward_return: float | None) -> FeatureRecord:
+    features: dict[str, object] = {
+        "forward_return_1d": forward_return,
+        "forward_return_5d": forward_return,
+        "forward_return_20d": forward_return,
+        "forward_log_return_1d": None,
+        "forward_log_return_5d": None,
+        "forward_log_return_20d": None,
+        "survives_to_t1": 1,
+        "survives_to_t5": 1,
+        "survives_to_t20": 1,
+    }
+    return FeatureRecord(date=date, ticker=ticker, features=features)
+
+
+def _make_training_pair(
+    n_dates: int = 30,
+    n_tickers: int = 10,
+) -> tuple[list[FeatureRecord], list[FeatureRecord]]:
+    tickers = [f"TK{i:02d}" for i in range(n_tickers)]
+    dates = [f"2024-01-{d + 1:02d}" for d in range(min(n_dates, 28))]
+    import random
+
+    rng = random.Random(42)
+
+    features = []
+    labels = []
+    for date in dates:
+        for ticker in tickers:
+            momentum = rng.uniform(-0.05, 0.05)
+            sentiment = rng.uniform(0.0, 1.0)
+            fwd_return = momentum + rng.uniform(-0.02, 0.02)
+            features.append(_make_feature_record(date, ticker, momentum=momentum, sentiment=sentiment))
+            labels.append(_make_label_record(date, ticker, fwd_return))
+    return features, labels
+
+
+# ---------------------------------------------------------------------------
+# Helper tests (no xgboost required — but xgboost is imported at module level)
+# ---------------------------------------------------------------------------
+
+
+def test_safe_float_handles_none_and_nan() -> None:
+    assert _safe_float(None) == 0.0
+    assert _safe_float(float("nan")) == 0.0
+    assert _safe_float(float("inf")) == 0.0
+    assert _safe_float(1.5) == 1.5
+    assert _safe_float(0) == 0.0
+
+
+def test_rank_array_ascending_order() -> None:
+
+    arr = [3.0, 1.0, 2.0]
+    ranks = _rank_array(arr)
+    # 1.0 → rank 0, 2.0 → rank 1, 3.0 → rank 2
+    assert list(ranks) == [2.0, 0.0, 1.0]
+
+
+def test_extract_regime_returns_label_or_none() -> None:
+    rec_with = _make_feature_record("2024-01-01", "AAPL", regime="bull")
+    rec_without = _make_feature_record("2024-01-01", "AAPL")
+    assert _extract_regime(rec_with) == "bull"
+    assert _extract_regime(rec_without) is None
+
+
+def test_build_training_arrays_excludes_label_columns() -> None:
+    feat_records, label_records = _make_training_pair(n_dates=5, n_tickers=3)
+    X, y, cols = _build_training_arrays(feat_records, label_records)
+    for label_col in LABEL_FEATURE_COLUMNS:
+        assert label_col not in cols, f"Label column {label_col!r} leaked into features"
+
+
+def test_build_training_arrays_returns_consistent_shapes() -> None:
+    feat_records, label_records = _make_training_pair(n_dates=5, n_tickers=4)
+    X, y, cols = _build_training_arrays(feat_records, label_records)
+    assert X.shape[0] == len(y)
+    assert X.shape[1] == len(cols)
+    assert len(cols) > 0
+
+
+def test_build_training_arrays_drops_missing_labels() -> None:
+    features = [_make_feature_record("2024-01-01", "AAPL")]
+    labels_with_none = [_make_label_record("2024-01-01", "AAPL", None)]
+    labels_valid = [_make_label_record("2024-01-01", "AAPL", 0.01)]
+
+    X_none, y_none, _ = _build_training_arrays(features, labels_with_none)
+    X_valid, y_valid, _ = _build_training_arrays(features, labels_valid)
+
+    assert len(y_none) == 0
+    assert len(y_valid) == 1
+
+
+def test_compute_version_is_deterministic() -> None:
+    config = XGBoostRankerConfig()
+    cols = ("a", "b", "c")
+    v1 = _compute_version(config=config, feature_columns=cols, train_start="2024-01-01", train_end="2024-06-30", n_samples=100)
+    v2 = _compute_version(config=config, feature_columns=cols, train_start="2024-01-01", train_end="2024-06-30", n_samples=100)
+    assert v1 == v2
+    assert v1.startswith("v1-")
+
+
+def test_compute_version_changes_with_config() -> None:
+    cols = ("a",)
+    v1 = _compute_version(config=XGBoostRankerConfig(n_estimators=100), feature_columns=cols, train_start="2024-01-01", train_end="2024-06-30", n_samples=50)
+    v2 = _compute_version(config=XGBoostRankerConfig(n_estimators=200), feature_columns=cols, train_start="2024-01-01", train_end="2024-06-30", n_samples=50)
+    assert v1 != v2
+
+
+# ---------------------------------------------------------------------------
+# XGBoostRanker tests
+# ---------------------------------------------------------------------------
+
+
+def test_ranker_not_fitted_by_default() -> None:
+    ranker = XGBoostRanker()
+    assert not ranker.is_fitted
+    assert ranker.model_version == ""
+    assert ranker.feature_columns == ()
+
+
+def test_ranker_fit_returns_self() -> None:
+    features, labels = _make_training_pair()
+    ranker = XGBoostRanker(XGBoostRankerConfig(n_estimators=10))
+    result = ranker.fit(features, labels)
+    assert result is ranker
+
+
+def test_ranker_fit_sets_is_fitted() -> None:
+    features, labels = _make_training_pair()
+    ranker = XGBoostRanker(XGBoostRankerConfig(n_estimators=10))
+    ranker.fit(features, labels)
+    assert ranker.is_fitted
+    assert ranker.model_version.startswith("v1-")
+    assert len(ranker.feature_columns) > 0
+
+
+def test_ranker_score_returns_score_records_for_date() -> None:
+    features, labels = _make_training_pair(n_dates=5, n_tickers=5)
+    ranker = XGBoostRanker(XGBoostRankerConfig(n_estimators=10))
+    ranker.fit(features, labels)
+
+    test_date = "2024-01-01"
+    test_features = [r for r in features if r.date == test_date]
+    scores = ranker.score(test_features, test_date)
+
+    assert len(scores) == len(test_features)
+    for score in scores:
+        assert isinstance(score, ScoreRecord)
+        assert score.date == test_date
+        assert 0.0 <= score.pos_prob <= 1.0
+        assert 0.0 <= score.rank_score <= 1.0
+        assert 0.0 <= score.confidence <= 1.0
+        assert score.model_version == ranker.model_version
+
+
+def test_ranker_score_returns_empty_for_unknown_date() -> None:
+    features, labels = _make_training_pair(n_dates=5, n_tickers=3)
+    ranker = XGBoostRanker(XGBoostRankerConfig(n_estimators=10))
+    ranker.fit(features, labels)
+    scores = ranker.score(features, "2099-12-31")
+    assert scores == []
+
+
+def test_ranker_score_rank_scores_span_zero_to_one() -> None:
+    features, labels = _make_training_pair(n_dates=3, n_tickers=6)
+    ranker = XGBoostRanker(XGBoostRankerConfig(n_estimators=10))
+    ranker.fit(features, labels)
+
+    test_date = "2024-01-01"
+    test_features = [r for r in features if r.date == test_date]
+    scores = ranker.score(test_features, test_date)
+    rank_vals = [s.rank_score for s in scores]
+
+    assert min(rank_vals) == pytest.approx(0.0, abs=1e-9)
+    assert max(rank_vals) == pytest.approx(1.0, abs=1e-9)
+
+
+def test_ranker_score_raises_when_not_fitted() -> None:
+    ranker = XGBoostRanker()
+    with pytest.raises(RuntimeError, match="fit"):
+        ranker.score([], "2024-01-01")
+
+
+def test_ranker_fit_raises_on_empty_overlap() -> None:
+    features = [_make_feature_record("2024-01-01", "AAPL")]
+    labels = [_make_label_record("2024-02-01", "AAPL", 0.01)]  # no date overlap
+    ranker = XGBoostRanker(XGBoostRankerConfig(n_estimators=10))
+    with pytest.raises(ValueError, match="No training samples"):
+        ranker.fit(features, labels)
+
+
+def test_ranker_serialization_round_trip() -> None:
+    features, labels = _make_training_pair(n_dates=5, n_tickers=4)
+    original = XGBoostRanker(XGBoostRankerConfig(n_estimators=10))
+    original.fit(features, labels)
+
+    payload = original.to_bytes()
+    restored = XGBoostRanker.from_bytes(payload)
+
+    assert restored.model_version == original.model_version
+    assert restored.feature_columns == original.feature_columns
+    assert restored.is_fitted
+
+    test_date = "2024-01-01"
+    test_features = [r for r in features if r.date == test_date]
+    scores_orig = original.score(test_features, test_date)
+    scores_rest = restored.score(test_features, test_date)
+
+    assert len(scores_orig) == len(scores_rest)
+    for s1, s2 in zip(scores_orig, scores_rest):
+        assert s1.ticker == s2.ticker
+        assert s1.return_score == pytest.approx(s2.return_score, abs=1e-6)
+
+
+def test_ranker_to_bytes_raises_when_not_fitted() -> None:
+    ranker = XGBoostRanker()
+    with pytest.raises(RuntimeError, match="unfitted"):
+        ranker.to_bytes()
+
+
+def test_ranker_from_bytes_raises_on_bad_schema() -> None:
+    import pickle
+
+    bad_bundle = {"schema": "unknown_v99", "xgb_model_bytes": b"", "feature_columns": []}
+    with pytest.raises(ValueError, match="schema"):
+        XGBoostRanker.from_bytes(pickle.dumps(bad_bundle))
+
+
+def test_ranker_excludes_string_features_from_matrix() -> None:
+    """Regime label (string) must not appear in feature columns."""
+    features = [_make_feature_record("2024-01-01", f"TK{i}", regime="bull") for i in range(5)]
+    labels = [_make_label_record("2024-01-01", f"TK{i}", 0.01 * i) for i in range(5)]
+    features += [_make_feature_record("2024-01-02", f"TK{i}", regime="bear") for i in range(5)]
+    labels += [_make_label_record("2024-01-02", f"TK{i}", -0.01 * i) for i in range(5)]
+
+    ranker = XGBoostRanker(XGBoostRankerConfig(n_estimators=10))
+    ranker.fit(features, labels)
+    assert "regime_label" not in ranker.feature_columns


### PR DESCRIPTION
What I added via this PR:
  1. Layer 2 — XGBoost Ranker (core/models/)

  XGBoostRanker trains on any window of FeatureRecord + label records and produces ScoreRecord output with four signals per ticker: return_score (raw regression), rank_score
  (cross-sectional rank ∈ [0,1]), pos_prob (logistic-calibrated probability of positive return), and confidence. Serializes to a portable byte bundle for R2 storage. New R2
  paths added: layer2_model_path() and layer2_model_manifest_path().

  2. Layer 4 — Risk Engine (core/risk/)

  RiskEngine applies hard rules in two passes: per-proposal first (position cap, minimum size, ADV participation limit), then portfolio-level (gross exposure, sector
  concentration). Proposals are sorted by size so the largest survive first when a limit is full. Returns ApprovedOrderRecord with BUY/SELL/HOLD/REJECT action and the list of
  rules that fired. Fully stateless — no ML.

  3. Backtesting Framework (core/backtesting/)

  BacktestEngine runs walk-forward cross-validation: train on N days, score out-of-sample for M days, slide, repeat. Refits the model fresh on each fold. Simulates an
  equal-weight top-N portfolio and realises PnL from the forward-return labels. metrics.py provides pure-Python Sharpe, max drawdown, annual return, hit rate, Spearman IC
  (with midrank tie-breaking), and one-way turnover — no pandas or numpy required, so they run anywhere.

  Next step: Layer 3 portfolio construction (PortfolioRecord generation from ScoreRecord), then wiring Layers 2→4→5 in app/pi/run_daily.py to replace the current stub logic