### PR TITLE
Implement Layer 1 semantic sentiment aggregation

### DIFF
--- a/app/lab/data_pipelines/run_finbert_sentiment.py
+++ b/app/lab/data_pipelines/run_finbert_sentiment.py
@@ -192,18 +192,20 @@ def run_finbert_sentiment(
             _load_preprocessed_news_records(active_writer, config.preprocessed_news_key),
             config.tickers,
         )
+        embedding_frame = (
+            _load_parquet_frame(active_writer, config.embedding_key)
+            if config.embedding_key is not None
+            else None
+        )
+        topic_label_frame = (
+            _load_parquet_frame(active_writer, config.topic_label_key)
+            if config.topic_label_key is not None
+            else None
+        )
         relevance_result = apply_news_relevance_gate(
             records,
-            embeddings=(
-                _load_parquet_frame(active_writer, config.embedding_key)
-                if config.embedding_key is not None
-                else None
-            ),
-            topic_labels=(
-                _load_parquet_frame(active_writer, config.topic_label_key)
-                if config.topic_label_key is not None
-                else None
-            ),
+            embeddings=embedding_frame,
+            topic_labels=topic_label_frame,
         )
         active_writer.put_object(
             relevance_gate_key,
@@ -221,6 +223,8 @@ def run_finbert_sentiment(
         )
         feature_records = sentiment_feature_records_from_scored_news(
             scored_frame,
+            topic_labels=topic_label_frame,
+            relevance_gate=relevance_result.audit_frame,
             credibility_config=credibility_config,
             bucket_timezone=runtime.bucket_timezone,
         )
@@ -239,6 +243,13 @@ def run_finbert_sentiment(
                 "relevance_rejected_rows": relevance_result.rejected_rows,
                 "scored_rows": len(scored_records),
                 "feature_rows": len(feature_records),
+                "semantic_aggregation": {
+                    "topic_labels_loaded": topic_label_frame is not None,
+                    "relevance_gate_loaded": True,
+                    "source_credibility_config_path": str(
+                        runtime.source_credibility_config_path
+                    ),
+                },
             }
         )
         _write_manifest(

--- a/core/features/catalog.py
+++ b/core/features/catalog.py
@@ -254,6 +254,54 @@ def feature_catalog() -> dict[str, FeatureRule]:
         required=False,
         minimum=0.0,
     )
+    for name in (
+        "nlp_source_weight_mean",
+        "nlp_source_weight_sum",
+        "nlp_effective_weight_sum",
+        "nlp_sentiment_topic_count",
+        "nlp_relevance_accepted_count",
+        "nlp_relevance_borderline_count",
+        "nlp_missing_source_count",
+        "nlp_missing_topic_count",
+        "nlp_missing_relevance_evidence_count",
+    ):
+        rules[name] = FeatureRule(
+            owner="sentiment",
+            kind="number",
+            required=False,
+            minimum=0.0,
+        )
+    for name in (
+        "nlp_sentiment_topic_score",
+        "nlp_sentiment_dominant_topic_score",
+    ):
+        rules[name] = FeatureRule(
+            owner="sentiment",
+            kind="number",
+            required=False,
+            minimum=-1.0,
+            maximum=1.0,
+        )
+    rules["nlp_sentiment_dominant_topic_id"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+    )
+    rules["nlp_sentiment_dominant_topic_probability"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    for name in (
+        "nlp_contributing_article_ids",
+        "nlp_topic_sentiment_summary",
+        "nlp_source_weight_summary",
+        "nlp_relevance_reason_codes",
+        "nlp_semantic_warning_codes",
+    ):
+        rules[name] = FeatureRule(owner="sentiment", kind="string", required=False)
 
     rules["regime_label"] = FeatureRule(
         owner="regime",

--- a/core/features/sentiment_features.py
+++ b/core/features/sentiment_features.py
@@ -46,6 +46,29 @@ REQUIRED_SENTIMENT_COLUMNS: frozenset[str] = frozenset(
     }
 )
 
+TOPIC_EVIDENCE_COLUMNS: frozenset[str] = frozenset(
+    {
+        "date",
+        "ticker",
+        "article_id",
+        "topic_id",
+        "topic_probability",
+    }
+)
+
+RELEVANCE_EVIDENCE_COLUMNS: frozenset[str] = frozenset(
+    {
+        "date",
+        "ticker",
+        "article_id",
+        "relevance_decision",
+        "relevance_score",
+        "ticker_relevance_score",
+        "financial_relevance_score",
+        "topic_relevance_score",
+    }
+)
+
 SENTIMENT_FEATURE_COLUMNS: tuple[str, ...] = (
     "nlp_sentiment_positive",
     "nlp_sentiment_negative",
@@ -56,6 +79,24 @@ SENTIMENT_FEATURE_COLUMNS: tuple[str, ...] = (
     "nlp_article_count",
     "nlp_sentence_count",
     "nlp_relevance_score",
+    "nlp_source_weight_mean",
+    "nlp_source_weight_sum",
+    "nlp_effective_weight_sum",
+    "nlp_missing_source_count",
+    "nlp_sentiment_topic_score",
+    "nlp_sentiment_topic_count",
+    "nlp_sentiment_dominant_topic_id",
+    "nlp_sentiment_dominant_topic_score",
+    "nlp_sentiment_dominant_topic_probability",
+    "nlp_relevance_accepted_count",
+    "nlp_relevance_borderline_count",
+    "nlp_missing_topic_count",
+    "nlp_missing_relevance_evidence_count",
+    "nlp_contributing_article_ids",
+    "nlp_topic_sentiment_summary",
+    "nlp_source_weight_summary",
+    "nlp_relevance_reason_codes",
+    "nlp_semantic_warning_codes",
 )
 
 
@@ -237,13 +278,17 @@ def aggregate_sentiment_by_ticker_day(
 def sentiment_feature_records_from_scored_news(
     scored_news: pd.DataFrame,
     *,
+    topic_labels: pd.DataFrame | None = None,
+    relevance_gate: pd.DataFrame | None = None,
     credibility_config: SourceCredibilityConfig | None = None,
     bucket_timezone: str = "America/New_York",
 ) -> list[FeatureRecord]:
-    """Aggregate scored news rows into ticker-day sentiment FeatureRecords."""
+    """Aggregate scored news rows into ticker-day semantic sentiment FeatureRecords."""
     config = _normalized_config(credibility_config or load_source_credibility_config())
     pd, frame = _prepare_scored_news_frame(
         scored_news,
+        topic_labels=topic_labels,
+        relevance_gate=relevance_gate,
         config=config,
         bucket_timezone=bucket_timezone,
     )
@@ -257,6 +302,8 @@ def sentiment_feature_records_from_scored_news(
 
         strength_values = group[["sentiment_positive", "sentiment_negative"]].max(axis=1)
         sentiment_std = group["sentiment_score"].astype(float).std(ddof=0)
+        topic_summary = _topic_sentiment_summary(group)
+        dominant_topic = topic_summary[0] if topic_summary else {}
         records.append(
             FeatureRecord(
                 date=str(date_value),
@@ -282,6 +329,50 @@ def sentiment_feature_records_from_scored_news(
                     "nlp_sentence_count": int(len(group)),
                     "nlp_relevance_score": _weighted_average(
                         group["relevance_score"], group["_source_weight"]
+                    ),
+                    "nlp_source_weight_mean": _mean(group["_source_weight"]),
+                    "nlp_source_weight_sum": _sum_positive(group["_source_weight"]),
+                    "nlp_effective_weight_sum": _sum_positive(group["_effective_weight"]),
+                    "nlp_missing_source_count": _missing_source_count(group),
+                    "nlp_sentiment_topic_score": _weighted_average(
+                        group["sentiment_score"], group["_topic_effective_weight"]
+                    ),
+                    "nlp_sentiment_topic_count": _topic_count(group),
+                    "nlp_sentiment_dominant_topic_id": dominant_topic.get("topic_id"),
+                    "nlp_sentiment_dominant_topic_score": dominant_topic.get(
+                        "sentiment_score"
+                    ),
+                    "nlp_sentiment_dominant_topic_probability": dominant_topic.get(
+                        "mean_topic_probability"
+                    ),
+                    "nlp_relevance_accepted_count": _decision_count(group, "accepted"),
+                    "nlp_relevance_borderline_count": _decision_count(group, "borderline"),
+                    "nlp_missing_topic_count": _missing_topic_count(group),
+                    "nlp_missing_relevance_evidence_count": _missing_relevance_count(group),
+                    "nlp_contributing_article_ids": json.dumps(
+                        _contributing_article_ids(group),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    "nlp_topic_sentiment_summary": json.dumps(
+                        topic_summary,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    "nlp_source_weight_summary": json.dumps(
+                        _source_weight_summary(group),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    "nlp_relevance_reason_codes": json.dumps(
+                        _relevance_reason_codes(group),
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                    "nlp_semantic_warning_codes": json.dumps(
+                        _semantic_warning_codes(group),
+                        sort_keys=True,
+                        separators=(",", ":"),
                     ),
                 },
             )
@@ -329,6 +420,8 @@ def sentiment_aggregates_to_records(aggregates: pd.DataFrame) -> list[NewsSentim
 def _prepare_scored_news_frame(
     scored_news: pd.DataFrame,
     *,
+    topic_labels: pd.DataFrame | None = None,
+    relevance_gate: pd.DataFrame | None = None,
     config: SourceCredibilityConfig,
     bucket_timezone: str,
 ) -> tuple[Any, pd.DataFrame]:
@@ -341,6 +434,10 @@ def _prepare_scored_news_frame(
     if len(frame) == 0:
         return pd, frame
 
+    frame["_artifact_date"] = [
+        _to_iso_date(row.get("date"))
+        for row in frame.to_dict(orient="records")
+    ]
     frame["date"] = [
         _bucket_date(
             row.get("published_at"),
@@ -376,7 +473,206 @@ def _prepare_scored_news_frame(
     )
     frame["_relevance_weight"] = frame["relevance_score"].map(_relevance_weight)
     frame["_effective_weight"] = frame["_source_weight"] * frame["_relevance_weight"]
+    frame = _attach_topic_evidence(pd, frame, topic_labels)
+    frame = _attach_relevance_evidence(pd, frame, relevance_gate)
+    frame["_topic_effective_weight"] = [
+        _topic_effective_weight(row)
+        for row in frame.to_dict(orient="records")
+    ]
     return pd, frame
+
+
+def _attach_topic_evidence(
+    pd: Any,
+    frame: pd.DataFrame,
+    topic_labels: pd.DataFrame | None,
+) -> pd.DataFrame:
+    """Attach article-level topic metadata to scored sentiment rows."""
+    frame = frame.copy()
+    frame["_topic_id"] = None
+    frame["_topic_probability"] = None
+    frame["_topic_embedding_cache_key"] = None
+    frame["_missing_topic_evidence"] = True
+    frame["_missing_topic_artifact"] = topic_labels is None or len(topic_labels) == 0
+    if topic_labels is None or len(topic_labels) == 0:
+        return frame
+
+    _validate_optional_evidence_columns(
+        topic_labels,
+        required=TOPIC_EVIDENCE_COLUMNS,
+        label="topic_labels",
+    )
+    topic_frame = topic_labels.copy()
+    topic_frame["_artifact_date"] = topic_frame["date"].map(_to_iso_date)
+    topic_frame["_join_ticker"] = topic_frame["ticker"].map(_normalize_join_ticker)
+    topic_frame["_join_article_id"] = topic_frame["article_id"].map(_normalize_optional_string)
+    topic_frame = topic_frame.dropna(
+        subset=["_artifact_date", "_join_ticker", "_join_article_id"]
+    )
+    if len(topic_frame) == 0:
+        return frame
+    topic_columns = [
+        "_artifact_date",
+        "_join_ticker",
+        "_join_article_id",
+        "topic_id",
+        "topic_probability",
+    ]
+    if "embedding_cache_key" in topic_frame.columns:
+        topic_columns.append("embedding_cache_key")
+    topic_frame = topic_frame.loc[:, topic_columns].drop_duplicates(
+        subset=["_artifact_date", "_join_ticker", "_join_article_id"],
+        keep="first",
+    )
+    rename_columns = {
+        "topic_id": "_topic_id",
+        "topic_probability": "_topic_probability",
+        "embedding_cache_key": "_topic_embedding_cache_key",
+    }
+    topic_frame = topic_frame.rename(columns=rename_columns)
+    frame["_join_ticker"] = frame["ticker"].map(_normalize_join_ticker)
+    frame["_join_article_id"] = frame.get("article_id", pd.Series(index=frame.index)).map(
+        _normalize_optional_string
+    )
+    frame = frame.drop(
+        columns=[
+            "_topic_id",
+            "_topic_probability",
+            "_topic_embedding_cache_key",
+        ],
+        errors="ignore",
+    ).merge(
+        topic_frame,
+        on=["_artifact_date", "_join_ticker", "_join_article_id"],
+        how="left",
+    )
+    frame["_missing_topic_evidence"] = frame["_topic_id"].map(_to_float_or_none).isna()
+    frame["_missing_topic_artifact"] = False
+    return frame
+
+
+def _attach_relevance_evidence(
+    pd: Any,
+    frame: pd.DataFrame,
+    relevance_gate: pd.DataFrame | None,
+) -> pd.DataFrame:
+    """Attach relevance-gate audit evidence to scored sentiment rows."""
+    frame = frame.copy()
+    for column in (
+        "_relevance_decision",
+        "_ticker_relevance_score",
+        "_financial_relevance_score",
+        "_topic_relevance_score",
+        "_relevance_reason_codes",
+    ):
+        frame[column] = None
+    frame["_missing_relevance_evidence"] = relevance_gate is None or len(relevance_gate) == 0
+    if relevance_gate is None or len(relevance_gate) == 0:
+        return frame
+
+    _validate_optional_evidence_columns(
+        relevance_gate,
+        required=RELEVANCE_EVIDENCE_COLUMNS,
+        label="relevance_gate",
+    )
+    gate_frame = relevance_gate.copy()
+    gate_frame["_artifact_date"] = gate_frame["date"].map(_to_iso_date)
+    gate_frame["_join_ticker"] = gate_frame["ticker"].map(_normalize_join_ticker)
+    gate_frame["_join_article_id"] = gate_frame["article_id"].map(_normalize_optional_string)
+    gate_frame["_join_sentence_index"] = gate_frame.get(
+        "sentence_index",
+        pd.Series(index=gate_frame.index),
+    ).map(_normalize_optional_int)
+    gate_frame["_join_chunk_index"] = gate_frame.get(
+        "chunk_index",
+        pd.Series(index=gate_frame.index),
+    ).map(_normalize_optional_int)
+    gate_frame = gate_frame.dropna(
+        subset=["_artifact_date", "_join_ticker", "_join_article_id"]
+    )
+    if len(gate_frame) == 0:
+        return frame
+    gate_frame = gate_frame.loc[
+        :,
+        [
+            "_artifact_date",
+            "_join_ticker",
+            "_join_article_id",
+            "_join_sentence_index",
+            "_join_chunk_index",
+            "relevance_decision",
+            "ticker_relevance_score",
+            "financial_relevance_score",
+            "topic_relevance_score",
+            "reason_codes",
+        ],
+    ].drop_duplicates(
+        subset=[
+            "_artifact_date",
+            "_join_ticker",
+            "_join_article_id",
+            "_join_sentence_index",
+            "_join_chunk_index",
+        ],
+        keep="first",
+    )
+    gate_frame = gate_frame.rename(
+        columns={
+            "relevance_decision": "_relevance_decision",
+            "ticker_relevance_score": "_ticker_relevance_score",
+            "financial_relevance_score": "_financial_relevance_score",
+            "topic_relevance_score": "_topic_relevance_score",
+            "reason_codes": "_relevance_reason_codes",
+        }
+    )
+    frame["_join_ticker"] = frame["ticker"].map(_normalize_join_ticker)
+    frame["_join_article_id"] = frame.get("article_id", pd.Series(index=frame.index)).map(
+        _normalize_optional_string
+    )
+    frame["_join_sentence_index"] = frame.get(
+        "sentence_index",
+        pd.Series(index=frame.index),
+    ).map(_normalize_optional_int)
+    frame["_join_chunk_index"] = frame.get(
+        "chunk_index",
+        pd.Series(index=frame.index),
+    ).map(_normalize_optional_int)
+    frame = frame.drop(
+        columns=[
+            "_relevance_decision",
+            "_ticker_relevance_score",
+            "_financial_relevance_score",
+            "_topic_relevance_score",
+            "_relevance_reason_codes",
+        ],
+        errors="ignore",
+    ).merge(
+        gate_frame,
+        on=[
+            "_artifact_date",
+            "_join_ticker",
+            "_join_article_id",
+            "_join_sentence_index",
+            "_join_chunk_index",
+        ],
+        how="left",
+    )
+    frame["_missing_relevance_evidence"] = frame["_relevance_decision"].map(
+        _normalize_optional_string
+    ).isna()
+    return frame
+
+
+def _validate_optional_evidence_columns(
+    frame: pd.DataFrame,
+    *,
+    required: frozenset[str],
+    label: str,
+) -> None:
+    """Raise when an optional evidence artifact is present but malformed."""
+    missing = sorted(required - set(frame.columns))
+    if missing:
+        raise ValueError(f"{label} frame missing required columns: {missing}")
 
 
 def _validate_columns(
@@ -448,6 +744,16 @@ def _source_weight(source: Any, *, config: SourceCredibilityConfig) -> float:
     return config.source_weights.get(normalized_source, config.default_source_weight)
 
 
+def _topic_effective_weight(row: Mapping[str, Any]) -> float:
+    """Return the source/relevance/topic confidence product for topic sentiment."""
+    topic_id = _normalize_optional_int(row.get("_topic_id"))
+    probability = _to_float_or_none(row.get("_topic_probability"))
+    effective_weight = _to_float_or_none(row.get("_effective_weight"))
+    if topic_id is None or topic_id < 0 or probability is None or effective_weight is None:
+        return 0.0
+    return max(probability, 0.0) * max(effective_weight, 0.0)
+
+
 def _relevance_weight(value: Any) -> float:
     """Return the non-negative article relevance multiplier."""
     numeric = _to_float_or_none(value)
@@ -472,6 +778,140 @@ def _weighted_average(values: pd.Series, weights: pd.Series) -> float | None:
     return weighted_sum / total_weight
 
 
+def _mean(values: pd.Series) -> float | None:
+    """Return a finite arithmetic mean, or None for empty inputs."""
+    finite = [value for value in values.map(_to_float_or_none).tolist() if value is not None]
+    if not finite:
+        return None
+    return sum(finite) / len(finite)
+
+
+def _sum_positive(values: pd.Series) -> float:
+    """Return the sum of positive finite values."""
+    return sum(
+        value
+        for value in values.map(_to_float_or_none).tolist()
+        if value is not None and value > 0.0
+    )
+
+
+def _topic_count(group: pd.DataFrame) -> int:
+    """Return the count of valid topic ids contributing to sentiment."""
+    topic_ids = [
+        topic_id
+        for topic_id in group["_topic_id"].map(_normalize_optional_int).tolist()
+        if topic_id is not None and topic_id >= 0
+    ]
+    return len(set(topic_ids))
+
+
+def _decision_count(group: pd.DataFrame, decision: str) -> int:
+    """Return the count of rows matching one relevance decision."""
+    return sum(
+        1
+        for value in group["_relevance_decision"].map(_normalize_optional_string).tolist()
+        if value == decision
+    )
+
+
+def _missing_topic_count(group: pd.DataFrame) -> int:
+    """Return the count of scored rows without matching topic evidence."""
+    return int(group["_missing_topic_evidence"].map(bool).sum())
+
+
+def _missing_relevance_count(group: pd.DataFrame) -> int:
+    """Return the count of scored rows without matching relevance-gate evidence."""
+    return int(group["_missing_relevance_evidence"].map(bool).sum())
+
+
+def _missing_source_count(group: pd.DataFrame) -> int:
+    """Return the count of scored rows that fell back to the default source weight."""
+    return sum(
+        1 for value in group["source"].map(_normalize_optional_string).tolist() if value is None
+    )
+
+
+def _contributing_article_ids(group: pd.DataFrame) -> list[str]:
+    """Return sorted unique article ids contributing to a ticker-day aggregate."""
+    if "article_id" not in group.columns:
+        return []
+    return sorted(
+        {
+            article_id
+            for article_id in group["article_id"].map(_normalize_optional_string).tolist()
+            if article_id is not None
+        }
+    )
+
+
+def _topic_sentiment_summary(group: pd.DataFrame) -> list[dict[str, Any]]:
+    """Return per-topic sentiment summaries ordered by topic evidence weight."""
+    valid = group[group["_topic_effective_weight"].map(lambda value: float(value) > 0.0)]
+    if len(valid) == 0:
+        return []
+
+    summaries: list[dict[str, Any]] = []
+    for topic_id, topic_group in valid.groupby("_topic_id", sort=True, dropna=True):
+        topic_weight = _sum_positive(topic_group["_topic_effective_weight"])
+        summaries.append(
+            {
+                "topic_id": _normalize_optional_int(topic_id),
+                "sentence_count": int(len(topic_group)),
+                "article_count": _article_count(topic_group),
+                "weight": topic_weight,
+                "sentiment_score": _weighted_average(
+                    topic_group["sentiment_score"],
+                    topic_group["_topic_effective_weight"],
+                ),
+                "mean_topic_probability": _weighted_average(
+                    topic_group["_topic_probability"],
+                    topic_group["_effective_weight"],
+                ),
+            }
+        )
+    return sorted(
+        summaries,
+        key=lambda row: (-(row["weight"] or 0.0), row["topic_id"] if row["topic_id"] is not None else 0),
+    )
+
+
+def _source_weight_summary(group: pd.DataFrame) -> list[dict[str, Any]]:
+    """Return per-source counts and configured weights used by aggregation."""
+    summary_rows: list[dict[str, Any]] = []
+    for source, source_group in group.groupby("source", sort=True, dropna=False):
+        summary_rows.append(
+            {
+                "source": _normalize_optional_string(source),
+                "source_weight": _mean(source_group["_source_weight"]),
+                "sentence_count": int(len(source_group)),
+                "article_count": _article_count(source_group),
+            }
+        )
+    return summary_rows
+
+
+def _semantic_warning_codes(group: pd.DataFrame) -> list[str]:
+    """Return deterministic warning codes for degraded optional semantic inputs."""
+    warnings: set[str] = set()
+    if _missing_source_count(group) > 0:
+        warnings.add("missing_source_default_weight")
+    if bool(group["_missing_topic_artifact"].any()):
+        warnings.add("missing_topic_artifact")
+    elif _missing_topic_count(group) > 0:
+        warnings.add("missing_topic_evidence")
+    if _missing_relevance_count(group) > 0:
+        warnings.add("missing_relevance_evidence")
+    return sorted(warnings)
+
+
+def _relevance_reason_codes(group: pd.DataFrame) -> list[str]:
+    """Return relevance-gate reason codes that contributed to scored rows."""
+    reason_codes: set[str] = set()
+    for value in group["_relevance_reason_codes"].map(_json_string_list).tolist():
+        reason_codes.update(value)
+    return sorted(reason_codes)
+
+
 def _validate_probability_columns(frame: pd.DataFrame) -> None:
     """Raise when FinBERT probability columns fall outside [0, 1]."""
     for column in ("sentiment_positive", "sentiment_negative", "sentiment_neutral"):
@@ -485,6 +925,12 @@ def _normalize_source(source: Any) -> str:
     if source is None:
         return ""
     return re.sub(r"\s+", " ", str(source).strip().lower())
+
+
+def _normalize_join_ticker(value: Any) -> str | None:
+    """Return uppercase ticker text for evidence joins."""
+    text = _normalize_optional_string(value)
+    return text.upper() if text is not None else None
 
 
 def _to_iso_date(value: Any) -> str | None:
@@ -550,6 +996,31 @@ def _to_float_or_none(value: Any) -> float | None:
     return numeric
 
 
+def _normalize_optional_int(value: Any) -> int | None:
+    """Return an int from a finite numeric value, or None."""
+    numeric = _to_float_or_none(value)
+    if numeric is None:
+        return None
+    return int(numeric)
+
+
+def _json_string_list(value: Any) -> list[str]:
+    """Return a string list from decoded or JSON-encoded values."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            value = json.loads(text)
+        except json.JSONDecodeError:
+            return [text]
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
 def _normalize_optional_float(value: Any) -> float | None:
     """Return a finite optional float suitable for Pydantic models."""
     return _to_float_or_none(value)
@@ -559,6 +1030,11 @@ def _normalize_optional_string(value: Any) -> str | None:
     """Return a non-empty string or None."""
     if value is None:
         return None
+    try:
+        if value != value:
+            return None
+    except (TypeError, ValueError):
+        pass
     text = str(value).strip()
     return text or None
 

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -321,6 +321,42 @@ Notes:
   `reason_codes`, entity/ticker evidence, topic metadata, and embedding cache metadata
 - this is a non-contract artifact; no `core/contracts/schemas.py` change is required
 
+### Layer 1 topic-aware sentiment aggregation (non-contract artifact)
+
+Purpose:
+- combine FinBERT-scored sentence/chunk rows with the existing article topic labels,
+  relevance-gate evidence, and configured source credibility weights into ticker-day
+  semantic sentiment `FeatureRecord` rows
+- preserve enough audit metadata for downstream reports to explain which articles, topics,
+  source weights, and relevance decisions contributed to the aggregate
+
+Notes:
+- the aggregation stage consumes only completed Layer 1 artifacts for the same run/date:
+  `news_sentiment_scored`, `topic_labels`, and `news_relevance_gate`
+- source weights are loaded from `config/source_credibility.json`; missing source names use
+  the documented default weight and emit `missing_source_default_weight` in
+  `nlp_semantic_warning_codes`
+- topic evidence is joined by point-in-time artifact date, ticker, and article id; relevance
+  evidence is joined by artifact date, ticker, article id, sentence index, and chunk index
+- missing optional topic or relevance evidence does not fabricate values: topic sentiment
+  fields remain null where appropriate, missing counts are populated, and warning codes such
+  as `missing_topic_artifact`, `missing_topic_evidence`, or
+  `missing_relevance_evidence` are emitted
+- ticker-day sentiment FeatureRecords are persisted at
+  `features/{YYYY-MM-DD}/sentiment_features/{run_id}.parquet`; current summary keys include
+  the existing `nlp_sentiment_*`, `nlp_article_count`, `nlp_sentence_count`, and
+  `nlp_relevance_score` fields plus semantic audit fields such as
+  `nlp_sentiment_topic_score`, `nlp_sentiment_topic_count`,
+  `nlp_sentiment_dominant_topic_id`, `nlp_sentiment_dominant_topic_score`,
+  `nlp_sentiment_dominant_topic_probability`, `nlp_relevance_accepted_count`,
+  `nlp_relevance_borderline_count`, `nlp_source_weight_mean`,
+  `nlp_source_weight_sum`, `nlp_effective_weight_sum`, missing-evidence counts,
+  `nlp_contributing_article_ids`, `nlp_topic_sentiment_summary`,
+  `nlp_source_weight_summary`, `nlp_relevance_reason_codes`, and
+  `nlp_semantic_warning_codes`
+- this remains a `FeatureRecord` output with feature-dictionary keys, so no
+  `core/contracts/schemas.py` migration is required
+
 ### FeatureRecord
 
 Represents one fully aligned feature row for one `(date, ticker)`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -71,6 +71,11 @@ Expected execution chain:
    - FinBERT sentiment runs consume the completed preprocessing, embedding, and topic-label
      artifacts through the pre-FinBERT relevance gate; rejected rows are retained in the
      `news_relevance_gate` audit artifact but are not scored by FinBERT
+   - The `sentiment_features` artifact is the source-weighted ticker-day semantic aggregate:
+     it joins scored FinBERT rows to topic labels and relevance-gate decisions by
+     point-in-time article/ticker evidence, applies `config/source_credibility.json`, and
+     emits topic sentiment, source-weight summaries, contributing article ids, and warning
+     codes for missing optional evidence
    - Multi-date lab/readiness runs invoke the same module with `--from-date` /
      `--to-date`; when the Modal app is available, that path submits one batched remote
      Layer 1 job so topic modeling and FinBERT stay on the declared Modal dependency stack

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -128,6 +128,10 @@ Execution chain:
      `features/{YYYY-MM-DD}/news_sentiment_scored/{run_id}.parquet` and aggregate
      ticker-day sentiment FeatureRecords into the requested ticker scope at
      `features/{YYYY-MM-DD}/sentiment_features/{run_id}.parquet`
+   - The ticker-day sentiment aggregation combines FinBERT probabilities, article topic
+     labels, relevance-gate audit evidence, and `config/source_credibility.json` weights;
+     missing optional topic or relevance evidence is carried as null topic sentiment values,
+     missing-evidence counts, and `nlp_semantic_warning_codes` rather than fabricated inputs
    - Compute market, NLP, context, and optional order-book spread / imbalance features for today
    - Write authoritative date-first feature shards at `features/{YYYY-MM-DD}/{TICKER}.parquet`
      for every ticker in the point-in-time universe; legacy per-ticker histories under

--- a/tests/unit/test_feature_catalog.py
+++ b/tests/unit/test_feature_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from core.features.catalog import feature_catalog, validate_feature_value
 from core.features.order_book_features import ORDER_BOOK_FEATURE_COLUMNS
 from core.features.sector_features import SECTOR_FEATURE_COLUMNS
+from core.features.sentiment_features import SENTIMENT_FEATURE_COLUMNS
 
 
 def test_feature_catalog_registers_sector_features() -> None:
@@ -46,5 +47,32 @@ def test_feature_catalog_registers_optional_order_book_features() -> None:
     )
     assert (
         validate_feature_value("l2_book_imbalance", 0.2, catalog["l2_book_imbalance"])
+        is None
+    )
+
+
+def test_feature_catalog_registers_sentiment_semantic_features() -> None:
+    """All sentiment semantic aggregation columns exist in the Layer 1 catalog."""
+    catalog = feature_catalog()
+
+    for feature_name in SENTIMENT_FEATURE_COLUMNS:
+        assert feature_name in catalog
+        assert catalog[feature_name].owner in {"sentiment", "nlp"}
+        assert catalog[feature_name].required is False
+
+    assert (
+        validate_feature_value(
+            "nlp_sentiment_topic_score",
+            -1.1,
+            catalog["nlp_sentiment_topic_score"],
+        )
+        is not None
+    )
+    assert (
+        validate_feature_value(
+            "nlp_topic_sentiment_summary",
+            '[{"topic_id":1}]',
+            catalog["nlp_topic_sentiment_summary"],
+        )
         is None
     )

--- a/tests/unit/test_finbert_sentiment_runner.py
+++ b/tests/unit/test_finbert_sentiment_runner.py
@@ -87,6 +87,7 @@ def test_run_finbert_sentiment_reads_preprocessed_news_and_writes_outputs(
     assert manifest["metadata"]["relevance_accepted_rows"] == 2
     assert manifest["metadata"]["relevance_borderline_rows"] == 1
     assert manifest["metadata"]["feature_rows"] == 2
+    assert manifest["metadata"]["semantic_aggregation"]["relevance_gate_loaded"] is True
 
 
 def test_run_finbert_sentiment_honors_requested_ticker_scope(
@@ -182,6 +183,7 @@ def test_run_finbert_sentiment_scores_only_relevance_gate_candidates(
         "relevance_decision",
     ].iloc[0] == "rejected"
     assert manifest["metadata"]["relevance_rejected_rows"] == 1
+    assert manifest["metadata"]["semantic_aggregation"]["topic_labels_loaded"] is True
 
 
 def test_run_finbert_sentiment_writes_failure_manifest(

--- a/tests/unit/test_sentiment_features.py
+++ b/tests/unit/test_sentiment_features.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -24,7 +25,7 @@ def _row(
     date: str = "2024-04-10",
     ticker: str = "AAPL",
     article_id: str = "article-1",
-    source: str = "Reuters",
+    source: str | None = "Reuters",
     published_at: str | None = None,
     sentiment_positive: float = 0.8,
     sentiment_negative: float = 0.1,
@@ -356,6 +357,123 @@ def test_sentiment_feature_records_from_scored_news_matches_contract() -> None:
     assert records[0].features["nlp_article_count"] == 2
     assert records[0].features["nlp_sentence_count"] == 3
     assert records[0].features["nlp_sentiment_score"] == pytest.approx(1.0 / 3.0)
+    assert json.loads(records[0].features["nlp_semantic_warning_codes"]) == [
+        "missing_relevance_evidence",
+        "missing_topic_artifact",
+    ]
+
+
+def test_sentiment_feature_records_combine_topics_relevance_and_source_weights() -> None:
+    """Semantic aggregation combines FinBERT, topics, relevance, and source weights."""
+    scored_news = pd.DataFrame(
+        [
+            _row(
+                article_id="aapl-specific",
+                source="Reuters",
+                sentiment_positive=0.9,
+                sentiment_negative=0.05,
+                sentiment_neutral=0.05,
+                sentiment_score=0.85,
+                relevance_score=0.9,
+            )
+            | {"sentence_index": 0, "chunk_index": 0},
+            _row(
+                article_id="broad-market",
+                source="Personal Blog",
+                sentiment_positive=0.2,
+                sentiment_negative=0.6,
+                sentiment_neutral=0.2,
+                sentiment_score=-0.4,
+                relevance_score=0.4,
+            )
+            | {"sentence_index": 0, "chunk_index": 0},
+        ]
+    )
+    topic_labels = pd.DataFrame(
+        [
+            _topic_row("aapl-specific", topic_id=7, topic_probability=0.8),
+            _topic_row("broad-market", topic_id=3, topic_probability=0.5),
+        ]
+    )
+    relevance_gate = pd.DataFrame(
+        [
+            _relevance_row("aapl-specific", decision="accepted", relevance_score=0.9),
+            _relevance_row("broad-market", decision="borderline", relevance_score=0.4),
+        ]
+    )
+
+    records = sentiment_feature_records_from_scored_news(
+        scored_news,
+        topic_labels=topic_labels,
+        relevance_gate=relevance_gate,
+        credibility_config=SourceCredibilityConfig(
+            default_source_weight=1.0,
+            source_weights={"reuters": 2.0, "personal blog": 0.5},
+        ),
+    )
+
+    features = records[0].features
+    topic_summary = json.loads(features["nlp_topic_sentiment_summary"])
+    source_summary = json.loads(features["nlp_source_weight_summary"])
+
+    assert features["nlp_sentiment_score"] == pytest.approx(0.725)
+    assert features["nlp_sentiment_topic_score"] == pytest.approx(0.7688311688311689)
+    assert features["nlp_sentiment_topic_count"] == 2
+    assert features["nlp_sentiment_dominant_topic_id"] == 7
+    assert features["nlp_sentiment_dominant_topic_score"] == pytest.approx(0.85)
+    assert features["nlp_relevance_accepted_count"] == 1
+    assert features["nlp_relevance_borderline_count"] == 1
+    assert features["nlp_effective_weight_sum"] == pytest.approx(2.0)
+    assert json.loads(features["nlp_contributing_article_ids"]) == [
+        "aapl-specific",
+        "broad-market",
+    ]
+    assert json.loads(features["nlp_semantic_warning_codes"]) == []
+    assert topic_summary[0]["topic_id"] == 7
+    assert topic_summary[0]["article_count"] == 1
+    assert source_summary == [
+        {
+            "article_count": 1,
+            "sentence_count": 1,
+            "source": "Personal Blog",
+            "source_weight": 0.5,
+        },
+        {
+            "article_count": 1,
+            "sentence_count": 1,
+            "source": "Reuters",
+            "source_weight": 2.0,
+        },
+    ]
+
+
+def test_sentiment_feature_records_warn_on_missing_optional_topic_evidence() -> None:
+    """Missing optional topic rows produce null topic features and warning metadata."""
+    scored_news = pd.DataFrame([_row(source=None) | {"sentence_index": 0, "chunk_index": 0}])
+    relevance_gate = pd.DataFrame([_relevance_row("article-1")])
+
+    records = sentiment_feature_records_from_scored_news(
+        scored_news,
+        topic_labels=pd.DataFrame(
+            columns=["date", "ticker", "article_id", "topic_id", "topic_probability"]
+        ),
+        relevance_gate=relevance_gate,
+        credibility_config=SourceCredibilityConfig(
+            default_source_weight=1.0,
+            source_weights={},
+        ),
+    )
+
+    features = records[0].features
+
+    assert features["nlp_sentiment_topic_score"] is None
+    assert features["nlp_sentiment_dominant_topic_id"] is None
+    assert features["nlp_missing_source_count"] == 1
+    assert features["nlp_missing_topic_count"] == 1
+    assert json.loads(features["nlp_semantic_warning_codes"]) == [
+        "missing_source_default_weight",
+        "missing_topic_artifact",
+    ]
 
 
 def test_sentiment_feature_records_to_frame_serializes_features() -> None:
@@ -371,16 +489,67 @@ def test_sentiment_feature_records_to_frame_serializes_features() -> None:
 
     frame = sentiment_feature_records_to_frame(records)
 
-    assert frame.to_dict(orient="records") == [
-        {
-            "date": "2024-04-10",
-            "ticker": "AAPL",
-            "features": (
-                '{"nlp_article_count":1,"nlp_relevance_score":1.0,'
-                '"nlp_sentence_count":1,"nlp_sentiment_negative":0.1,'
-                '"nlp_sentiment_neutral":0.1,"nlp_sentiment_positive":0.8,'
-                '"nlp_sentiment_score":0.7,"nlp_sentiment_std":0.0,'
-                '"nlp_sentiment_strength":0.8}'
-            ),
-        }
-    ]
+    serialized = frame.to_dict(orient="records")
+    features = json.loads(serialized[0]["features"])
+
+    assert serialized[0]["date"] == "2024-04-10"
+    assert serialized[0]["ticker"] == "AAPL"
+    assert features["nlp_article_count"] == 1
+    assert features["nlp_relevance_score"] == 1.0
+    assert features["nlp_sentence_count"] == 1
+    assert features["nlp_sentiment_score"] == 0.7
+    assert features["nlp_sentiment_strength"] == 0.8
+
+
+def _topic_row(
+    article_id: str,
+    *,
+    topic_id: int,
+    topic_probability: float,
+) -> dict[str, object]:
+    """Build one topic-label row."""
+    return {
+        "date": "2024-04-10",
+        "ticker": "AAPL",
+        "article_id": article_id,
+        "normalized_headline": article_id,
+        "text": article_id,
+        "article_sentence_count": 1,
+        "embedding_cache_key": f"embedding-{article_id}",
+        "topic_model": "test-topic",
+        "topic_model_version": "test-version",
+        "topic_id": topic_id,
+        "topic_probability": topic_probability,
+    }
+
+
+def _relevance_row(
+    article_id: str,
+    *,
+    decision: str = "accepted",
+    relevance_score: float = 1.0,
+) -> dict[str, object]:
+    """Build one relevance-gate audit row."""
+    return {
+        "date": "2024-04-10",
+        "ticker": "AAPL",
+        "article_id": article_id,
+        "sentence_index": 0,
+        "chunk_index": 0,
+        "headline": article_id,
+        "text": article_id,
+        "source": "Reuters",
+        "published_at": "2024-04-10T14:30:00Z",
+        "relevance_decision": decision,
+        "relevance_score": relevance_score,
+        "ticker_relevance_score": 1.0,
+        "financial_relevance_score": 1.0,
+        "topic_relevance_score": 0.8,
+        "reason_codes": "[]",
+        "ticker_evidence": "{}",
+        "entity_evidence": "[]",
+        "topic_id": 7,
+        "topic_probability": 0.8,
+        "embedding_cache_key": f"embedding-{article_id}",
+        "has_embedding": True,
+    }


### PR DESCRIPTION
## What this PR does
Implements Layer 1 topic-aware semantic sentiment aggregation by joining FinBERT-scored rows with topic labels and relevance-gate audit evidence, applying configured source credibility weights, and emitting ticker-day FeatureRecord fields for topic sentiment, source/relevance summaries, contributing article ids, and missing-evidence warnings.

## Closes
Closes #229

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch was pre-created by Hermes as `code-monkey/issue-229-semantic-aggregation-20260625T221935Z`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
Not applicable. No UI or external artifact write was performed.

## Notes for reviewer
- No `core/contracts/schemas.py` changes; semantic metadata stays inside the existing `FeatureRecord.features` dictionary.
- Aggregation consumes existing Layer 1 artifacts only: `news_sentiment_scored`, `topic_labels`, and `news_relevance_gate`.
- Missing optional topic/relevance/source evidence degrades to null/count/warning fields instead of fabricated values.
- Commands run:
  - `./.venv/bin/ruff check .` — passed
  - `./.venv/bin/pytest tests/unit/test_sentiment_features.py tests/unit/test_feature_catalog.py -v --tb=short` — 22 passed
  - `./.venv/bin/pytest tests/unit/ -v --tb=short` — 740 passed, 4 existing numpy warnings in AAPL holiday evidence tests
- Manifest key(s): not applicable; no R2/Modal run performed.
- Report path(s): not applicable.
- R2 output prefix(es): not written by this PR; runtime path remains `features/{YYYY-MM-DD}/sentiment_features/{run_id}.parquet`.
- Known skipped/missing data: no integration/R2 readiness run was performed because Issue #229 is code/docs/unit-test scoped with no external side effects.