### PR TITLE
Fix AAPL pilot holiday price coverage

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -376,11 +376,19 @@ def run_daily_layer1(
     tickers_processed = 0
     history_files_written = 0
     feature_rows_written = 0
-    processed_dates = _business_dates(config.from_date, config.to_date)
+    requested_calendar_dates = _calendar_dates(config.from_date, config.to_date)
+    processed_dates = _trading_dates(config.from_date, config.to_date)
+    skipped_non_trading_dates = tuple(
+        date_text
+        for date_text in requested_calendar_dates
+        if date_text not in set(processed_dates)
+    )
     metadata: dict[str, object] = {
         "from_date": config.from_date,
         "to_date": config.to_date,
+        "requested_calendar_dates": list(requested_calendar_dates),
         "processed_dates": list(processed_dates),
+        "skipped_non_trading_dates": list(skipped_non_trading_dates),
         "layer0_run_id": config.layer0_run_id or config.run_id,
         "benchmark_ticker": config.benchmark_ticker,
         "requested_tickers": list(config.tickers),
@@ -429,6 +437,7 @@ def run_daily_layer1(
             benchmark_ticker=config.benchmark_ticker,
             universe_by_date=universe_by_date,
             required_macro_series=_manifest_fred_series_ids(upstream_manifest),
+            skipped_non_trading_dates=skipped_non_trading_dates,
         )
 
         news_results = _run_news_stage(
@@ -640,7 +649,7 @@ def _run_modal_batched_stage_outputs(
     scorer_factory: Callable[[object], object] = finbert_module.FinBERTScorer,
 ) -> ModalBatchedStageOutputs:
     """Run per-date branches inside one Modal context for a multi-date readiness window."""
-    processed_dates = _business_dates(config.from_date, config.to_date)
+    processed_dates = _trading_dates(config.from_date, config.to_date)
     news_output_keys_by_date: dict[str, str] = {}
     topic_output_keys_by_date: dict[str, str] = {}
     sentiment_output_keys_by_date: dict[str, str] = {}
@@ -1252,6 +1261,7 @@ def _require_upstream_archives(
     benchmark_ticker: str,
     universe_by_date: Mapping[str, Sequence[str]],
     required_macro_series: Sequence[str],
+    skipped_non_trading_dates: Sequence[str] = (),
 ) -> None:
     """Require the Layer 0 archives needed by the daily Layer 1 run."""
     required_keys = [raw_price_path(benchmark_ticker)]
@@ -1287,6 +1297,7 @@ def _require_upstream_archives(
         processed_dates=processed_dates,
         benchmark_ticker=benchmark_ticker,
         universe_by_date=universe_by_date,
+        skipped_non_trading_dates=skipped_non_trading_dates,
     )
 
 
@@ -1311,6 +1322,7 @@ def _require_target_date_price_coverage(
     processed_dates: Sequence[str],
     benchmark_ticker: str,
     universe_by_date: Mapping[str, Sequence[str]],
+    skipped_non_trading_dates: Sequence[str] = (),
 ) -> None:
     """Fail closed when raw price archives exist but miss expected target dates."""
     expected_dates_by_ticker = _expected_dates_by_ticker(universe_by_date)
@@ -1326,9 +1338,17 @@ def _require_target_date_price_coverage(
         if missing_dates:
             missing_coverage[ticker] = missing_dates
     if missing_coverage:
+        skipped_note = ""
+        if skipped_non_trading_dates:
+            skipped_note = (
+                "; skipped_non_trading_dates=["
+                + ",".join(sorted(dict.fromkeys(skipped_non_trading_dates)))
+                + "]"
+            )
         raise RuntimeError(
             "Layer 0 raw price archives missing target-date coverage for Layer 1 run: "
             + _format_ticker_dates(missing_coverage)
+            + skipped_note
         )
 
 
@@ -1506,38 +1526,122 @@ def _single_as_of_date(config: Layer1DailyConfig) -> str | None:
     return None
 
 
-def _business_dates(from_date: str, to_date: str) -> tuple[str, ...]:
-    """Return business dates between two ISO dates, inclusive."""
+def _calendar_dates(from_date: str, to_date: str) -> tuple[str, ...]:
+    """Return calendar dates between two ISO dates, inclusive."""
     start = Date.fromisoformat(from_date)
     end = Date.fromisoformat(to_date)
     dates: list[str] = []
     current = start
     while current <= end:
-        if current.weekday() < 5:
-            dates.append(current.isoformat())
+        dates.append(current.isoformat())
         current += timedelta(days=1)
     return tuple(dates)
 
 
+def _trading_dates(from_date: str, to_date: str) -> tuple[str, ...]:
+    """Return US equity trading sessions between two ISO dates, inclusive."""
+    return tuple(
+        date_text
+        for date_text in _calendar_dates(from_date, to_date)
+        if _is_us_equity_trading_session(Date.fromisoformat(date_text))
+    )
+
+
 def _previous_business_day(date_text: str) -> str:
-    """Return the prior business day for one ISO date."""
+    """Return the prior US equity trading session for one ISO date."""
     current = Date.fromisoformat(date_text) - timedelta(days=1)
-    while current.weekday() >= 5:
+    while not _is_us_equity_trading_session(current):
         current -= timedelta(days=1)
     return current.isoformat()
 
 
 def _subtract_business_days(date_text: str, count: int) -> str:
-    """Return the ISO date that is `count` business days before `date_text`."""
+    """Return the ISO date that is `count` trading sessions before `date_text`."""
     if count < 0:
         raise ValueError("count must be non-negative")
     current = Date.fromisoformat(date_text)
     remaining = count
     while remaining > 0:
         current -= timedelta(days=1)
-        if current.weekday() < 5:
+        if _is_us_equity_trading_session(current):
             remaining -= 1
     return current.isoformat()
+
+
+def _is_us_equity_trading_session(day: Date) -> bool:
+    """Return True when the date is a regular US equity market session."""
+    if day.weekday() >= 5:
+        return False
+    return day not in _us_equity_market_holidays(day.year)
+
+
+def _us_equity_market_holidays(year: int) -> set[Date]:
+    """Return regular full-day US equity market holidays for one year."""
+    holidays = {
+        _observed_fixed_holiday(year, 1, 1),
+        _nth_weekday(year, 1, 0, 3),
+        _nth_weekday(year, 2, 0, 3),
+        _easter_sunday(year) - timedelta(days=2),
+        _last_weekday(year, 5, 0),
+        _observed_fixed_holiday(year, 7, 4),
+        _nth_weekday(year, 9, 0, 1),
+        _nth_weekday(year, 11, 3, 4),
+        _observed_fixed_holiday(year, 12, 25),
+    }
+    if year >= 2022:
+        holidays.add(_observed_fixed_holiday(year, 6, 19))
+    next_new_year_observed = _observed_fixed_holiday(year + 1, 1, 1)
+    if next_new_year_observed.year == year:
+        holidays.add(next_new_year_observed)
+    return holidays
+
+
+def _observed_fixed_holiday(year: int, month: int, day: int) -> Date:
+    """Return the weekday-observed date for one fixed-date market holiday."""
+    holiday = Date(year, month, day)
+    if holiday.weekday() == 5:
+        return holiday - timedelta(days=1)
+    if holiday.weekday() == 6:
+        return holiday + timedelta(days=1)
+    return holiday
+
+
+def _nth_weekday(year: int, month: int, weekday: int, n: int) -> Date:
+    """Return the nth weekday in a month, where Monday is 0."""
+    current = Date(year, month, 1)
+    while current.weekday() != weekday:
+        current += timedelta(days=1)
+    return current + timedelta(days=7 * (n - 1))
+
+
+def _last_weekday(year: int, month: int, weekday: int) -> Date:
+    """Return the last weekday in a month, where Monday is 0."""
+    if month == 12:
+        current = Date(year + 1, 1, 1) - timedelta(days=1)
+    else:
+        current = Date(year, month + 1, 1) - timedelta(days=1)
+    while current.weekday() != weekday:
+        current -= timedelta(days=1)
+    return current
+
+
+def _easter_sunday(year: int) -> Date:
+    """Return Gregorian Easter Sunday for one year."""
+    a = year % 19
+    b = year // 100
+    c = year % 100
+    d = b // 4
+    e = b % 4
+    f = (b + 8) // 25
+    g = (b - f + 1) // 3
+    h = (19 * a + b - d - g + 15) % 30
+    i = c // 4
+    k = c % 4
+    correction = (32 + 2 * e + 2 * i - h - k) % 7
+    m = (a + 11 * h + 22 * correction) // 451
+    month = (h + correction - 7 * m + 114) // 31
+    day = ((h + correction - 7 * m + 114) % 31) + 1
+    return Date(year, month, day)
 
 
 def _truthy(value: str | None, *, default: bool = False) -> bool:

--- a/tests/unit/test_daily_layer1_runner.py
+++ b/tests/unit/test_daily_layer1_runner.py
@@ -18,7 +18,9 @@ from app.lab.data_pipelines.run_daily_layer1 import (
     _existing_news_runner,
     _existing_regime_runner,
     _existing_text_topic_runner,
+    _previous_business_day,
     _run_modal_batched_stage_outputs,
+    _trading_dates,
     load_modal_runtime_config,
     main,
     run_daily_layer1,
@@ -51,6 +53,45 @@ from tests.fixtures.layer1_support import (
     local_writer,
     seed_layer0_archives,
 )
+
+
+def _write_raw_price_frame(writer: R2Writer, ticker: str, frame: pd.DataFrame) -> None:
+    """Write a raw price parquet frame to the local object store."""
+    buffer = io.BytesIO()
+    frame.to_parquet(buffer, index=False)
+    writer.put_object(raw_price_path(ticker), buffer.getvalue())
+
+
+def _price_frame_without_memorial_day(
+    ticker: str,
+    *,
+    missing_dates: tuple[str, ...],
+) -> pd.DataFrame:
+    """Return synthetic 2026 price history with Memorial Day absent."""
+    missing = set(missing_dates)
+    rows: list[dict[str, object]] = []
+    close = 100.0 if ticker != "SPY" else 400.0
+    dates = [
+        day.date().isoformat()
+        for day in pd.bdate_range("2026-02-02", "2026-05-26")
+        if day.date().isoformat() != "2026-05-25"
+    ]
+    for index, date_text in enumerate(date for date in dates if date not in missing):
+        close += 0.5
+        rows.append(
+            {
+                "date": date_text,
+                "ticker": ticker,
+                "open": close - 0.25,
+                "high": close + 0.5,
+                "low": close - 0.5,
+                "close": close,
+                "adj_close": close,
+                "volume": 1_000_000 + index,
+                "dollar_volume": close * (1_000_000 + index),
+            }
+        )
+    return pd.DataFrame(rows)
 
 
 def test_run_daily_layer1_happy_path_writes_history_and_completed_manifest(
@@ -566,6 +607,129 @@ def test_run_daily_layer1_fails_closed_when_raw_price_history_misses_target_date
     )
     assert manifest.status is RunStatus.FAILED
     assert "missing target-date coverage" in str(manifest.metadata["error"]["message"])
+
+
+def test_run_daily_layer1_skips_memorial_day_raw_price_requirement(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Market holidays inside a requested Layer 1 window are not required price dates."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2026-05-22", "2026-05-26"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-aapl-memorial-day",),
+    )
+    _write_raw_price_frame(
+        writer,
+        "AAPL",
+        _price_frame_without_memorial_day("AAPL", missing_dates=()),
+    )
+    _write_raw_price_frame(
+        writer,
+        "SPY",
+        _price_frame_without_memorial_day("SPY", missing_dates=()),
+    )
+
+    result = run_daily_layer1(
+        Layer1DailyConfig(
+            run_id="layer1-aapl-memorial-day",
+            from_date="2026-05-22",
+            to_date="2026-05-26",
+            tickers=("AAPL",),
+        ),
+        writer=writer,
+        news_runner=fake_news_runner(writer, ["AAPL"]),
+        text_topic_runner=fake_topic_runner(writer, ["AAPL"]),
+        finbert_runner=fake_sentiment_runner(writer, ["AAPL"]),
+        regime_runner=fake_regime_runner(writer),
+        validation_output_dir=tmp_path / "reports",
+        now=datetime(2026, 5, 26, 22, 0, tzinfo=UTC),
+    )
+
+    manifest = PipelineManifestRecord.model_validate_json(writer.get_object(result.manifest_key))
+
+    assert _trading_dates("2026-05-22", "2026-05-26") == (
+        "2026-05-22",
+        "2026-05-26",
+    )
+    assert _previous_business_day("2026-05-26") == "2026-05-22"
+    assert result.processed_dates == ("2026-05-22", "2026-05-26")
+    assert manifest.status is RunStatus.COMPLETED
+    assert manifest.metadata["requested_calendar_dates"] == [
+        "2026-05-22",
+        "2026-05-23",
+        "2026-05-24",
+        "2026-05-25",
+        "2026-05-26",
+    ]
+    assert manifest.metadata["skipped_non_trading_dates"] == [
+        "2026-05-23",
+        "2026-05-24",
+        "2026-05-25",
+    ]
+    assert writer.exists("features/2026-05-25/AAPL.parquet") is False
+    assert writer.exists("features/2026-05-26/AAPL.parquet") is True
+
+
+def test_run_daily_layer1_still_fails_when_trading_session_price_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing AAPL or SPY raw prices on real sessions still fail closed."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer0_archives(
+        writer,
+        dates=["2026-05-22", "2026-05-26"],
+        tickers=["AAPL"],
+        layer0_run_ids=("layer1-aapl-real-missing-session",),
+    )
+    _write_raw_price_frame(
+        writer,
+        "AAPL",
+        _price_frame_without_memorial_day("AAPL", missing_dates=()),
+    )
+    _write_raw_price_frame(
+        writer,
+        "SPY",
+        _price_frame_without_memorial_day("SPY", missing_dates=("2026-05-26",)),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        run_daily_layer1(
+            Layer1DailyConfig(
+                run_id="layer1-aapl-real-missing-session",
+                from_date="2026-05-22",
+                to_date="2026-05-26",
+                tickers=("AAPL",),
+            ),
+            writer=writer,
+            news_runner=fake_news_runner(writer, ["AAPL"]),
+            text_topic_runner=fake_topic_runner(writer, ["AAPL"]),
+            finbert_runner=fake_sentiment_runner(writer, ["AAPL"]),
+            regime_runner=fake_regime_runner(writer),
+            validation_output_dir=tmp_path / "reports",
+        )
+
+    manifest = PipelineManifestRecord.model_validate_json(
+        writer.get_object(
+            pipeline_manifest_path(LAYER1_DAILY_STAGE, "layer1-aapl-real-missing-session")
+        )
+    )
+
+    assert "SPY=[2026-05-26]" in str(exc_info.value)
+    assert "2026-05-25" not in str(exc_info.value).split("SPY=[2026-05-26]")[0]
+    assert "skipped_non_trading_dates=[2026-05-23,2026-05-24,2026-05-25]" in str(
+        exc_info.value
+    )
+    assert manifest.status is RunStatus.FAILED
+    assert manifest.metadata["skipped_non_trading_dates"] == [
+        "2026-05-23",
+        "2026-05-24",
+        "2026-05-25",
+    ]
+    assert "SPY=[2026-05-26]" in str(manifest.metadata["error"]["message"])
 
 
 def test_run_daily_layer1_recovers_macro_inputs_without_target_date_snapshot_key(

--- a/tests/unit/test_modal_runner_entrypoints.py
+++ b/tests/unit/test_modal_runner_entrypoints.py
@@ -494,7 +494,7 @@ def test_daily_layer1_modal_main_orchestrates_stage_apps_before_final_assembly(
         {
             "run_id": "smoke-daily-2024-01-02",
             "train_start_date": "2023-10-01",
-            "train_end_date": "2024-01-01",
+            "train_end_date": "2023-12-29",
             "inference_dates": "2024-01-02",
             "benchmark_ticker": "SPY",
             "max_iterations": 77,
@@ -631,7 +631,7 @@ def test_daily_layer1_modal_main_reuses_completed_stage_outputs_when_present(
         {
             "run_id": "resume-daily-2024-01-02",
             "train_start_date": None,
-            "train_end_date": "2024-01-01",
+            "train_end_date": "2023-12-29",
             "inference_dates": "2024-01-02",
             "benchmark_ticker": "SPY",
             "max_iterations": 100,


### PR DESCRIPTION
## What this PR does
Fixes Layer 1 date-window handling so requested calendar windows are converted to regular US equity trading sessions before upstream archive and target-date raw-price coverage checks run. Non-trading dates, including weekends and market holidays such as 2026-05-25, are recorded in manifest metadata as skipped, while missing AAPL/SPY coverage on real trading sessions still fails closed.

## Closes
Closes #218

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — awaiting human review

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
- `./.venv/bin/pytest tests/unit/ -v --tb=short`: 706 passed, 1 skipped, 8 warnings
- `./.venv/bin/ruff check app/lab/data_pipelines/run_daily_layer1.py tests/unit/test_daily_layer1_runner.py tests/unit/test_modal_runner_entrypoints.py`: passed

## Notes for reviewer
The session helper covers regular full-day US equity market holidays and updates prior-training-session derivation, so 2024-01-02 now correctly uses 2023-12-29 as the previous trading session. The AAPL pilot still must be rerun after merge before #202 proceeds.