### PR TITLE
Extend Layer 1 news preprocessing records

### DIFF
--- a/core/contracts/schemas.py
+++ b/core/contracts/schemas.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-SCHEMA_VERSION = "1.2.0"
+SCHEMA_VERSION = "1.3.0"
 
 
 class ActionType(StrEnum):
@@ -67,12 +67,19 @@ class NewsSentimentRecord(BaseModel):
     date: str
     ticker: str
     headline: str | None = None
+    normalized_headline: str | None = None
     text: str | None = None
     article_id: str | None = None
     sentence_index: int | None = Field(default=None, ge=0)
+    chunk_index: int | None = Field(default=None, ge=0)
     source: str | None = None
     url: str | None = None
     published_at: datetime | None = None
+    source_text_field: str | None = None
+    source_text_order: int | None = Field(default=None, ge=0)
+    source_text_provenance: dict[str, Any] = Field(default_factory=dict)
+    ticker_mentions: tuple[str, ...] = Field(default_factory=tuple)
+    entity_mentions: tuple[str, ...] = Field(default_factory=tuple)
     sentiment_positive: float | None = Field(default=None, ge=0.0, le=1.0)
     sentiment_negative: float | None = Field(default=None, ge=0.0, le=1.0)
     sentiment_neutral: float | None = Field(default=None, ge=0.0, le=1.0)

--- a/core/features/news_preprocessing.py
+++ b/core/features/news_preprocessing.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import math
 import re
 from collections.abc import Iterable, Mapping, Sequence
@@ -15,6 +16,39 @@ from services.wikipedia.sp500_universe import canonicalize_ticker
 
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[\"'A-Z0-9])")
 _WHITESPACE = re.compile(r"\s+")
+_TICKER_TEXT_PATTERN = re.compile(r"\b[A-Z][A-Z0-9.-]{0,6}\b")
+_ENTITY_PHRASE_PATTERN = re.compile(
+    r"\b(?:[A-Z][a-z0-9&]+(?:\s+[A-Z][a-z0-9&]+){0,3}|[A-Z]{2,}(?:\s+[A-Z]{2,})*)\b"
+)
+_ENTITY_STOPWORDS = frozenset(
+    {
+        "article",
+        "earnings",
+        "full",
+        "new",
+        "product",
+        "quarterly",
+        "reported",
+        "reports",
+        "results",
+        "shares",
+        "text",
+    }
+)
+_ENTITY_ALIAS_RULES: tuple[tuple[str, str], ...] = (
+    ("apple inc", "Apple"),
+    ("apple", "Apple"),
+    ("berkshire hathaway", "Berkshire Hathaway"),
+    ("federal reserve", "Federal Reserve"),
+    ("meta platforms", "Meta Platforms"),
+    ("meta", "Meta Platforms"),
+    ("microsoft corporation", "Microsoft"),
+    ("microsoft corp", "Microsoft"),
+    ("microsoft", "Microsoft"),
+    ("s&p 500", "S&P 500"),
+    ("spdr s&p 500 etf trust", "SPY"),
+    ("sec", "SEC"),
+)
 
 
 @dataclass(frozen=True)
@@ -34,6 +68,52 @@ class NewsPreprocessingConfig:
             raise ValueError("At least one text field must be included")
 
 
+@dataclass(frozen=True)
+class NewsTextChunk:
+    """One reviewable sentence/chunk extracted from a raw news article."""
+
+    text: str
+    source_field: str
+    source_order: int
+    chunk_index: int
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        return {
+            "text": self.text,
+            "source_field": self.source_field,
+            "source_order": self.source_order,
+            "chunk_index": self.chunk_index,
+        }
+
+
+def split_article_chunks(
+    article: Mapping[str, Any],
+    *,
+    config: NewsPreprocessingConfig | None = None,
+) -> list[NewsTextChunk]:
+    """Return reviewable sentence/chunk rows with per-field provenance preserved."""
+    settings = config or NewsPreprocessingConfig()
+    chunks: list[NewsTextChunk] = []
+    for source_field, include_field in (
+        ("headline", settings.include_headline),
+        ("summary", settings.include_summary),
+        ("content", settings.include_content),
+    ):
+        if not include_field:
+            continue
+        for source_order, sentence in enumerate(_sentences_from_text(article.get(source_field), settings=settings)):
+            chunks.append(
+                NewsTextChunk(
+                    text=sentence,
+                    source_field=source_field,
+                    source_order=source_order,
+                    chunk_index=len(chunks),
+                )
+            )
+    return chunks
+
+
 def preprocess_news_articles(
     articles: Sequence[Mapping[str, Any]],
     *,
@@ -41,42 +121,69 @@ def preprocess_news_articles(
     point_in_time_tickers: Iterable[str] | None,
     config: NewsPreprocessingConfig | None = None,
 ) -> list[NewsSentimentRecord]:
-    """Convert raw Layer 0 news articles into sentence-level sentiment records."""
+    """Convert raw Layer 0 news articles into reviewable sentence/chunk records."""
     normalized_date = _validate_date(as_of_date)
     settings = config or NewsPreprocessingConfig()
     allowed_tickers = _normalize_allowed_tickers(point_in_time_tickers)
 
     records: list[NewsSentimentRecord] = []
     for article in articles:
-        article_tickers = _article_tickers(article)
+        article_tickers = sorted(
+            {
+                *_article_tickers(article),
+                *_article_text_tickers(article, allowed_tickers),
+            }
+        )
         if allowed_tickers is not None:
             article_tickers = sorted(ticker for ticker in article_tickers if ticker in allowed_tickers)
         if not article_tickers:
             continue
 
-        sentences = split_article_sentences(article, config=settings)
-        if not sentences:
-            continue
-
         article_id = _article_id(article)
         headline = _optional_text(article.get("headline"))
+        normalized_headline = _normalize_headline(headline)
         source = _optional_text(article.get("source") or article.get("author"))
         url = _optional_text(article.get("url"))
         published_at = _published_at(article)
+        chunks = split_article_chunks(article, config=settings)
+        if not chunks:
+            continue
 
-        for sentence_index, sentence in enumerate(sentences):
+        for chunk in chunks:
+            chunk_tickers = tuple(_ticker_mentions(chunk.text, article_tickers, allowed_tickers))
+            entity_mentions = tuple(_entity_mentions(chunk.text, headline=headline))
+            provenance = _source_text_provenance(
+                article=article,
+                article_id=article_id,
+                headline=headline,
+                normalized_headline=normalized_headline,
+                chunk=chunk,
+                article_tickers=article_tickers,
+                chunk_tickers=chunk_tickers,
+                entity_mentions=entity_mentions,
+            )
             for ticker in article_tickers:
+                record_ticker_mentions = tuple(
+                    _dedupe_preserving_order([ticker, *chunk_tickers])
+                )
                 records.append(
                     NewsSentimentRecord(
                         date=normalized_date,
                         ticker=ticker,
                         headline=headline,
-                        text=sentence,
+                        normalized_headline=normalized_headline,
+                        text=chunk.text,
                         article_id=article_id,
-                        sentence_index=sentence_index,
+                        sentence_index=chunk.chunk_index,
+                        chunk_index=chunk.chunk_index,
                         source=source,
                         url=url,
                         published_at=published_at,
+                        source_text_field=chunk.source_field,
+                        source_text_order=chunk.source_order,
+                        source_text_provenance=provenance,
+                        ticker_mentions=record_ticker_mentions,
+                        entity_mentions=entity_mentions,
                     )
                 )
 
@@ -97,15 +204,9 @@ def split_article_sentences(
     config: NewsPreprocessingConfig | None = None,
 ) -> list[str]:
     """Return normalized article sentences from configured raw text fields."""
-    settings = config or NewsPreprocessingConfig()
-    chunks: list[str] = []
-    if settings.include_headline:
-        chunks.extend(_sentences_from_text(article.get("headline"), settings=settings))
-    if settings.include_summary:
-        chunks.extend(_sentences_from_text(article.get("summary"), settings=settings))
-    if settings.include_content:
-        chunks.extend(_sentences_from_text(article.get("content"), settings=settings))
-    return _dedupe_preserving_order(chunks)
+    return _dedupe_preserving_order(
+        chunk.text for chunk in split_article_chunks(article, config=config)
+    )
 
 
 def records_to_news_sentiment_frame(records: Sequence[NewsSentimentRecord]) -> Any:
@@ -116,12 +217,19 @@ def records_to_news_sentiment_frame(records: Sequence[NewsSentimentRecord]) -> A
             "date": record.date,
             "ticker": record.ticker,
             "headline": record.headline,
+            "normalized_headline": record.normalized_headline,
             "text": record.text,
             "article_id": record.article_id,
             "sentence_index": record.sentence_index,
+            "chunk_index": record.chunk_index,
             "source": record.source,
             "url": record.url,
             "published_at": record.published_at.isoformat() if record.published_at else None,
+            "source_text_field": record.source_text_field,
+            "source_text_order": record.source_text_order,
+            "source_text_provenance": json.dumps(record.source_text_provenance, sort_keys=True),
+            "ticker_mentions": json.dumps(list(record.ticker_mentions)),
+            "entity_mentions": json.dumps(list(record.entity_mentions)),
             "sentiment_positive": record.sentiment_positive,
             "sentiment_negative": record.sentiment_negative,
             "sentiment_neutral": record.sentiment_neutral,
@@ -142,12 +250,19 @@ def news_sentiment_frame_to_records(frame: Any) -> list[NewsSentimentRecord]:
                 date=str(row["date"]),
                 ticker=str(row["ticker"]),
                 headline=_optional_text(row.get("headline")),
+                normalized_headline=_optional_text(row.get("normalized_headline")),
                 text=_optional_text(row.get("text")),
                 article_id=_optional_text(row.get("article_id")),
                 sentence_index=_optional_int(row.get("sentence_index")),
+                chunk_index=_optional_int(row.get("chunk_index")),
                 source=_optional_text(row.get("source")),
                 url=_optional_text(row.get("url")),
                 published_at=_optional_datetime(row.get("published_at")),
+                source_text_field=_optional_text(row.get("source_text_field")),
+                source_text_order=_optional_int(row.get("source_text_order")),
+                source_text_provenance=_optional_json_object(row.get("source_text_provenance")),
+                ticker_mentions=tuple(_optional_json_list(row.get("ticker_mentions"))),
+                entity_mentions=tuple(_optional_json_list(row.get("entity_mentions"))),
                 sentiment_positive=_optional_float(row.get("sentiment_positive")),
                 sentiment_negative=_optional_float(row.get("sentiment_negative")),
                 sentiment_neutral=_optional_float(row.get("sentiment_neutral")),
@@ -162,12 +277,19 @@ _NEWS_SENTIMENT_COLUMNS: tuple[str, ...] = (
     "date",
     "ticker",
     "headline",
+    "normalized_headline",
     "text",
     "article_id",
     "sentence_index",
+    "chunk_index",
     "source",
     "url",
     "published_at",
+    "source_text_field",
+    "source_text_order",
+    "source_text_provenance",
+    "ticker_mentions",
+    "entity_mentions",
     "sentiment_positive",
     "sentiment_negative",
     "sentiment_neutral",
@@ -194,11 +316,34 @@ def _article_tickers(article: Mapping[str, Any]) -> list[str]:
     return sorted(tickers)
 
 
+def _article_text_tickers(
+    article: Mapping[str, Any],
+    allowed_tickers: set[str] | None,
+) -> list[str]:
+    """Return tickers detected from raw article text when point-in-time filtering is available."""
+    if allowed_tickers is None:
+        return []
+
+    combined_text = " ".join(
+        _optional_text(article.get(field)) or "" for field in ("headline", "summary", "content")
+    ).strip()
+    if not combined_text:
+        return []
+
+    tickers: list[str] = []
+    for candidate in _TICKER_TEXT_PATTERN.findall(combined_text):
+        canonical = canonicalize_ticker(candidate)
+        if canonical and canonical in allowed_tickers:
+            tickers.append(canonical)
+    return _dedupe_preserving_order(tickers)
+
+
 def _normalize_allowed_tickers(tickers: Iterable[str] | None) -> set[str] | None:
     """Return normalized point-in-time ticker allow-list, or None when disabled."""
     if tickers is None:
         return None
-    return {canonicalize_ticker(ticker) for ticker in tickers if str(ticker).strip()}
+    normalized = {canonicalize_ticker(ticker) for ticker in tickers if str(ticker).strip()}
+    return {ticker for ticker in normalized if ticker}
 
 
 def _sentences_from_text(value: Any, *, settings: NewsPreprocessingConfig) -> list[str]:
@@ -215,7 +360,7 @@ def _sentences_from_text(value: Any, *, settings: NewsPreprocessingConfig) -> li
     return sentences
 
 
-def _dedupe_preserving_order(values: Sequence[str]) -> list[str]:
+def _dedupe_preserving_order(values: Iterable[str]) -> list[str]:
     """Remove exact duplicate strings without changing first-seen order."""
     seen: set[str] = set()
     deduped: list[str] = []
@@ -287,6 +432,138 @@ def _optional_int(value: Any) -> int | None:
     if numeric is None:
         return None
     return int(numeric)
+
+
+def _normalize_headline(value: str | None) -> str:
+    """Normalize a headline for duplicate detection and auditing."""
+    if not value:
+        return ""
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", value.lower())).strip()
+
+
+def _ticker_mentions(
+    text: str,
+    article_tickers: Sequence[str],
+    allowed_tickers: set[str] | None,
+) -> list[str]:
+    """Return ticker mentions detected from article tags and source text."""
+    mentions: list[str] = []
+    for ticker in article_tickers:
+        mentions.append(ticker)
+    if allowed_tickers is not None:
+        for candidate in _TICKER_TEXT_PATTERN.findall(text or ""):
+            canonical = canonicalize_ticker(candidate)
+            if canonical and canonical in allowed_tickers:
+                mentions.append(canonical)
+    return _dedupe_preserving_order(mentions)
+
+
+def _entity_mentions(text: str, *, headline: str | None = None) -> list[str]:
+    """Return auditable entity mentions detected from the article text."""
+    combined_text = " ".join(part for part in (headline, text) if part).strip()
+    if not combined_text:
+        return []
+
+    normalized = combined_text.lower()
+    mentions: list[str] = []
+    for alias, entity in _ENTITY_ALIAS_RULES:
+        if _text_contains_term(normalized, alias):
+            mentions.append(entity)
+
+    if mentions:
+        return _dedupe_preserving_order(mentions)
+
+    for phrase in _ENTITY_PHRASE_PATTERN.findall(combined_text):
+        cleaned = phrase.strip()
+        if not cleaned:
+            continue
+        if cleaned.lower() in _ENTITY_STOPWORDS:
+            continue
+        if all(token.lower() in _ENTITY_STOPWORDS for token in cleaned.split()):
+            continue
+        mentions.append(cleaned)
+    return _dedupe_preserving_order(mentions)
+
+
+def _source_text_provenance(
+    *,
+    article: Mapping[str, Any],
+    article_id: str,
+    headline: str | None,
+    normalized_headline: str,
+    chunk: NewsTextChunk,
+    article_tickers: Sequence[str],
+    chunk_tickers: Sequence[str],
+    entity_mentions: Sequence[str],
+) -> dict[str, Any]:
+    """Return raw article and chunk provenance for one preprocessed row."""
+    published_at = _published_at(article)
+    return {
+        "article_id": article_id,
+        "source_field": chunk.source_field,
+        "source_order": chunk.source_order,
+        "chunk_index": chunk.chunk_index,
+        "headline": headline,
+        "normalized_headline": normalized_headline,
+        "source": _optional_text(article.get("source") or article.get("author")),
+        "published_at": published_at.isoformat() if published_at else None,
+        "raw_headline": _optional_text(article.get("headline")),
+        "raw_summary": _optional_text(article.get("summary")),
+        "raw_content": _optional_text(article.get("content")),
+        "source_field_text": _optional_text(article.get(chunk.source_field)),
+        "article_tickers": list(article_tickers),
+        "chunk_tickers": list(chunk_tickers),
+        "entity_mentions": list(entity_mentions),
+    }
+
+
+def _optional_json_object(value: Any) -> dict[str, Any]:
+    """Return a JSON object or an empty dictionary for missing values."""
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return {}
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
+
+
+def _optional_json_list(value: Any) -> list[str]:
+    """Return a JSON list or an empty list for missing values."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [str(item) for item in value if _optional_text(item) is not None]
+    if isinstance(value, tuple):
+        return [str(item) for item in value if _optional_text(item) is not None]
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return []
+        if not isinstance(parsed, list):
+            return []
+        return [str(item) for item in parsed if _optional_text(item) is not None]
+    return []
+
+
+def _text_contains_term(text: str, term: str) -> bool:
+    """Return True when a normalized term appears in text."""
+    if not text or not term:
+        return False
+    if " " in term:
+        return term in text.lower()
+    return re.search(rf"\b{re.escape(term.lower())}\b", text.lower()) is not None
 
 
 def _validate_date(value: str) -> str:

--- a/data/sample/contracts_schema_records.json
+++ b/data/sample/contracts_schema_records.json
@@ -87,6 +87,6 @@
     "created_at": "2026-04-06T21:00:00",
     "stage": "validation",
     "bundle_path": "artifacts/bundles/xgb-v1.tar.gz",
-    "schema_version": "1.2.0"
+    "schema_version": "1.3.0"
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,7 +206,7 @@ r2/
     YYYY-MM-DD/       # Canonical date-first Layer 1 feature partition
       TICKER.parquet  # Complete FeatureRecord shard for one date/ticker
       regime/         # Colocated Layer 1.5 regime artifacts for the date
-      news_sentiment/ # Sentence-level NewsSentimentRecord rows from Modal preprocessing
+      news_sentiment/ # Layer 1 news preprocessing rows with article and chunk provenance
       text_embeddings/# Sentence embedding cache keyed by pinned model/version
       topic_labels/   # Sentence-level BERTopic labels from Modal
       topic_features/ # Ticker-day FeatureRecord topic summaries
@@ -272,7 +272,8 @@ Responsibilities:
 - avoid survivorship bias — use historical constituent lists, never today's index
 - apply daily liquidity and tradeability filters
 - use Alpaca delayed SIP adjusted OHLCV as the canonical historical market data store
-- ingest raw Alpaca news with point-in-time timestamps and raw text
+- ingest raw Alpaca news with point-in-time timestamps and raw text, then convert it into
+  sentence/chunk rows that preserve article provenance and auditable ticker/entity evidence
 - ingest SimFin as-reported fundamentals and earnings dates as point-in-time raw context,
   with public SEC company-facts fallback when SimFin has a provider gap
 - ingest FRED macro and rate series as point-in-time raw context

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -227,12 +227,19 @@ Fields:
 - `date`
 - `ticker`
 - `headline`
+- `normalized_headline`
 - `text`
 - `article_id`
 - `sentence_index`
+- `chunk_index`
 - `source`
 - `url`
 - `published_at`
+- `source_text_field`
+- `source_text_order`
+- `source_text_provenance`
+- `ticker_mentions`
+- `entity_mentions`
 - `sentiment_positive`
 - `sentiment_negative`
 - `sentiment_neutral`
@@ -247,8 +254,12 @@ Use cases:
 
 Input note:
 - generated from Layer 0 raw point-in-time news archives
-- sentence-level preprocessing rows should populate `text`, `article_id`, and
-  `sentence_index`; aggregated ticker-day rows may leave those fields unset
+- preprocessing rows should preserve article provenance in `article_id`, `headline`,
+  `normalized_headline`, `source`, `url`, `published_at`, `source_text_field`,
+  `source_text_order`, and `source_text_provenance`
+- sentence/chunk rows should populate `text`, `sentence_index`, `chunk_index`,
+  `ticker_mentions`, and `entity_mentions`; aggregated ticker-day rows may leave those
+  fields unset
 - `published_at` must preserve the raw article timestamp exactly for downstream leakage checks
 
 ### FeatureRecord

--- a/docs/layer1_semantic_review_dashboard.md
+++ b/docs/layer1_semantic_review_dashboard.md
@@ -32,6 +32,10 @@ support is flagged and kept out of the default acceptance path.
 This prevents unrelated or weakly relevant rows from silently dominating the
 review queue.
 
+Upstream preprocessing rows also carry `normalized_headline`, `ticker_mentions`,
+`entity_mentions`, and `source_text_provenance` so the dashboard can explain why
+an article was considered AAPL-relevant before FinBERT scoring.
+
 ## Local run
 
 ```bash
@@ -80,9 +84,14 @@ Each `articles[]` entry contains:
 - `evidence_snippets`
 - `sentence_rows[]`
 
-Each `sentence_rows[]` entry contains:
+Each sentence_rows[] entry contains:
 
 - `sentence_index`
+- `chunk_index`
+- `source_text_field`
+- `source_text_order`
+- `ticker_mentions`
+- `entity_mentions`
 - `text`
 - FinBERT probabilities and score
 - `row_granularity: "sentence-level"`

--- a/tests/unit/test_news_preprocessing.py
+++ b/tests/unit/test_news_preprocessing.py
@@ -1,74 +1,108 @@
 from __future__ import annotations
 
-import io
 from datetime import UTC
 
-import pandas as pd
-
-from core.contracts.schemas import NewsSentimentRecord
 from core.features.news_preprocessing import (
     NewsPreprocessingConfig,
     news_sentiment_frame_to_records,
     preprocess_news_articles,
     records_to_news_sentiment_frame,
+    split_article_chunks,
     split_article_sentences,
 )
 
 
-def test_preprocess_news_articles_emits_sentence_records_for_multiple_alias_tickers() -> None:
-    """Raw Alpaca symbols are normalized and expanded into per-ticker sentence rows."""
+def test_split_article_chunks_preserves_source_field_provenance() -> None:
+    """Sentence/chunk rows preserve their source field instead of deduping provenance away."""
+    article = {
+        "headline": "Apple moves higher.",
+        "summary": "Apple moves higher.",
+        "content": "Apple moves higher.",
+    }
+
+    chunks = split_article_chunks(article)
+    sentences = split_article_sentences(article)
+
+    assert [chunk.source_field for chunk in chunks] == ["headline", "summary", "content"]
+    assert [chunk.source_order for chunk in chunks] == [0, 0, 0]
+    assert [chunk.chunk_index for chunk in chunks] == [0, 1, 2]
+    assert [chunk.text for chunk in chunks] == ["Apple moves higher."] * 3
+    assert sentences == ["Apple moves higher."]
+
+
+def test_preprocess_news_articles_tags_tickers_entities_and_provenance() -> None:
+    """AAPL, competitor-only, broad-market, and irrelevant article examples are handled cleanly."""
     articles = [
         {
             "id": 1001,
-            "headline": "Apple and Berkshire rally.",
-            "summary": "Apple Inc. reported earnings. Berkshire also gained!",
-            "content": "Apple Inc. reported earnings. Berkshire also gained!",
+            "headline": "Apple releases quarterly results.",
+            "summary": "Apple reported quarterly earnings.",
+            "content": "Full article text for Apple earnings.",
             "source": "benzinga",
-            "url": "https://example.test/article",
+            "url": "https://example.test/apple",
             "created_at": "2024-01-02T12:00:00+00:00",
-            "symbols": ["AAPL", "BRK.B", "FB", "NOTIN"],
-        }
+            "symbols": ["AAPL"],
+        },
+        {
+            "id": 1002,
+            "headline": "Microsoft announces new product.",
+            "summary": "Microsoft expanded its product line.",
+            "content": "Full article text for Microsoft product.",
+            "source": "benzinga",
+            "url": "https://example.test/microsoft",
+            "created_at": "2024-01-02T13:00:00+00:00",
+            "symbols": ["MSFT"],
+        },
+        {
+            "id": 1003,
+            "headline": "S&P 500 rises as Fed holds rates.",
+            "summary": "Federal Reserve signaled patience.",
+            "content": "Broad market trading stayed orderly.",
+            "source": "benzinga",
+            "url": "https://example.test/market",
+            "created_at": "2024-01-02T14:00:00+00:00",
+            "symbols": ["SPY"],
+        },
+        {
+            "id": 1004,
+            "headline": "Local bakery opens a new store.",
+            "summary": "Neighborhood foot traffic increased.",
+            "content": "Irrelevant local news.",
+            "source": "benzinga",
+            "url": "https://example.test/irrelevant",
+            "created_at": "2024-01-02T15:00:00+00:00",
+            "symbols": [],
+        },
     ]
 
     records = preprocess_news_articles(
         articles,
         as_of_date="2024-01-02",
-        point_in_time_tickers=["AAPL", "BRK-B", "META"],
+        point_in_time_tickers=None,
     )
 
-    assert {(record.ticker, record.sentence_index) for record in records} == {
-        ("AAPL", 0),
-        ("BRK-B", 0),
-        ("META", 0),
-        ("AAPL", 1),
-        ("BRK-B", 1),
-        ("META", 1),
-        ("AAPL", 2),
-        ("BRK-B", 2),
-        ("META", 2),
-    }
-    assert all(isinstance(record, NewsSentimentRecord) for record in records)
-    assert all(record.article_id == "1001" for record in records)
-    assert all(record.headline == "Apple and Berkshire rally." for record in records)
-    assert all(record.published_at is not None for record in records)
-    assert records[0].published_at.isoformat() == "2024-01-02T12:00:00+00:00"
+    assert {record.ticker for record in records} == {"AAPL", "MSFT", "SPY"}
+    assert all(record.article_id in {"1001", "1002", "1003"} for record in records)
+    assert all(record.source_text_provenance["article_id"] == record.article_id for record in records)
+    assert all(record.source_text_provenance["chunk_index"] == record.chunk_index for record in records)
 
+    aapl_records = [record for record in records if record.ticker == "AAPL"]
+    assert {record.source_text_field for record in aapl_records} == {"headline", "summary", "content"}
+    assert all(record.normalized_headline == "apple releases quarterly results" for record in aapl_records)
+    assert all(record.ticker_mentions == ("AAPL",) for record in aapl_records)
+    assert all("Apple" in record.entity_mentions for record in aapl_records)
+    assert aapl_records[0].headline == "Apple releases quarterly results."
+    assert aapl_records[0].published_at is not None
+    assert aapl_records[0].published_at.isoformat() == "2024-01-02T12:00:00+00:00"
+    assert aapl_records[0].source_text_provenance["raw_headline"] == "Apple releases quarterly results."
 
-def test_split_article_sentences_handles_abbreviations_and_deduplicates() -> None:
-    """Sentence splitting avoids common abbreviation splits and removes duplicate text."""
-    article = {
-        "headline": "U.S. stocks rose.",
-        "summary": "Apple Inc. reported earnings. Shares rose!",
-        "content": "Apple Inc. reported earnings. Shares rose!",
-    }
+    msft_records = [record for record in records if record.ticker == "MSFT"]
+    assert all("Microsoft" in record.entity_mentions for record in msft_records)
+    assert all(record.ticker_mentions == ("MSFT",) for record in msft_records)
 
-    sentences = split_article_sentences(article)
-
-    assert sentences == [
-        "U.S. stocks rose.",
-        "Apple Inc. reported earnings.",
-        "Shares rose!",
-    ]
+    spy_records = [record for record in records if record.ticker == "SPY"]
+    assert all(any(entity in record.entity_mentions for entity in {"S&P 500", "Federal Reserve"}) for record in spy_records)
+    assert all(record.ticker_mentions == ("SPY",) for record in spy_records)
 
 
 def test_preprocess_news_articles_filters_empty_text_and_missing_universe_symbols() -> None:
@@ -86,8 +120,8 @@ def test_preprocess_news_articles_filters_empty_text_and_missing_universe_symbol
     assert records == []
 
 
-def test_news_sentiment_frame_round_trips_records() -> None:
-    """Preprocessed records serialize to a Parquet-ready frame and back."""
+def test_news_sentiment_frame_round_trips_records_with_provenance() -> None:
+    """Preprocessed records serialize to a frame and back without losing provenance."""
     records = preprocess_news_articles(
         [
             {
@@ -102,15 +136,17 @@ def test_news_sentiment_frame_round_trips_records() -> None:
     )
 
     frame = records_to_news_sentiment_frame(records)
-    restored = news_sentiment_frame_to_records(pd.read_parquet(_to_parquet(frame)))
+    restored = news_sentiment_frame_to_records(frame)
 
     assert restored == records
     assert restored[0].published_at.tzinfo == UTC
-
-
-def _to_parquet(frame: pd.DataFrame) -> io.BytesIO:
-    """Serialize a frame to an in-memory Parquet buffer."""
-    buffer = io.BytesIO()
-    frame.to_parquet(buffer, index=False)
-    buffer.seek(0)
-    return buffer
+    assert restored[0].ticker_mentions == ("AAPL",)
+    assert restored[0].entity_mentions == ("Apple",)
+    assert set(frame.columns) >= {
+        "normalized_headline",
+        "chunk_index",
+        "source_text_field",
+        "source_text_provenance",
+        "ticker_mentions",
+        "entity_mentions",
+    }


### PR DESCRIPTION
## Summary
- Extend Layer 1 news preprocessing rows with provenance, normalized headline, chunk provenance, and ticker/entity mention fields
- Update the shared contract sample plus docs for the new news preprocessing shape
- Replace unit tests to cover AAPL, competitor-only, broad-market, and irrelevant article cases

## Verification
- HOME=/home/juyoungoh /home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/pytest tests/unit/ -v --tb=short
- HOME=/home/juyoungoh /home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/ruff check .

Closes #226