### PR TITLE
Fail closed AAPL pilot on HMM gaps

### DIFF
--- a/app/lab/data_pipelines/run_aapl_layer1_accuracy.py
+++ b/app/lab/data_pipelines/run_aapl_layer1_accuracy.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import shlex
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -32,6 +33,7 @@ from core.features.aapl_accuracy import (  # noqa: E402
     DEFAULT_AAPL_ACCURACY_OUTPUT_DIR,
     AAPLFeatureAccuracyConfig,
     build_aapl_feature_accuracy_report,
+    build_terminal_aapl_feature_accuracy_report,
     load_aapl_feature_accuracy_config,
     write_aapl_feature_accuracy_report,
 )
@@ -113,9 +115,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         except Layer1ValidationError as exc:
             logger.error("AAPL Layer 1 pilot validation failed: {}", exc)
+            _write_terminal_failure_report(
+                args=args,
+                config=config,
+                writer=writer,
+                failure=exc,
+            )
             return 1
         except Exception as exc:  # noqa: BLE001
             logger.error("AAPL Layer 1 pilot failed: {}", exc)
+            _write_terminal_failure_report(
+                args=args,
+                config=config,
+                writer=writer,
+                failure=exc,
+            )
             return 1
         logger.info(
             "AAPL Layer 1 pilot generated manifest={} report={}",
@@ -149,6 +163,78 @@ def main(argv: Sequence[str] | None = None) -> int:
         report.recommendation_for_issue_202,
     )
     return 0 if report.acceptance.get("accepted") is True else 1
+
+
+def _write_terminal_failure_report(
+    *,
+    args: argparse.Namespace,
+    config: AAPLFeatureAccuracyConfig,
+    writer: R2Writer,
+    failure: BaseException,
+) -> None:
+    """Persist a fail-closed AAPL pilot report for escaped Layer 1 failures."""
+    report = build_terminal_aapl_feature_accuracy_report(
+        run_id=str(args.run_id).strip(),
+        from_date=str(args.from_date).strip(),
+        to_date=str(args.to_date).strip(),
+        layer1_run_id=(
+            str(args.layer1_run_id).strip()
+            if args.layer1_run_id is not None
+            else str(args.run_id).strip()
+        ),
+        layer0_run_id=(
+            str(args.layer0_run_id).strip() if args.layer0_run_id is not None else None
+        ),
+        config=config,
+        writer=writer,
+        failure_type=type(failure).__name__,
+        failure_message=str(failure),
+        rerun_command=_build_rerun_command(args),
+    )
+    local_report_path = write_aapl_feature_accuracy_report(
+        report,
+        output_dir=args.output_dir,
+    )
+    logger.info("AAPL terminal diagnostic report written locally: {}", local_report_path)
+    logger.info("AAPL terminal diagnostic report written to object store: {}", report.report_key)
+    logger.info("Recommendation for #202: {}", report.recommendation_for_issue_202)
+
+
+def _build_rerun_command(args: argparse.Namespace) -> str:
+    """Return a shell command that reruns the same AAPL-only pilot."""
+    command = [
+        "./.venv/bin/modal",
+        "run",
+        "app/lab/data_pipelines/run_aapl_layer1_accuracy.py",
+        "--run-id",
+        str(args.run_id).strip(),
+        "--ticker",
+        "AAPL",
+        "--from-date",
+        str(args.from_date).strip(),
+        "--to-date",
+        str(args.to_date).strip(),
+    ]
+    if args.layer0_run_id is not None:
+        command.extend(["--layer0-run-id", str(args.layer0_run_id).strip()])
+    if args.layer1_run_id is not None:
+        command.extend(["--layer1-run-id", str(args.layer1_run_id).strip()])
+    if args.benchmark_ticker is not None:
+        command.extend(["--benchmark-ticker", str(args.benchmark_ticker).strip()])
+    if args.config_path != DEFAULT_AAPL_ACCURACY_CONFIG_PATH:
+        command.extend(["--config-path", str(args.config_path)])
+    if args.output_dir != DEFAULT_AAPL_ACCURACY_OUTPUT_DIR:
+        command.extend(["--output-dir", str(args.output_dir)])
+    if args.run_layer1:
+        command.append("--run-layer1")
+    if args.allow_layer0_manifest_date_range:
+        command.append("--allow-layer0-manifest-date-range")
+    command.extend(["--min-sentence-chars", str(int(args.min_sentence_chars))])
+    if args.hmm_train_start_date is not None:
+        command.extend(["--hmm-train-start-date", str(args.hmm_train_start_date).strip()])
+    command.extend(["--hmm-max-iterations", str(int(args.hmm_max_iterations))])
+    command.extend(["--hmm-min-training-rows", str(int(args.hmm_min_training_rows))])
+    return " ".join(shlex.quote(part) for part in command)
 
 
 def _run_scoped_layer1_on_modal(

--- a/app/lab/data_pipelines/run_hmm_regime_detection.py
+++ b/app/lab/data_pipelines/run_hmm_regime_detection.py
@@ -209,7 +209,11 @@ def run_hmm_regime_detection(
                 config=hmm_config,
             )
         else:
-            regime_frame = _empty_regime_frame(readiness.inference_dates)
+            regime_frame = _empty_regime_frame(config.inference_dates)
+        regime_frame = _ensure_requested_regime_rows(
+            regime_frame,
+            requested_dates=config.inference_dates,
+        )
         regime_frame = _with_regime_readiness_columns(regime_frame, readiness=readiness)
         probability_errors = validate_hmm_regime_probabilities(regime_frame)
         if probability_errors:
@@ -240,13 +244,13 @@ def run_hmm_regime_detection(
                 "regime_readiness_by_date": _regime_readiness_by_date(regime_frame),
                 "warning_inference_dates": [
                     date_text
-                    for date_text in readiness.inference_dates
+                    for date_text in config.inference_dates
                     if (not readiness.can_fit_model)
-                    or date_text in readiness.incomplete_inference_feature_gaps
+                    or date_text not in readiness.complete_inference_dates
                 ],
                 "regime_layer2_ready": bool(
                     readiness.can_fit_model
-                    and len(readiness.complete_inference_dates) == len(readiness.inference_dates)
+                    and set(readiness.complete_inference_dates) == set(config.inference_dates)
                 ),
                 "regime_rows": len(regime_frame),
             }
@@ -366,6 +370,33 @@ def _empty_regime_frame(inference_dates: Sequence[str]) -> pd.DataFrame:
     return pd.DataFrame(rows, columns=list(HMM_REGIME_COLUMNS))
 
 
+def _ensure_requested_regime_rows(
+    frame: pd.DataFrame,
+    *,
+    requested_dates: Sequence[str],
+) -> pd.DataFrame:
+    """Return regime output with one row for every requested inference date."""
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "pandas and pyarrow are required to write HMM regime outputs."
+        ) from exc
+    if not isinstance(frame, pd.DataFrame):
+        raise TypeError("frame must be a pandas DataFrame")
+
+    existing_dates = set(frame["date"].astype(str).tolist()) if "date" in frame.columns else set()
+    missing_dates = [date_text for date_text in requested_dates if date_text not in existing_dates]
+    if not missing_dates:
+        return frame.sort_values("date").reset_index(drop=True)
+
+    padded = pd.concat(
+        [frame, _empty_regime_frame(missing_dates)],
+        ignore_index=True,
+    )
+    return padded.sort_values("date").reset_index(drop=True)
+
+
 def _with_regime_readiness_columns(
     frame: pd.DataFrame,
     *,
@@ -396,10 +427,12 @@ def _with_regime_readiness_columns(
         missing_features = readiness.incomplete_inference_feature_gaps.get(date_text, ())
         if not readiness.can_fit_model:
             reason = "insufficient_training_history"
+        elif date_text in readiness.complete_inference_dates:
+            reason = "ready"
         elif missing_features:
             reason = "incomplete_inference_features"
         else:
-            reason = "ready"
+            reason = "missing_inference_row"
         annotated.loc[index, "regime_readiness_reason"] = reason
         annotated.loc[index, "regime_missing_features"] = ",".join(missing_features)
         if reason == "ready":

--- a/core/features/aapl_accuracy.py
+++ b/core/features/aapl_accuracy.py
@@ -261,6 +261,107 @@ def build_aapl_feature_accuracy_report(
     return report
 
 
+def build_terminal_aapl_feature_accuracy_report(
+    *,
+    run_id: str,
+    from_date: str,
+    to_date: str,
+    failure_type: str,
+    failure_message: str,
+    rerun_command: str,
+    layer1_run_id: str | None = None,
+    layer0_run_id: str | None = None,
+    config: AAPLFeatureAccuracyConfig | None = None,
+    writer: AAPLAccuracyReader | None = None,
+    now: datetime | None = None,
+) -> AAPLFeatureAccuracyReport:
+    """Build and upload a fail-closed terminal AAPL pilot diagnostic report."""
+    _validate_iso_date(from_date, "from_date")
+    _validate_iso_date(to_date, "to_date")
+    if from_date > to_date:
+        raise ValueError("from_date must be <= to_date")
+    if not run_id.strip():
+        raise ValueError("run_id cannot be empty")
+    if not failure_type.strip():
+        raise ValueError("failure_type cannot be empty")
+    if not failure_message.strip():
+        raise ValueError("failure_message cannot be empty")
+    if not rerun_command.strip():
+        raise ValueError("rerun_command cannot be empty")
+
+    active_config = config or load_aapl_feature_accuracy_config()
+    active_writer = writer or R2Writer()
+    active_layer1_run_id = layer1_run_id or run_id
+    report_key = layer1_aapl_accuracy_report_path(run_id, from_date, to_date)
+    layer1_manifest_key = pipeline_manifest_path("layer1", active_layer1_run_id)
+    layer0_manifest_key = (
+        pipeline_manifest_path("layer0", layer0_run_id) if layer0_run_id is not None else None
+    )
+    terminal_diagnostic = {
+        "status": "terminal_failure",
+        "failure_type": failure_type,
+        "failure_message": failure_message,
+        "fail_closed": True,
+        "issue_202_gate": "closed",
+        "rerun_required": True,
+        "rerun_command": rerun_command,
+    }
+    report = AAPLFeatureAccuracyReport(
+        run_id=run_id,
+        layer1_run_id=active_layer1_run_id,
+        layer0_run_id=layer0_run_id,
+        ticker=active_config.ticker.strip().upper(),
+        benchmark_ticker=active_config.benchmark_ticker.strip().upper(),
+        from_date=from_date,
+        to_date=to_date,
+        generated_at=(now or datetime.now(UTC)).replace(microsecond=0).isoformat(),
+        report_key=report_key,
+        input_evidence={
+            "layer0_manifest_key": layer0_manifest_key,
+            "layer0_manifest_status": _manifest_status(active_writer, layer0_manifest_key),
+            "layer1_manifest_key": layer1_manifest_key,
+            "layer1_manifest_status": _manifest_status(active_writer, layer1_manifest_key),
+            "terminal_diagnostic": terminal_diagnostic,
+        },
+        output_paths={
+            "report_key": report_key,
+            "feature_output_key_examples": [],
+            "missing_feature_keys": [],
+            "r2_output_prefixes": {
+                "date_first_features": "features/{YYYY-MM-DD}/AAPL.parquet",
+                "diagnostic_reports": "artifacts/reports/diagnostics/",
+            },
+        },
+        parameter_config=_config_to_dict(active_config),
+        feature_quality={
+            "feature_rows": 0,
+            "feature_dates": [],
+            "terminal_failure": terminal_diagnostic,
+        },
+        catalog_failures=[
+            {
+                "stage": "layer1_generation",
+                "message": failure_message,
+                "failure_type": failure_type,
+            }
+        ],
+        optimization_results=[],
+        best_parameter_candidate=None,
+        acceptance={
+            "accepted": False,
+            "checks": {
+                "terminal_diagnostic_written": True,
+                "rerun_required": True,
+                "issue_202_gate_closed": True,
+            },
+            "thresholds": asdict(active_config.quality_thresholds),
+        },
+        recommendation_for_issue_202="do_not_proceed",
+    )
+    active_writer.put_object(report_key, render_aapl_feature_accuracy_report(report))
+    return report
+
+
 def write_aapl_feature_accuracy_report(
     report: AAPLFeatureAccuracyReport,
     *,

--- a/tests/unit/test_aapl_layer1_accuracy.py
+++ b/tests/unit/test_aapl_layer1_accuracy.py
@@ -14,6 +14,7 @@ from core.features.aapl_accuracy import (
     AAPLQualityThresholds,
     MarketParameterCandidate,
     build_aapl_feature_accuracy_report,
+    build_terminal_aapl_feature_accuracy_report,
     load_aapl_feature_accuracy_config,
     render_aapl_feature_accuracy_report,
     write_aapl_feature_accuracy_report,
@@ -268,6 +269,116 @@ def test_build_aapl_feature_accuracy_report_blocks_when_raw_price_data_missing(
     assert report.acceptance["checks"]["has_raw_price_data"] is False
     assert report.acceptance["accepted"] is False
     assert report.recommendation_for_issue_202 == "do_not_proceed"
+
+
+def test_build_terminal_aapl_feature_accuracy_report_fails_closed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Escaped Layer 1 failures still write the durable #202 gate report."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2024-01-03"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer0-aapl-terminal",),
+    )
+
+    report = build_terminal_aapl_feature_accuracy_report(
+        run_id="layer1-aapl-terminal",
+        from_date="2024-01-03",
+        to_date="2024-01-03",
+        layer0_run_id="layer0-aapl-terminal",
+        failure_type="ValueError",
+        failure_message="HMM regime run produced no rows",
+        rerun_command=(
+            "./.venv/bin/modal run app/lab/data_pipelines/run_aapl_layer1_accuracy.py "
+            "--run-layer1"
+        ),
+        writer=writer,
+        now=datetime(2024, 1, 4, 12, 0, tzinfo=UTC),
+    )
+    payload = json.loads(writer.get_object(report.report_key))
+
+    assert report.recommendation_for_issue_202 == "do_not_proceed"
+    assert report.acceptance["accepted"] is False
+    assert report.input_evidence["terminal_diagnostic"]["fail_closed"] is True
+    assert payload["input_evidence"]["terminal_diagnostic"]["rerun_required"] is True
+    assert payload["acceptance"]["checks"]["issue_202_gate_closed"] is True
+
+
+def test_main_writes_terminal_report_when_scoped_layer1_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The CLI fail-closes with a local and object-store report on Layer 1 exceptions."""
+    writer = local_writer(tmp_path, monkeypatch)
+    config_path = tmp_path / "config.json"
+    config_path.write_text(
+        json.dumps(
+            {
+                "ticker": "AAPL",
+                "benchmark_ticker": "SPY",
+                "target_horizon_days": 5,
+                "quality_thresholds": {
+                    "min_feature_rows": 1,
+                    "max_required_feature_null_rate": 1.0,
+                    "min_label_pairs": 1,
+                    "min_abs_best_candidate_correlation": 0.0,
+                },
+                "market_parameter_candidates": [
+                    {
+                        "name": "candidate",
+                        "return_window_days": 5,
+                        "volatility_window_days": 5,
+                        "volume_window_days": 5,
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(aapl_runner, "R2Writer", lambda: writer)
+    monkeypatch.setattr(
+        aapl_runner,
+        "_run_scoped_layer1_on_modal",
+        lambda **kwargs: (_ for _ in ()).throw(
+            ValueError("HMM regime run run-id produced no rows for inference_date=2026-05-25")
+        ),
+    )
+
+    exit_code = aapl_runner.main(
+        [
+            "--run-id",
+            "layer1-aapl-terminal-main",
+            "--from-date",
+            "2026-05-25",
+            "--to-date",
+            "2026-05-25",
+            "--layer0-run-id",
+            "layer0-aapl",
+            "--config-path",
+            str(config_path),
+            "--output-dir",
+            str(tmp_path / "out"),
+            "--run-layer1",
+            "--allow-layer0-manifest-date-range",
+        ]
+    )
+
+    report_key = layer1_aapl_accuracy_report_path(
+        "layer1-aapl-terminal-main",
+        "2026-05-25",
+        "2026-05-25",
+    )
+    payload = json.loads(writer.get_object(report_key))
+    local_path = tmp_path / "out" / Path(report_key).name
+
+    assert exit_code == 1
+    assert local_path.exists()
+    assert payload["recommendation_for_issue_202"] == "do_not_proceed"
+    assert payload["input_evidence"]["terminal_diagnostic"]["failure_type"] == "ValueError"
+    assert "--ticker AAPL" in payload["input_evidence"]["terminal_diagnostic"]["rerun_command"]
 
 
 def test_parse_args_rejects_non_aapl_ticker() -> None:

--- a/tests/unit/test_hmm_regime_runner.py
+++ b/tests/unit/test_hmm_regime_runner.py
@@ -198,6 +198,74 @@ def test_run_hmm_regime_detection_emits_warning_rows_for_short_history(
     }
 
 
+def test_run_hmm_regime_detection_emits_warning_row_for_missing_inference_date(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A requested date absent from the HMM frame writes a terminal warning row."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    bars = _benchmark_bars(130)
+    macro = _macro_archive(150)
+    _write_parquet(writer, raw_price_path("SPY"), bars)
+    _write_parquet(writer, raw_macro_path("2023-01-02"), macro)
+
+    dates = pd.bdate_range("2024-01-02", periods=120)
+    synthetic_training = pd.DataFrame(
+        [
+            {
+                "date": date.date().isoformat(),
+                "spy_log_return_1d": 0.01 + index * 0.0001,
+                "spy_return_5d": 0.03,
+                "spy_realized_vol_21d": 0.12,
+                "spy_realized_vol_63d": 0.10,
+                "spy_vol_ratio_21_63": 1.2,
+                "spy_drawdown_63d": -0.02,
+                "vix_level": 16.0,
+                "vix_change_5d": -0.1,
+                "yield_curve_slope_10y_2y": 0.3,
+                "yield_curve_slope_10y_3m": 0.4,
+                "high_yield_spread": 3.1,
+                "is_complete": True,
+            }
+            for index, date in enumerate(dates[:101])
+        ]
+    )
+    monkeypatch.setattr(
+        "app.lab.data_pipelines.run_hmm_regime_detection.build_hmm_training_frame",
+        lambda benchmark, macro: synthetic_training,
+    )
+
+    missing_inference_date = str(dates[110].date())
+    result = run_hmm_regime_detection(
+        HMMRegimePipelineConfig(
+            run_id="hmm-missing-inference-row",
+            train_end_date=str(dates[100].date()),
+            inference_dates=(missing_inference_date,),
+            min_training_rows=90,
+            max_iterations=20,
+        ),
+        writer=writer,
+    )
+
+    output = pd.read_parquet(io.BytesIO(writer.get_object(result.output_key)))
+    manifest = json.loads(writer.get_object(result.manifest_key))
+
+    assert output.loc[0, "date"] == missing_inference_date
+    assert pd.isna(output.loc[0, "regime_confidence"])
+    assert output.loc[0, "regime_readiness_status"] == "warning"
+    assert output.loc[0, "regime_readiness_reason"] == "missing_inference_row"
+    assert manifest["status"] == RunStatus.COMPLETED
+    assert manifest["metadata"]["regime_layer2_ready"] is False
+    assert manifest["metadata"]["warning_inference_dates"] == [missing_inference_date]
+    assert manifest["metadata"]["regime_readiness_by_date"][missing_inference_date] == {
+        "status": "warning",
+        "reason": "missing_inference_row",
+        "required_for_layer2": False,
+        "missing_features": [],
+        "probability_sum": None,
+    }
+
+
 def test_run_hmm_regime_detection_scores_inference_rows_when_only_dropped_features_are_null(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## What this PR does
Fixes the AAPL-only Layer 1 accuracy pilot so HMM missing-inference-date gaps no longer leave #202 with a missing gate artifact. The HMM runner now writes explicit warning/null regime rows for every requested inference date, including dates absent from the HMM training frame, and the AAPL pilot wrapper writes a terminal fail-closed diagnostic report if Layer 1 still raises before the normal accuracy report can be built.

## Closes
Closes #212

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`, `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover the HMM missing inference-date path and terminal AAPL report path
- [x] No live API calls in unit tests — local writer fixtures used

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch named `codex/212-aapl-hmm-terminal-report`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] No new dependencies added to requirements

## New dependencies
None

## Verification artifacts
Commands run:
- `python3 -m venv .venv && ./.venv/bin/python -m pip install -r requirements/dev.txt`
- `./.venv/bin/pytest tests/unit/test_hmm_regime_runner.py tests/unit/test_aapl_layer1_accuracy.py -v --tb=short` → 19 passed
- `./.venv/bin/pytest tests/unit/ -v --tb=short` → 707 passed, 1 skipped, 8 warnings
- `./.venv/bin/ruff check app/lab/data_pipelines/run_aapl_layer1_accuracy.py app/lab/data_pipelines/run_hmm_regime_detection.py core/features/aapl_accuracy.py tests/unit/test_aapl_layer1_accuracy.py tests/unit/test_hmm_regime_runner.py`
- `git diff --check`

Report path behavior:
- Normal and terminal AAPL diagnostics use `artifacts/reports/diagnostics/layer1_aapl_feature_accuracy_{run_id}_{from}_to_{to}.json`.
- On escaped Layer 1 failure, the terminal report sets `recommendation_for_issue_202=do_not_proceed`, `fail_closed=true`, and includes a rerun command.

## Notes for reviewer
This does not start the broad all-ticker historical backfill from #202. A fresh AAPL pilot rerun is required before #202 can proceed; this PR only ensures that rerun will either produce the normal `proceed` / `do_not_proceed` / `needs_human_review` recommendation or a durable terminal `do_not_proceed` diagnostic.