### PR TITLE
Add AAPL Layer 1 accuracy workflow

### DIFF
--- a/app/lab/data_pipelines/README.md
+++ b/app/lab/data_pipelines/README.md
@@ -19,6 +19,10 @@ This is where news, market, and context inputs are aligned into training-ready t
   GPU worker when the text/FinBERT branches need acceleration.
   The Pi daily runtime invokes the same module through `modal run` for single-date jobs after
   Layer 0 completes, while local/lab runs can use `python ... --from-date/--to-date`.
+- `run_aapl_layer1_accuracy.py` is the pre-backfill AAPL-only pilot workflow. With
+  `--run-layer1`, it narrows Layer 1 generation to `AAPL` and then writes a feature
+  accuracy/parameter-calibration report. Without `--run-layer1`, it audits existing AAPL
+  date-first shards. It is intentionally guarded against non-AAPL ticker scope.
 
 ## Modal entrypoints
 
@@ -31,6 +35,7 @@ python -m pip install -r requirements/modal.txt
 | Runner | Deploy command | Smoke run | Config owner | CPU / GPU expectation |
 |---|---|---|---|---|
 | Daily Layer 1 orchestrator | `modal deploy app/lab/data_pipelines/run_daily_layer1.py` | Pi/Hermes invokes this through `python -m modal run app/lab/data_pipelines/run_daily_layer1.py --run-id <run_id> --as-of-date <YYYY-MM-DD> --layer0-run-id <run_id>` after Layer 0 completes | `config/modal.json` | Cloud-only orchestration entrypoint for single-date Pi-triggered runs |
+| AAPL Layer 1 accuracy pilot | n/a | `python app/lab/data_pipelines/run_aapl_layer1_accuracy.py --run-id layer1-aapl-accuracy-<window>-v1 --from-date <from> --to-date <to> --layer0-run-id <run_id> --run-layer1` | `config/layer1_aapl_accuracy.json` | AAPL-only local/lab pilot; do not use for full-universe backfill |
 | News preprocessing | `modal deploy app/lab/data_pipelines/run_news_preprocessing.py` | `modal run app/lab/data_pipelines/run_news_preprocessing.py --run-id smoke-news --as-of-date 2024-01-02` | `config/news_preprocessing.json` | CPU only |
 | Text topics | `modal deploy app/lab/data_pipelines/run_text_topics.py` | `modal run app/lab/data_pipelines/run_text_topics.py --run-id smoke-topics --as-of-date 2024-01-02 --preprocessed-news-key features/2024-01-02/news_sentiment/smoke-news.parquet` | `config/text_models.json` | Cloud-only embeddings/topic modeling; CPU smoke path, GPU optional for larger historical batches |
 | FinBERT sentiment | `modal deploy app/lab/data_pipelines/run_finbert_sentiment.py` | `modal run app/lab/data_pipelines/run_finbert_sentiment.py --run-id smoke-finbert --as-of-date 2024-01-02 --preprocessed-news-key features/2024-01-02/news_sentiment/smoke-news.parquet` | `config/finbert_sentiment.json` | Cloud-only heavy NLP; CPU smoke path, GPU recommended when throughput matters |

--- a/app/lab/data_pipelines/run_aapl_layer1_accuracy.py
+++ b/app/lab/data_pipelines/run_aapl_layer1_accuracy.py
@@ -1,0 +1,161 @@
+"""AAPL-only Layer 1 feature generation and accuracy workflow."""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+from loguru import logger
+
+
+def _resolve_repo_root() -> Path:
+    """Return the repository root for local runs and Modal-mounted runs."""
+    env_root = os.getenv("AI_STOCK_TRADER_REPO_ROOT")
+    if env_root:
+        return Path(env_root).resolve()
+    resolved = Path(__file__).resolve()
+    return resolved.parents[3] if len(resolved.parents) > 3 else resolved.parent
+
+
+_REPO_ROOT = _resolve_repo_root()
+sys.path.insert(0, str(_REPO_ROOT))
+
+from app.lab.data_pipelines.run_daily_layer1 import (  # noqa: E402
+    Layer1DailyConfig,
+    Layer1ValidationError,
+    run_daily_layer1,
+)
+from core.features.aapl_accuracy import (  # noqa: E402
+    DEFAULT_AAPL_ACCURACY_CONFIG_PATH,
+    DEFAULT_AAPL_ACCURACY_OUTPUT_DIR,
+    AAPLFeatureAccuracyConfig,
+    build_aapl_feature_accuracy_report,
+    load_aapl_feature_accuracy_config,
+    write_aapl_feature_accuracy_report,
+)
+from services.r2.writer import R2Writer  # noqa: E402
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments for the AAPL-only Layer 1 accuracy workflow."""
+    parser = argparse.ArgumentParser(
+        description="Run or audit the AAPL-only Layer 1 feature accuracy pilot."
+    )
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--ticker", default="AAPL")
+    parser.add_argument("--from-date", required=True, metavar="YYYY-MM-DD")
+    parser.add_argument("--to-date", required=True, metavar="YYYY-MM-DD")
+    parser.add_argument("--layer0-run-id", default=None)
+    parser.add_argument("--layer1-run-id", default=None)
+    parser.add_argument("--benchmark-ticker", default=None)
+    parser.add_argument("--config-path", type=Path, default=DEFAULT_AAPL_ACCURACY_CONFIG_PATH)
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_AAPL_ACCURACY_OUTPUT_DIR)
+    parser.add_argument(
+        "--run-layer1",
+        action="store_true",
+        help="First run Layer 1 generation narrowed to AAPL before writing diagnostics.",
+    )
+    parser.add_argument(
+        "--allow-layer0-manifest-date-range",
+        action="store_true",
+        help="Allow a completed Layer 0 manifest whose date window contains this pilot window.",
+    )
+    parser.add_argument("--min-sentence-chars", type=int, default=2)
+    parser.add_argument("--hmm-train-start-date", default=None, metavar="YYYY-MM-DD")
+    parser.add_argument("--hmm-max-iterations", type=int, default=100)
+    parser.add_argument("--hmm-min-training-rows", type=int, default=30)
+    args = parser.parse_args(argv)
+    if str(args.ticker).strip().upper() != "AAPL":
+        parser.error("This workflow is intentionally limited to --ticker AAPL")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the AAPL-only Layer 1 pilot and write the accuracy report."""
+    args = parse_args(argv)
+    writer = R2Writer()
+    config = load_aapl_feature_accuracy_config(args.config_path)
+    benchmark_ticker = (
+        str(args.benchmark_ticker).strip().upper()
+        if args.benchmark_ticker is not None
+        else config.benchmark_ticker
+    )
+    config = AAPLFeatureAccuracyConfig(
+        ticker=config.ticker,
+        benchmark_ticker=benchmark_ticker,
+        target_horizon_days=config.target_horizon_days,
+        quality_thresholds=config.quality_thresholds,
+        market_parameter_candidates=config.market_parameter_candidates,
+    )
+    if args.run_layer1:
+        try:
+            result = run_daily_layer1(
+                Layer1DailyConfig(
+                    run_id=str(args.run_id).strip(),
+                    from_date=str(args.from_date).strip(),
+                    to_date=str(args.to_date).strip(),
+                    layer0_run_id=(
+                        str(args.layer0_run_id).strip()
+                        if args.layer0_run_id is not None
+                        else None
+                    ),
+                    tickers=("AAPL",),
+                    benchmark_ticker=benchmark_ticker,
+                    allow_layer0_manifest_date_range=bool(
+                        args.allow_layer0_manifest_date_range
+                    ),
+                    min_sentence_chars=int(args.min_sentence_chars),
+                    hmm_train_start_date=(
+                        str(args.hmm_train_start_date).strip()
+                        if args.hmm_train_start_date is not None
+                        else None
+                    ),
+                    hmm_max_iterations=int(args.hmm_max_iterations),
+                    hmm_min_training_rows=int(args.hmm_min_training_rows),
+                ),
+                writer=writer,
+            )
+        except Layer1ValidationError as exc:
+            logger.error("AAPL Layer 1 pilot validation failed: {}", exc)
+            return 1
+        except Exception as exc:  # noqa: BLE001
+            logger.error("AAPL Layer 1 pilot failed: {}", exc)
+            return 1
+        logger.info(
+            "AAPL Layer 1 pilot generated manifest={} report={}",
+            result.manifest_key,
+            result.validation_report_key,
+        )
+
+    report = build_aapl_feature_accuracy_report(
+        run_id=str(args.run_id).strip(),
+        from_date=str(args.from_date).strip(),
+        to_date=str(args.to_date).strip(),
+        layer1_run_id=(
+            str(args.layer1_run_id).strip()
+            if args.layer1_run_id is not None
+            else str(args.run_id).strip()
+        ),
+        layer0_run_id=(
+            str(args.layer0_run_id).strip() if args.layer0_run_id is not None else None
+        ),
+        config=config,
+        writer=writer,
+    )
+    local_report_path = write_aapl_feature_accuracy_report(
+        report,
+        output_dir=args.output_dir,
+    )
+    logger.info("AAPL accuracy report written locally: {}", local_report_path)
+    logger.info("AAPL accuracy report written to object store: {}", report.report_key)
+    logger.info(
+        "Recommendation for #202: {}",
+        report.recommendation_for_issue_202,
+    )
+    return 0 if report.acceptance.get("accepted") is True else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/config/README.md
+++ b/config/README.md
@@ -56,4 +56,7 @@ Use an R2 token/access key with read/write access to the bucket. Do not use the 
 - `config/modal.json` controls the Pi-triggered Layer 1 orchestration apps, including the
   dedicated multi-date readiness timeout and the optional `T4` GPU cap for the batched
   Layer 1 runner.
+- `config/layer1_aapl_accuracy.json` controls the AAPL-only Layer 1 accuracy pilot
+  thresholds, target forward-return horizon, and market parameter candidates used before
+  deciding whether to start the broad historical backfill.
 - `config/requirements/` is deprecated; dependency files live under repository-root `requirements/`.

--- a/config/layer1_aapl_accuracy.json
+++ b/config/layer1_aapl_accuracy.json
@@ -1,0 +1,31 @@
+{
+  "ticker": "AAPL",
+  "benchmark_ticker": "SPY",
+  "target_horizon_days": 5,
+  "quality_thresholds": {
+    "min_feature_rows": 1,
+    "max_required_feature_null_rate": 0.35,
+    "min_label_pairs": 3,
+    "min_abs_best_candidate_correlation": 0.0
+  },
+  "market_parameter_candidates": [
+    {
+      "name": "short_momentum",
+      "return_window_days": 5,
+      "volatility_window_days": 5,
+      "volume_window_days": 10
+    },
+    {
+      "name": "baseline_momentum",
+      "return_window_days": 21,
+      "volatility_window_days": 21,
+      "volume_window_days": 20
+    },
+    {
+      "name": "intermediate_momentum",
+      "return_window_days": 63,
+      "volatility_window_days": 21,
+      "volume_window_days": 20
+    }
+  ]
+}

--- a/core/features/aapl_accuracy.py
+++ b/core/features/aapl_accuracy.py
@@ -1,0 +1,590 @@
+"""AAPL-only Layer 1 feature accuracy and parameter calibration helpers."""
+from __future__ import annotations
+
+import importlib
+import io
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from datetime import date as Date
+from pathlib import Path
+from typing import Any, Protocol
+
+from core.contracts.schemas import FeatureRecord, PipelineManifestRecord
+from core.features.catalog import feature_catalog, feature_family_map, validate_feature_value
+from core.features.io import parquet_bytes_to_feature_record
+from core.labels.forward_returns import compute_forward_return_labels
+from services.r2.paths import (
+    layer1_aapl_accuracy_report_path,
+    layer1_feature_path,
+    pipeline_manifest_path,
+    raw_price_path,
+    raw_universe_path,
+)
+from services.r2.writer import R2Writer
+
+DEFAULT_AAPL_ACCURACY_CONFIG_PATH = Path("config/layer1_aapl_accuracy.json")
+DEFAULT_AAPL_ACCURACY_OUTPUT_DIR = Path("artifacts/reports/diagnostics")
+
+
+class AAPLAccuracyReader(Protocol):
+    """Object-store operations required by the AAPL accuracy workflow."""
+
+    def exists(self, key: str) -> bool:
+        """Return True when the object exists."""
+
+    def get_object(self, key: str) -> bytes:
+        """Read an object payload by key."""
+
+    def put_object(self, key: str, data: bytes | str) -> None:
+        """Persist an object payload by key."""
+
+
+@dataclass(frozen=True)
+class AAPLQualityThresholds:
+    """Acceptance thresholds for one AAPL Layer 1 accuracy report."""
+
+    min_feature_rows: int = 1
+    max_required_feature_null_rate: float = 0.35
+    min_label_pairs: int = 3
+    min_abs_best_candidate_correlation: float = 0.0
+
+    def __post_init__(self) -> None:
+        """Validate threshold ranges."""
+        if self.min_feature_rows < 1:
+            raise ValueError("min_feature_rows must be at least 1")
+        if not 0.0 <= self.max_required_feature_null_rate <= 1.0:
+            raise ValueError("max_required_feature_null_rate must be in [0.0, 1.0]")
+        if self.min_label_pairs < 1:
+            raise ValueError("min_label_pairs must be at least 1")
+        if self.min_abs_best_candidate_correlation < 0.0:
+            raise ValueError("min_abs_best_candidate_correlation must be non-negative")
+
+
+@dataclass(frozen=True)
+class MarketParameterCandidate:
+    """Configurable candidate parameters for AAPL market-feature calibration."""
+
+    name: str
+    return_window_days: int
+    volatility_window_days: int
+    volume_window_days: int
+
+    def __post_init__(self) -> None:
+        """Validate candidate name and positive windows."""
+        if not self.name.strip():
+            raise ValueError("market parameter candidate name cannot be empty")
+        for field_name, value in (
+            ("return_window_days", self.return_window_days),
+            ("volatility_window_days", self.volatility_window_days),
+            ("volume_window_days", self.volume_window_days),
+        ):
+            if value <= 0:
+                raise ValueError(f"{field_name} must be positive")
+
+
+@dataclass(frozen=True)
+class AAPLFeatureAccuracyConfig:
+    """Configuration for one AAPL-only Layer 1 accuracy and calibration run."""
+
+    ticker: str = "AAPL"
+    benchmark_ticker: str = "SPY"
+    target_horizon_days: int = 5
+    quality_thresholds: AAPLQualityThresholds = field(default_factory=AAPLQualityThresholds)
+    market_parameter_candidates: tuple[MarketParameterCandidate, ...] = (
+        MarketParameterCandidate(
+            name="baseline_momentum",
+            return_window_days=21,
+            volatility_window_days=21,
+            volume_window_days=20,
+        ),
+    )
+
+    def __post_init__(self) -> None:
+        """Validate the fixed AAPL pilot scope and label horizon."""
+        if self.ticker.strip().upper() != "AAPL":
+            raise ValueError("AAPL accuracy workflow is intentionally limited to ticker=AAPL")
+        if not self.benchmark_ticker.strip():
+            raise ValueError("benchmark_ticker cannot be empty")
+        if self.target_horizon_days <= 0:
+            raise ValueError("target_horizon_days must be positive")
+        if not self.market_parameter_candidates:
+            raise ValueError("market_parameter_candidates must not be empty")
+
+
+@dataclass(frozen=True)
+class AAPLFeatureAccuracyReport:
+    """Durable report for the AAPL-only Layer 1 feature accuracy pilot."""
+
+    run_id: str
+    layer1_run_id: str
+    layer0_run_id: str | None
+    ticker: str
+    benchmark_ticker: str
+    from_date: str
+    to_date: str
+    generated_at: str
+    report_key: str
+    input_evidence: dict[str, object]
+    output_paths: dict[str, object]
+    parameter_config: dict[str, object]
+    feature_quality: dict[str, object]
+    catalog_failures: list[dict[str, object]]
+    optimization_results: list[dict[str, object]]
+    best_parameter_candidate: dict[str, object] | None
+    acceptance: dict[str, object]
+    recommendation_for_issue_202: str
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable report payload."""
+        return asdict(self)
+
+
+def load_aapl_feature_accuracy_config(
+    path: Path = DEFAULT_AAPL_ACCURACY_CONFIG_PATH,
+) -> AAPLFeatureAccuracyConfig:
+    """Load the AAPL feature-accuracy configuration from JSON."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    thresholds = AAPLQualityThresholds(**dict(payload.get("quality_thresholds", {})))
+    candidates = tuple(
+        MarketParameterCandidate(**dict(candidate))
+        for candidate in payload.get("market_parameter_candidates", [])
+    )
+    return AAPLFeatureAccuracyConfig(
+        ticker=str(payload.get("ticker", "AAPL")).strip().upper(),
+        benchmark_ticker=str(payload.get("benchmark_ticker", "SPY")).strip().upper(),
+        target_horizon_days=int(payload.get("target_horizon_days", 5)),
+        quality_thresholds=thresholds,
+        market_parameter_candidates=candidates,
+    )
+
+
+def build_aapl_feature_accuracy_report(
+    *,
+    run_id: str,
+    from_date: str,
+    to_date: str,
+    layer1_run_id: str | None = None,
+    layer0_run_id: str | None = None,
+    config: AAPLFeatureAccuracyConfig | None = None,
+    writer: AAPLAccuracyReader | None = None,
+    now: datetime | None = None,
+) -> AAPLFeatureAccuracyReport:
+    """Build and upload the AAPL-only Layer 1 feature accuracy report."""
+    _validate_iso_date(from_date, "from_date")
+    _validate_iso_date(to_date, "to_date")
+    if from_date > to_date:
+        raise ValueError("from_date must be <= to_date")
+    if not run_id.strip():
+        raise ValueError("run_id cannot be empty")
+
+    active_config = config or load_aapl_feature_accuracy_config()
+    active_writer = writer or R2Writer()
+    active_layer1_run_id = layer1_run_id or run_id
+    ticker = active_config.ticker.strip().upper()
+    dates = _business_dates(from_date, to_date)
+    feature_records, missing_feature_keys = _load_aapl_date_first_features(
+        writer=active_writer,
+        dates=dates,
+        ticker=ticker,
+    )
+    price_key = raw_price_path(ticker)
+    price_frame = _read_parquet_frame(active_writer.get_object(price_key))
+    feature_quality, catalog_failures = _summarize_feature_quality(feature_records)
+    optimization_results = _evaluate_market_parameter_candidates(
+        price_frame=price_frame,
+        feature_dates=[record.date for record in feature_records],
+        ticker=ticker,
+        horizon_days=active_config.target_horizon_days,
+        candidates=active_config.market_parameter_candidates,
+    )
+    best_candidate = _best_candidate(optimization_results)
+    report_key = layer1_aapl_accuracy_report_path(run_id, from_date, to_date)
+    layer1_manifest_key = pipeline_manifest_path("layer1", active_layer1_run_id)
+    layer0_manifest_key = (
+        pipeline_manifest_path("layer0", layer0_run_id) if layer0_run_id is not None else None
+    )
+    input_evidence = {
+        "layer0_manifest_key": layer0_manifest_key,
+        "layer0_manifest_status": _manifest_status(active_writer, layer0_manifest_key),
+        "layer1_manifest_key": layer1_manifest_key,
+        "layer1_manifest_status": _manifest_status(active_writer, layer1_manifest_key),
+        "raw_price_key": price_key,
+        "raw_price_rows": int(len(price_frame)),
+        "universe_keys": [raw_universe_path(date_text) for date_text in dates],
+    }
+    output_paths = {
+        "report_key": report_key,
+        "feature_output_key_examples": [
+            layer1_feature_path(record.date, record.ticker) for record in feature_records[:5]
+        ],
+        "missing_feature_keys": missing_feature_keys,
+        "r2_output_prefixes": {
+            "date_first_features": "features/{YYYY-MM-DD}/AAPL.parquet",
+            "diagnostic_reports": "artifacts/reports/diagnostics/",
+        },
+    }
+    acceptance = _build_acceptance(
+        feature_rows=len(feature_records),
+        missing_feature_keys=missing_feature_keys,
+        feature_quality=feature_quality,
+        catalog_failures=catalog_failures,
+        best_candidate=best_candidate,
+        thresholds=active_config.quality_thresholds,
+    )
+    recommendation = _recommend_issue_202(acceptance)
+    report = AAPLFeatureAccuracyReport(
+        run_id=run_id,
+        layer1_run_id=active_layer1_run_id,
+        layer0_run_id=layer0_run_id,
+        ticker=ticker,
+        benchmark_ticker=active_config.benchmark_ticker.strip().upper(),
+        from_date=from_date,
+        to_date=to_date,
+        generated_at=(now or datetime.now(UTC)).replace(microsecond=0).isoformat(),
+        report_key=report_key,
+        input_evidence=input_evidence,
+        output_paths=output_paths,
+        parameter_config=_config_to_dict(active_config),
+        feature_quality=feature_quality,
+        catalog_failures=catalog_failures,
+        optimization_results=optimization_results,
+        best_parameter_candidate=best_candidate,
+        acceptance=acceptance,
+        recommendation_for_issue_202=recommendation,
+    )
+    active_writer.put_object(report_key, render_aapl_feature_accuracy_report(report))
+    return report
+
+
+def write_aapl_feature_accuracy_report(
+    report: AAPLFeatureAccuracyReport,
+    *,
+    output_dir: Path | None = None,
+) -> Path:
+    """Write the AAPL feature accuracy report to a local JSON file."""
+    target_dir = output_dir or DEFAULT_AAPL_ACCURACY_OUTPUT_DIR
+    target_dir.mkdir(parents=True, exist_ok=True)
+    path = target_dir / aapl_feature_accuracy_report_filename(report)
+    path.write_text(render_aapl_feature_accuracy_report(report), encoding="utf-8")
+    return path
+
+
+def aapl_feature_accuracy_report_filename(report: AAPLFeatureAccuracyReport) -> str:
+    """Return the deterministic local JSON filename for one AAPL accuracy report."""
+    return (
+        f"layer1_aapl_feature_accuracy_{report.run_id}_{report.from_date}"
+        f"_to_{report.to_date}.json"
+    )
+
+
+def render_aapl_feature_accuracy_report(report: AAPLFeatureAccuracyReport) -> str:
+    """Render the AAPL feature accuracy report as deterministic JSON."""
+    return json.dumps(report.to_dict(), indent=2, sort_keys=True)
+
+
+def _load_aapl_date_first_features(
+    *,
+    writer: AAPLAccuracyReader,
+    dates: Sequence[str],
+    ticker: str,
+) -> tuple[list[FeatureRecord], list[str]]:
+    records: list[FeatureRecord] = []
+    missing_keys: list[str] = []
+    for date_text in dates:
+        key = layer1_feature_path(date_text, ticker)
+        if not writer.exists(key):
+            missing_keys.append(key)
+            continue
+        record = parquet_bytes_to_feature_record(writer.get_object(key))
+        if record.date != date_text or record.ticker != ticker:
+            raise ValueError(
+                "AAPL feature shard identity mismatch: "
+                f"key={key} actual={record.date}/{record.ticker}"
+            )
+        records.append(record)
+    return records, missing_keys
+
+
+def _summarize_feature_quality(
+    records: Sequence[FeatureRecord],
+) -> tuple[dict[str, object], list[dict[str, object]]]:
+    catalog = feature_catalog()
+    families = feature_family_map()
+    required_names = sorted(name for name, rule in catalog.items() if rule.required)
+    null_required = 0
+    required_observations = 0
+    family_summary: dict[str, dict[str, int]] = {}
+    catalog_failures: list[dict[str, object]] = []
+
+    for record in records:
+        for feature_name, rule in catalog.items():
+            if not rule.required:
+                continue
+            required_observations += 1
+            value = record.features.get(feature_name)
+            if value is None:
+                null_required += 1
+            message = validate_feature_value(feature_name, value, rule)
+            if message is not None:
+                catalog_failures.append(
+                    {
+                        "date": record.date,
+                        "ticker": record.ticker,
+                        "feature": feature_name,
+                        "message": message,
+                    }
+                )
+        for feature_name, value in record.features.items():
+            family = families.get(feature_name)
+            family_key = family.key if family is not None else "uncataloged"
+            summary = family_summary.setdefault(
+                family_key,
+                {"observations": 0, "nulls": 0, "finite_numeric": 0},
+            )
+            summary["observations"] += 1
+            if value is None:
+                summary["nulls"] += 1
+            if _to_finite_float(value) is not None:
+                summary["finite_numeric"] += 1
+
+    null_rate = (
+        null_required / required_observations if required_observations > 0 else 1.0
+    )
+    return (
+        {
+            "feature_rows": len(records),
+            "feature_dates": [record.date for record in records],
+            "catalog_required_feature_count": len(required_names),
+            "required_feature_observations": required_observations,
+            "required_feature_nulls": null_required,
+            "required_feature_null_rate": null_rate,
+            "catalog_failure_count": len(catalog_failures),
+            "family_summary": family_summary,
+        },
+        catalog_failures,
+    )
+
+
+def _evaluate_market_parameter_candidates(
+    *,
+    price_frame: Any,
+    feature_dates: Sequence[str],
+    ticker: str,
+    horizon_days: int,
+    candidates: Sequence[MarketParameterCandidate],
+) -> list[dict[str, object]]:
+    pd = _require_pandas()
+    if len(price_frame) == 0 or not feature_dates:
+        return [
+            {
+                "name": candidate.name,
+                "status": "insufficient_data",
+                "label_pairs": 0,
+                "abs_correlation_score": None,
+                "parameters": asdict(candidate),
+            }
+            for candidate in candidates
+        ]
+
+    frame = price_frame.sort_values("date").drop_duplicates("date").reset_index(drop=True)
+    labels = compute_forward_return_labels(frame, ticker)
+    label_column = f"forward_return_{horizon_days}d"
+    if label_column not in labels.columns:
+        future = frame["adj_close"].astype(float).shift(-horizon_days)
+        labels[label_column] = future / frame["adj_close"].astype(float) - 1.0
+    allowed_dates = set(feature_dates)
+    labels = labels.loc[labels["date"].isin(allowed_dates), ["date", label_column]]
+
+    adj_close = frame["adj_close"].astype(float)
+    returns_1d = adj_close.pct_change(1)
+    volume = frame["volume"].astype(float)
+    results: list[dict[str, object]] = []
+    for candidate in candidates:
+        candidate_frame = pd.DataFrame(
+            {
+                "date": frame["date"],
+                "candidate_return": adj_close.pct_change(
+                    candidate.return_window_days
+                ).shift(1),
+                "candidate_realized_vol": returns_1d.rolling(
+                    candidate.volatility_window_days
+                ).std().shift(1),
+                "candidate_volume_ratio": (
+                    volume / volume.rolling(candidate.volume_window_days).mean()
+                ).shift(1),
+            }
+        )
+        joined = candidate_frame.merge(labels, on="date", how="inner")
+        correlations = {
+            feature_name: _correlation(joined[feature_name], joined[label_column])
+            for feature_name in (
+                "candidate_return",
+                "candidate_realized_vol",
+                "candidate_volume_ratio",
+            )
+        }
+        finite_correlations = [
+            abs(value) for value in correlations.values() if value is not None
+        ]
+        label_pairs = int(joined[label_column].notna().sum())
+        results.append(
+            {
+                "name": candidate.name,
+                "status": "completed" if finite_correlations else "insufficient_data",
+                "label_pairs": label_pairs,
+                "target_label": label_column,
+                "correlations": correlations,
+                "abs_correlation_score": max(finite_correlations)
+                if finite_correlations
+                else None,
+                "parameters": asdict(candidate),
+            }
+        )
+    return results
+
+
+def _build_acceptance(
+    *,
+    feature_rows: int,
+    missing_feature_keys: Sequence[str],
+    feature_quality: Mapping[str, object],
+    catalog_failures: Sequence[Mapping[str, object]],
+    best_candidate: Mapping[str, object] | None,
+    thresholds: AAPLQualityThresholds,
+) -> dict[str, object]:
+    required_null_rate = float(feature_quality.get("required_feature_null_rate", 1.0))
+    best_score = (
+        _to_finite_float(best_candidate.get("abs_correlation_score"))
+        if best_candidate is not None
+        else None
+    )
+    checks = {
+        "has_min_feature_rows": feature_rows >= thresholds.min_feature_rows,
+        "has_no_missing_date_first_shards": len(missing_feature_keys) == 0,
+        "required_feature_null_rate_ok": (
+            required_null_rate <= thresholds.max_required_feature_null_rate
+        ),
+        "catalog_validation_ok": len(catalog_failures) == 0,
+        "has_min_label_pairs": (
+            best_candidate is not None
+            and int(best_candidate.get("label_pairs", 0)) >= thresholds.min_label_pairs
+        ),
+        "best_candidate_correlation_ok": (
+            best_score is not None
+            and best_score >= thresholds.min_abs_best_candidate_correlation
+        ),
+    }
+    return {
+        "checks": checks,
+        "accepted": all(checks.values()),
+        "thresholds": asdict(thresholds),
+    }
+
+
+def _recommend_issue_202(acceptance: Mapping[str, object]) -> str:
+    checks = acceptance.get("checks")
+    if not isinstance(checks, Mapping):
+        return "needs_human_review"
+    if bool(acceptance.get("accepted")):
+        return "proceed"
+    if not checks.get("has_no_missing_date_first_shards", False):
+        return "do_not_proceed"
+    if not checks.get("catalog_validation_ok", False):
+        return "do_not_proceed"
+    return "needs_human_review"
+
+
+def _best_candidate(results: Sequence[Mapping[str, object]]) -> dict[str, object] | None:
+    completed = [
+        dict(result)
+        for result in results
+        if _to_finite_float(result.get("abs_correlation_score")) is not None
+    ]
+    if not completed:
+        return None
+    return max(
+        completed,
+        key=lambda result: float(result["abs_correlation_score"]),
+    )
+
+
+def _manifest_status(writer: AAPLAccuracyReader, key: str | None) -> str | None:
+    if key is None:
+        return None
+    if not writer.exists(key):
+        return "missing"
+    manifest = PipelineManifestRecord.model_validate_json(writer.get_object(key))
+    return str(manifest.status.value)
+
+
+def _config_to_dict(config: AAPLFeatureAccuracyConfig) -> dict[str, object]:
+    return {
+        "ticker": config.ticker,
+        "benchmark_ticker": config.benchmark_ticker,
+        "target_horizon_days": config.target_horizon_days,
+        "quality_thresholds": asdict(config.quality_thresholds),
+        "market_parameter_candidates": [
+            asdict(candidate) for candidate in config.market_parameter_candidates
+        ],
+    }
+
+
+def _business_dates(from_date: str, to_date: str) -> tuple[str, ...]:
+    start = Date.fromisoformat(from_date)
+    end = Date.fromisoformat(to_date)
+    current = start
+    dates: list[str] = []
+    while current <= end:
+        if current.weekday() < 5:
+            dates.append(current.isoformat())
+        current = current.fromordinal(current.toordinal() + 1)
+    return tuple(dates)
+
+
+def _correlation(left: Any, right: Any) -> float | None:
+    paired = _require_pandas().DataFrame({"left": left, "right": right}).dropna()
+    if len(paired) < 2:
+        return None
+    value = paired["left"].corr(paired["right"])
+    return _to_finite_float(value)
+
+
+def _to_finite_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
+
+
+def _read_parquet_frame(payload: bytes) -> Any:
+    pd = _require_pandas()
+    return pd.read_parquet(io.BytesIO(payload))
+
+
+def _validate_iso_date(value: str, field_name: str) -> None:
+    try:
+        parsed = Date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be YYYY-MM-DD") from exc
+    if parsed.isoformat() != value:
+        raise ValueError(f"{field_name} must be YYYY-MM-DD")
+
+
+def _require_pandas() -> Any:
+    try:
+        import pandas as pd
+
+        importlib.import_module("pyarrow")
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required for the AAPL feature accuracy workflow."
+        ) from exc
+    return pd

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -207,6 +207,26 @@ Inspect R2 outputs via:
   `features/{YYYY-MM-DD}/sentiment_features/`, and
   `features/{YYYY-MM-DD}/regime/`
 
+Before launching the broad point-in-time historical Layer 1 backfill, run the
+AAPL-only accuracy and parameter-calibration pilot:
+
+```bash
+HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/run_aapl_layer1_accuracy.py \
+    --run-id layer1-aapl-accuracy-<window>-v1 \
+    --from-date <from> \
+    --to-date <to> \
+    --layer0-run-id <layer0-run-id> \
+    --allow-layer0-manifest-date-range \
+    --run-layer1
+```
+
+This command is intentionally limited to `AAPL`; it must not be used as the
+full-universe backfill tracked by #202. The durable diagnostic report is written
+to `artifacts/reports/diagnostics/layer1_aapl_feature_accuracy_{run_id}_{from}_to_{to}.json`
+and includes date window, input Layer 0 evidence, date-first feature shard
+examples, parameter candidates, quality diagnostics, and a recommendation for
+whether #202 should proceed.
+
 For a targeted correctness audit on a sample of stored Layer 1 histories, run:
 
 ```bash

--- a/docs/layer1_feature_audit.md
+++ b/docs/layer1_feature_audit.md
@@ -62,3 +62,35 @@ Interpretation:
 Exit code:
 - `0` when the audit produced no failures
 - `1` when at least one failure was detected
+
+## AAPL Accuracy Pilot Before Broad Backfill
+
+Before starting the broad point-in-time historical Layer 1 backfill, run the
+AAPL-only accuracy workflow:
+
+```bash
+HOME=/home/juyoungoh ./.venv/bin/python app/lab/data_pipelines/run_aapl_layer1_accuracy.py \
+    --run-id layer1-aapl-accuracy-<window>-v1 \
+    --from-date <from> \
+    --to-date <to> \
+    --layer0-run-id <layer0-run-id> \
+    --allow-layer0-manifest-date-range \
+    --run-layer1
+```
+
+The workflow is intentionally limited to `AAPL`. It validates the date-first
+pilot shards such as `features/{YYYY-MM-DD}/AAPL.parquet`, writes a local JSON
+report under `artifacts/reports/diagnostics/`, and uploads the durable report to:
+
+`artifacts/reports/diagnostics/layer1_aapl_feature_accuracy_{run_id}_{from}_to_{to}.json`
+
+The configurable parameters live in `config/layer1_aapl_accuracy.json`:
+- target forward-return horizon
+- quality thresholds for feature rows, required-feature null rate, label pairs, and
+  candidate correlation
+- market parameter candidates for return, volatility, and volume-ratio windows
+
+Use `recommendation_for_issue_202` in the report as the operator handoff:
+- `proceed`: AAPL pilot evidence is acceptable for starting #202.
+- `needs_human_review`: review the report before deciding whether to tune parameters.
+- `do_not_proceed`: keep #202 blocked until missing shards or catalog failures are fixed.

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -213,6 +213,20 @@ def layer1_validation_report_path(run_id: str, from_date: str, to_date: str) -> 
     )
 
 
+def layer1_aapl_accuracy_report_path(run_id: str, from_date: str, to_date: str) -> str:
+    """Return the durable AAPL-only Layer 1 feature-accuracy report key."""
+    safe_run_id = _validate_key_part(run_id)
+    return build_r2_key(
+        "artifacts",
+        "reports",
+        "diagnostics",
+        (
+            f"layer1_aapl_feature_accuracy_{safe_run_id}_"
+            f"{_format_date(from_date)}_to_{_format_date(to_date)}.json"
+        ),
+    )
+
+
 def layer0_ohlcv_provenance_report_path(run_id: str) -> str:
     """Return the canonical Layer 0 OHLCV adjustment-provenance report key for one run."""
     safe_run_id = _validate_key_part(run_id)

--- a/tests/unit/test_aapl_layer1_accuracy.py
+++ b/tests/unit/test_aapl_layer1_accuracy.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+
+from app.lab.data_pipelines.run_aapl_layer1_accuracy import parse_args
+from app.lab.data_pipelines.run_daily_layer1 import Layer1DailyConfig, run_daily_layer1
+from core.features.aapl_accuracy import (
+    AAPLFeatureAccuracyConfig,
+    AAPLQualityThresholds,
+    MarketParameterCandidate,
+    build_aapl_feature_accuracy_report,
+    load_aapl_feature_accuracy_config,
+    render_aapl_feature_accuracy_report,
+    write_aapl_feature_accuracy_report,
+)
+from services.r2.paths import layer1_aapl_accuracy_report_path
+from tests.fixtures.layer1_support import (
+    fake_news_runner,
+    fake_regime_runner,
+    fake_sentiment_runner,
+    fake_topic_runner,
+    local_writer,
+    seed_layer0_archives,
+)
+
+
+def test_load_aapl_feature_accuracy_config_requires_aapl_scope(tmp_path: Path) -> None:
+    """The AAPL accuracy config is loaded from JSON and rejects non-AAPL scope."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "ticker": "AAPL",
+                "benchmark_ticker": "SPY",
+                "target_horizon_days": 5,
+                "quality_thresholds": {
+                    "min_feature_rows": 2,
+                    "max_required_feature_null_rate": 1.0,
+                    "min_label_pairs": 2,
+                    "min_abs_best_candidate_correlation": 0.0,
+                },
+                "market_parameter_candidates": [
+                    {
+                        "name": "candidate",
+                        "return_window_days": 5,
+                        "volatility_window_days": 5,
+                        "volume_window_days": 5,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    config = load_aapl_feature_accuracy_config(config_path)
+
+    assert config.ticker == "AAPL"
+    assert config.quality_thresholds.min_feature_rows == 2
+    assert config.market_parameter_candidates[0].name == "candidate"
+
+    config_path.write_text(
+        json.dumps(
+            {
+                "ticker": "MSFT",
+                "market_parameter_candidates": [
+                    {
+                        "name": "candidate",
+                        "return_window_days": 5,
+                        "volatility_window_days": 5,
+                        "volume_window_days": 5,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="ticker=AAPL"):
+        load_aapl_feature_accuracy_config(config_path)
+
+
+def test_build_aapl_feature_accuracy_report_validates_date_first_pilot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An AAPL-only Layer 1 pilot produces a durable diagnostic report."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2024-01-03", "2024-01-04", "2024-01-05", "2024-01-08"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-aapl-accuracy",),
+    )
+    run_daily_layer1(
+        Layer1DailyConfig(
+            run_id="layer1-aapl-accuracy",
+            from_date="2024-01-03",
+            to_date="2024-01-08",
+            tickers=("AAPL",),
+        ),
+        writer=writer,
+        news_runner=fake_news_runner(writer, ["AAPL"]),
+        text_topic_runner=fake_topic_runner(writer, ["AAPL"]),
+        finbert_runner=fake_sentiment_runner(writer, ["AAPL"]),
+        regime_runner=fake_regime_runner(writer),
+        validation_output_dir=tmp_path / "reports",
+        now=datetime(2024, 1, 9, 12, 0, tzinfo=UTC),
+    )
+    config = AAPLFeatureAccuracyConfig(
+        quality_thresholds=AAPLQualityThresholds(
+            min_feature_rows=4,
+            max_required_feature_null_rate=1.0,
+            min_label_pairs=1,
+            min_abs_best_candidate_correlation=0.0,
+        ),
+        market_parameter_candidates=(
+            MarketParameterCandidate(
+                name="short",
+                return_window_days=5,
+                volatility_window_days=5,
+                volume_window_days=5,
+            ),
+        ),
+    )
+
+    report = build_aapl_feature_accuracy_report(
+        run_id="layer1-aapl-accuracy",
+        from_date="2024-01-03",
+        to_date="2024-01-08",
+        layer0_run_id="layer1-aapl-accuracy",
+        config=config,
+        writer=writer,
+        now=datetime(2024, 1, 9, 13, 0, tzinfo=UTC),
+    )
+    local_path = write_aapl_feature_accuracy_report(report, output_dir=tmp_path / "out")
+    payload = json.loads(render_aapl_feature_accuracy_report(report))
+
+    assert report.report_key == layer1_aapl_accuracy_report_path(
+        "layer1-aapl-accuracy",
+        "2024-01-03",
+        "2024-01-08",
+    )
+    assert writer.exists(report.report_key) is True
+    assert local_path.exists()
+    assert report.output_paths["missing_feature_keys"] == []
+    assert payload["feature_quality"]["feature_rows"] == 4
+    assert payload["acceptance"]["accepted"] is True
+    assert payload["recommendation_for_issue_202"] == "proceed"
+    assert payload["output_paths"]["feature_output_key_examples"][0] == (
+        "features/2024-01-03/AAPL.parquet"
+    )
+
+
+def test_build_aapl_feature_accuracy_report_blocks_when_date_first_shard_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing AAPL date-first shards keep the #202 recommendation blocked."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2024-01-03", "2024-01-04"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-aapl-missing",),
+    )
+    config = AAPLFeatureAccuracyConfig(
+        quality_thresholds=AAPLQualityThresholds(
+            min_feature_rows=1,
+            max_required_feature_null_rate=1.0,
+            min_label_pairs=1,
+        ),
+    )
+
+    report = build_aapl_feature_accuracy_report(
+        run_id="layer1-aapl-missing",
+        from_date="2024-01-03",
+        to_date="2024-01-04",
+        layer0_run_id="layer1-aapl-missing",
+        config=config,
+        writer=writer,
+    )
+
+    assert report.acceptance["accepted"] is False
+    assert report.output_paths["missing_feature_keys"] == [
+        "features/2024-01-03/AAPL.parquet",
+        "features/2024-01-04/AAPL.parquet",
+    ]
+    assert report.recommendation_for_issue_202 == "do_not_proceed"
+
+
+def test_parse_args_rejects_non_aapl_ticker() -> None:
+    """The CLI cannot be widened into the broad multi-ticker backfill."""
+    with pytest.raises(SystemExit):
+        parse_args(
+            [
+                "--run-id",
+                "layer1-aapl",
+                "--ticker",
+                "MSFT",
+                "--from-date",
+                "2024-01-03",
+                "--to-date",
+                "2024-01-04",
+            ]
+        )

--- a/tests/unit/test_r2_paths.py
+++ b/tests/unit/test_r2_paths.py
@@ -10,6 +10,7 @@ from services.r2.paths import (
     is_canonical_raw_price_key,
     is_legacy_raw_price_key,
     layer0_ohlcv_provenance_report_path,
+    layer1_aapl_accuracy_report_path,
     layer1_feature_path,
     layer1_news_preprocessing_path,
     layer1_regime_path,
@@ -117,6 +118,11 @@ def test_layer1_text_artifact_paths_return_canonical_keys() -> None:
         layer1_validation_report_path("run-001", "2025-01-02", "2025-01-03")
         == "artifacts/reports/integration/"
         "layer1_archive_validation_run-001_2025-01-02_to_2025-01-03.json"
+    )
+    assert (
+        layer1_aapl_accuracy_report_path("run-001", "2025-01-02", "2025-01-03")
+        == "artifacts/reports/diagnostics/"
+        "layer1_aapl_feature_accuracy_run-001_2025-01-02_to_2025-01-03.json"
     )
 
 


### PR DESCRIPTION
## What this PR does
Adds an AAPL-only Layer 1 feature accuracy and parameter-calibration workflow that can optionally run Layer 1 narrowed to `AAPL`, validates date-first AAPL shards, scores configurable market parameter candidates against forward returns, and writes a durable diagnostic report for deciding whether the broad historical backfill in #202 should proceed.

## Closes
Closes #204

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [x] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, missing date-first shards, config validation, and the AAPL-only CLI guard
- [x] No live API calls in unit tests — fixtures used from local mock R2

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Verification artifacts
Commands run:
- `python -m venv .venv`
- `./.venv/bin/python -m pip install -r requirements/dev.txt`
- `./.venv/bin/python -m py_compile core/features/aapl_accuracy.py app/lab/data_pipelines/run_aapl_layer1_accuracy.py`
- `./.venv/bin/ruff check core/features/aapl_accuracy.py app/lab/data_pipelines/run_aapl_layer1_accuracy.py services/r2/paths.py tests/unit/test_aapl_layer1_accuracy.py tests/unit/test_r2_paths.py`
- `./.venv/bin/pytest tests/unit/test_aapl_layer1_accuracy.py tests/unit/test_r2_paths.py -v --tb=short`
- `./.venv/bin/pytest tests/unit/ -v --tb=short`

Test result summary:
- Focused tests: 25 passed, 6 Modal deprecation warnings
- Full unit suite: 696 passed, 1 skipped, 8 Modal deprecation warnings

Manifest key(s):
- When `--run-layer1` is used: `artifacts/manifests/layer1/{run_id}.json`

Report path(s):
- Local: `artifacts/reports/diagnostics/layer1_aapl_feature_accuracy_{run_id}_{from}_to_{to}.json`
- Durable object key: `artifacts/reports/diagnostics/layer1_aapl_feature_accuracy_{run_id}_{from}_to_{to}.json`

R2 output prefix(es):
- AAPL feature shard examples: `features/{YYYY-MM-DD}/AAPL.parquet`
- Diagnostics: `artifacts/reports/diagnostics/`

Known skipped/missing data:
- This worktree had `r2_configured=False`; I did not run the live production AAPL pilot and did not write production R2 artifacts.
- No Modal run was needed for local/unit validation.

Task-specific verification artifacts:
- AAPL pilot run_id: not run against production R2 from this environment; unit fixture run_id was `layer1-aapl-accuracy`.
- AAPL date window: unit fixture covered `2024-01-03` to `2024-01-08`.
- AAPL feature output key examples: `features/2024-01-03/AAPL.parquet` in local mock R2 tests.
- AAPL accuracy/diagnostic report path/key: `artifacts/reports/diagnostics/layer1_aapl_feature_accuracy_{run_id}_{from}_to_{to}.json`.
- Parameter/config summary: `config/layer1_aapl_accuracy.json` owns ticker `AAPL`, benchmark `SPY`, target horizon, quality thresholds, and market return/volatility/volume candidate windows.
- Recommendation for #202: keep #202 blocked until this new AAPL workflow is run against real R2/Layer 0 data and the produced report says `recommendation_for_issue_202=proceed`.

## Notes for reviewer
The workflow is deliberately guarded to reject non-AAPL ticker scope. It only writes new Layer 1 AAPL shards when explicitly called with `--run-layer1`; otherwise it audits existing AAPL date-first shards and writes the diagnostic report. It never deletes or destructively rewrites production R2 artifacts.
