### PR TITLE
Add semantic review price and HMM context

### DIFF
--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -288,13 +288,21 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
     .empty {{ color: #94a3b8; font-style: italic; }}
     .warning {{ color: #fbbf24; }}
     .section-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 12px; margin: 14px 0; }}
+    .chart-wrap {{ margin: 18px 0; }}
+    .chart {{ width: 100%; height: 300px; background: #0b1220; border: 1px solid #334155; border-radius: 8px; }}
+    .chart text {{ fill: #cbd5e1; font-size: 11px; }}
+    .chart-line {{ fill: none; stroke: #38bdf8; stroke-width: 2.5; }}
+    .axis-line {{ stroke: #334155; stroke-width: 1; }}
+    .prob-bear {{ fill: #f87171; }}
+    .prob-sideways {{ fill: #fbbf24; }}
+    .prob-bull {{ fill: #4ade80; }}
     pre {{ white-space: pre-wrap; word-break: break-word; }}
   </style>
 </head>
 <body>
   <header>
     <h1>Layer 1 semantic-review dashboard</h1>
-    <p class="note">Raw ticker/entity preprocessing, article embeddings, BERTopic labels, relevance-gate decisions, sentence-level FinBERT rows, ticker-date semantic aggregates, and date-level HMM regime evidence are separated by pipeline stage.</p>
+    <p class="note">Raw ticker/entity preprocessing, article embeddings, BERTopic labels, relevance-gate decisions, sentence-level FinBERT rows, ticker-date semantic aggregates, stock prices, and date-level HMM regime evidence are separated by pipeline stage.</p>
     <div class="meta" id="meta"></div>
   </header>
   <main>
@@ -328,6 +336,8 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         ['Topic labels', summary.topic_label_row_count ?? 0],
         ['Relevance rows', summary.relevance_gate_row_count ?? 0],
         ['Aggregates', summary.semantic_aggregate_row_count ?? 0],
+        ['Price rows', summary.price_row_count ?? 0],
+        ['HMM rows', summary.hmm_regime_row_count ?? 0],
       ];
       summaryEl.innerHTML = entries.map(([label, value]) => `<div class="card"><div>${{label}}</div><div style="font-size:1.6rem;font-weight:700">${{value}}</div></div>`).join('');
     }}
@@ -398,13 +408,93 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         ['finbert_sentence_rows', 'Sentence/chunk FinBERT rows'],
         ['semantic_aggregate_rows', 'Ticker-date semantic aggregates'],
         ['date_level_regime_rows', 'Date-level HMM regime'],
+        ['stock_price_rows', 'Stock-price rows'],
+        ['date_aligned_price_hmm_rows', 'Date-aligned price/HMM rows'],
       ];
       pipelineEl.innerHTML = `
         <section class="card">
           <h2>Pipeline Evidence</h2>
-          <p class="note">Human semantic review remains needs_human_review until these completed NLP pipeline sections are inspected and explicitly accepted.</p>
+          <p class="note">Human semantic review remains needs_human_review until completed NLP, stock-price, and HMM evidence are inspected and explicitly accepted.</p>
           <div class="section-grid">
             ${{labels.map(([key, label]) => renderPipelineCard(label, sections[key] || [])).join('')}}
+          </div>
+        </section>`;
+    }}
+
+    function renderMarketRegimeChart(rows, hmmContext) {{
+      if (!rows.length) {{
+        return '<section class="card chart-wrap"><h2>Stock Price and HMM Regime</h2><p class="empty">No price/HMM rows available.</p></section>';
+      }}
+      const priced = rows.filter((row) => row.price && Number.isFinite(Number(row.price.adj_close ?? row.price.close)));
+      const width = 960;
+      const height = 300;
+      const left = 48;
+      const right = 18;
+      const top = 22;
+      const priceBottom = 190;
+      const probTop = 218;
+      const probHeight = 54;
+      const values = priced.map((row) => Number(row.price.adj_close ?? row.price.close));
+      const minPrice = values.length ? Math.min(...values) : 0;
+      const maxPrice = values.length ? Math.max(...values) : 1;
+      const priceRange = Math.max(maxPrice - minPrice, 0.0001);
+      const step = rows.length > 1 ? (width - left - right) / (rows.length - 1) : 0;
+      const xFor = (index) => left + index * step;
+      const yFor = (value) => priceBottom - ((value - minPrice) / priceRange) * (priceBottom - top);
+      const points = rows
+        .map((row, index) => {{
+          const price = row.price;
+          if (!price) return null;
+          const value = Number(price.adj_close ?? price.close);
+          return Number.isFinite(value) ? `${{xFor(index)}},${{yFor(value)}}` : null;
+        }})
+        .filter(Boolean)
+        .join(' ');
+      const markers = rows.map((row, index) => {{
+        const regime = row.hmm_regime || {{}};
+        const price = row.price || {{}};
+        const value = Number(price.adj_close ?? price.close);
+        const x = xFor(index);
+        const y = Number.isFinite(value) ? yFor(value) : priceBottom;
+        const color = regime.regime === 'bear' ? '#f87171' : regime.regime === 'bull' ? '#4ade80' : '#fbbf24';
+        const warning = (row.warnings || []).join(', ');
+        return `<circle cx="${{x}}" cy="${{y}}" r="5" fill="${{color}}"><title>${{row.date}} ${{regime.regime || 'missing'}} ${{warning}}</title></circle>`;
+      }}).join('');
+      const bars = rows.map((row, index) => {{
+        const regime = row.hmm_regime || {{}};
+        const x = xFor(index) - 8;
+        const widthBar = 16;
+        const bear = Number(regime.prob_bear || 0) * probHeight;
+        const sideways = Number(regime.prob_sideways || 0) * probHeight;
+        const bull = Number(regime.prob_bull || 0) * probHeight;
+        const yBear = probTop + probHeight - bear;
+        const ySideways = yBear - sideways;
+        const yBull = ySideways - bull;
+        return `
+          <rect class="prob-bear" x="${{x}}" y="${{yBear}}" width="${{widthBar}}" height="${{bear}}"></rect>
+          <rect class="prob-sideways" x="${{x}}" y="${{ySideways}}" width="${{widthBar}}" height="${{sideways}}"></rect>
+          <rect class="prob-bull" x="${{x}}" y="${{yBull}}" width="${{widthBar}}" height="${{bull}}"></rect>`;
+      }}).join('');
+      const labels = rows.map((row, index) => `<text x="${{xFor(index) - 28}}" y="292">${{row.date.slice(5)}}</text>`).join('');
+      const contextWarnings = (hmmContext.warnings || []).join(', ') || 'none';
+      return `
+        <section class="card chart-wrap">
+          <h2>Stock Price and HMM Regime</h2>
+          <p class="note">Close/adjusted-close price and HMM bear/sideways/bull probabilities share the same date axis.</p>
+          <svg class="chart" viewBox="0 0 ${{width}} ${{height}}" role="img" aria-label="Stock price with HMM regime probabilities">
+            <line class="axis-line" x1="${{left}}" y1="${{priceBottom}}" x2="${{width - right}}" y2="${{priceBottom}}"></line>
+            <line class="axis-line" x1="${{left}}" y1="${{probTop + probHeight}}" x2="${{width - right}}" y2="${{probTop + probHeight}}"></line>
+            <text x="8" y="${{top + 10}}">${{formatNumber(maxPrice)}}</text>
+            <text x="8" y="${{priceBottom}}">${{formatNumber(minPrice)}}</text>
+            <polyline class="chart-line" points="${{points}}"></polyline>
+            ${{markers}}
+            ${{bars}}
+            ${{labels}}
+          </svg>
+          <div class="article-meta">
+            <span class="badge">training_windows=${{(hmmContext.training_windows || []).length}}</span>
+            <span class="badge">input_features=${{(hmmContext.input_feature_columns_used || []).length}}</span>
+            <span class="badge">warnings=${{escapeHtml(contextWarnings)}}</span>
           </div>
         </section>`;
     }}
@@ -434,6 +524,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
             <span class="badge">accepted=${{group.accepted_article_count}}</span>
             <span class="badge">flagged=${{group.flagged_article_count}}</span>
             <span class="badge">sentence_rows=${{group.sentence_count}}</span>
+            <span class="badge">close=${{group.price ? formatNumber(group.price.adj_close ?? group.price.close) : 'n/a'}}</span>
           </div>
           ${{(group.articles || []).map(renderArticle).join('') || '<p class="empty">No articles for this date.</p>'}}
         </section>`;
@@ -467,7 +558,10 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       renderMeta(payload.report || payload);
       renderSummary(payload.summary || (payload.report && payload.report.summary) || {{}});
       renderPipelineSections(payload.pipeline_sections || {{}});
-      contentEl.innerHTML = (payload.date_groups || []).map(renderDateGroup).join('');
+      contentEl.innerHTML = renderMarketRegimeChart(
+        payload.market_regime_series || [],
+        payload.hmm_evaluation_context || {{}}
+      ) + (payload.date_groups || []).map(renderDateGroup).join('');
       if (!(payload.date_groups || []).length) {{
         contentEl.innerHTML = '<p class="empty">No review rows were found for this run and date range.</p>';
       }}

--- a/core/features/aapl_evidence.py
+++ b/core/features/aapl_evidence.py
@@ -16,6 +16,7 @@ from typing import Any
 import pandas as pd
 
 from core.common.trading_calendar import skipped_non_trading_dates, trading_dates
+from core.features.regime_training import HMM_TRAINING_FEATURE_COLUMNS
 from services.r2.paths import (
     layer1_feature_path,
     layer1_news_preprocessing_path,
@@ -118,6 +119,16 @@ class SemanticReviewRegimeRow:
     prob_bear: float | None
     prob_sideways: float | None
     prob_bull: float | None
+    readiness_status: str | None = None
+    readiness_reason: str | None = None
+    required_for_layer2: bool | None = None
+    missing_features: list[str] = field(default_factory=list)
+    probability_sum: float | None = None
+    training_rows: int | None = None
+    complete_training_rows: int | None = None
+    min_training_rows: int | None = None
+    artifact_key: str | None = None
+    manifest_key: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable representation."""
@@ -128,11 +139,38 @@ class SemanticReviewRegimeRow:
 
 
 @dataclass(frozen=True)
+class SemanticReviewPriceRow:
+    """Date-level raw price evidence aligned to semantic and HMM review rows."""
+
+    date: str
+    ticker: str
+    open: float | None
+    high: float | None
+    low: float | None
+    close: float | None
+    adj_close: float | None
+    volume: int | None
+    dollar_volume: float | None
+    return_1d: float | None
+    drawdown_from_window_high: float | None
+    artifact_key: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable representation."""
+        payload = asdict(self)
+        payload["scope"] = "ticker-date"
+        payload["stage"] = "raw_price_context"
+        return payload
+
+
+@dataclass(frozen=True)
 class SemanticReviewDateGroup:
     """One trading-date bucket that contains the date-level regime and article cards."""
 
     date: str
     regime: dict[str, object] | None
+    price: dict[str, object] | None
+    market_regime_context: dict[str, object]
     article_count: int
     accepted_article_count: int
     flagged_article_count: int
@@ -178,6 +216,9 @@ class Layer1SemanticReviewReport:
     relevance_gate_rows: list[dict[str, object]]
     semantic_aggregate_rows: list[dict[str, object]]
     regime_rows: list[dict[str, object]]
+    price_rows: list[dict[str, object]]
+    market_regime_rows: list[dict[str, object]]
+    hmm_evaluation_context: dict[str, object]
     article_groups: list[dict[str, object]]
     date_groups: list[dict[str, object]]
     summary: dict[str, int]
@@ -216,8 +257,19 @@ def build_layer1_aapl_evidence_report(
         "news_sentiment_scored": [],
         "sentiment_features": [],
         "regime": [],
+        "regime_manifests": [],
+        "raw_prices": [],
     }
     trading_date_list = trading_dates(from_date, to_date)
+    price_key = raw_price_path(requested_ticker)
+    price_rows = _load_price_rows(
+        writer=active_writer,
+        key=price_key,
+        ticker=requested_ticker,
+        dates=trading_date_list,
+        artifact_keys=artifact_keys,
+        load_warnings=load_warnings,
+    )
     for current_date in trading_date_list:
         primary_key = layer1_sentiment_score_path(current_date, run_id)
         fallback_key = layer1_sentiment_score_path(current_date, f"{run_id}-{current_date}")
@@ -287,9 +339,18 @@ def build_layer1_aapl_evidence_report(
             continue
         if resolved_key is not None:
             artifact_keys["regime"].append(resolved_key)
+            regime_frame = regime_frame.copy()
+            regime_frame["_artifact_key"] = resolved_key
         regime_frames.append(regime_frame)
 
     regime_frame = pd.concat(regime_frames, ignore_index=True) if regime_frames else pd.DataFrame()
+    regime_manifest_context = _load_regime_manifest_context(
+        writer=active_writer,
+        dates=trading_date_list,
+        run_id=run_id,
+        artifact_keys=artifact_keys,
+        load_warnings=load_warnings,
+    )
 
     preprocessing_frame = _load_date_partitioned_artifacts(
         writer=active_writer,
@@ -344,6 +405,8 @@ def build_layer1_aapl_evidence_report(
         ticker=requested_ticker,
     )) is not None:
         scored_frame, regime_frame = cached_frames
+        price_rows = []
+        regime_manifest_context = _empty_regime_manifest_context(trading_date_list)
         scored_frames = [scored_frame]
         regime_frames = [regime_frame]
         load_warnings = [
@@ -380,7 +443,31 @@ def build_layer1_aapl_evidence_report(
         relevance_gate_rows=relevance_gate_rows,
     )
     regime_by_date = _build_regime_map(regime_frame)
-    date_groups = _build_date_groups(article_groups, regime_by_date, semantic_aggregate_rows)
+    _enrich_regime_rows_with_manifests(regime_by_date, regime_manifest_context)
+    _append_market_context_warnings(
+        dates=trading_date_list,
+        price_rows=price_rows,
+        regime_map=regime_by_date,
+        load_warnings=load_warnings,
+    )
+    market_regime_rows = _build_market_regime_rows(
+        dates=trading_date_list,
+        price_rows=price_rows,
+        regime_map=regime_by_date,
+    )
+    hmm_evaluation_context = _build_hmm_evaluation_context(
+        dates=trading_date_list,
+        regime_map=regime_by_date,
+        manifest_context=regime_manifest_context,
+        artifact_keys=artifact_keys,
+    )
+    date_groups = _build_date_groups(
+        article_groups,
+        regime_by_date,
+        semantic_aggregate_rows,
+        price_rows=price_rows,
+        market_regime_rows=market_regime_rows,
+    )
     summary = {
         "row_count": int(article_summary["row_count"]),
         "article_count": int(article_summary["article_count"]),
@@ -396,6 +483,8 @@ def build_layer1_aapl_evidence_report(
         "topic_label_row_count": len(topic_label_rows),
         "relevance_gate_row_count": len(relevance_gate_rows),
         "semantic_aggregate_row_count": len(semantic_aggregate_rows),
+        "price_row_count": len(price_rows),
+        "hmm_regime_row_count": len(regime_by_date),
     }
     generated_at = datetime.now(tz=UTC).isoformat()
     return Layer1SemanticReviewReport(
@@ -426,6 +515,9 @@ def build_layer1_aapl_evidence_report(
         relevance_gate_rows=relevance_gate_rows,
         semantic_aggregate_rows=semantic_aggregate_rows,
         regime_rows=[item.to_dict() for item in _regime_rows_from_map(regime_by_date)],
+        price_rows=[item.to_dict() for item in price_rows],
+        market_regime_rows=market_regime_rows,
+        hmm_evaluation_context=hmm_evaluation_context,
         article_groups=[group.to_dict() for group in article_groups],
         date_groups=[group.to_dict() for group in date_groups],
         summary=summary,
@@ -606,14 +698,20 @@ def _build_regime_map(frame: pd.DataFrame) -> dict[str, SemanticReviewRegimeRow]
     date_column = _first_existing_column(normalized, ("date", "as_of_date"))
     if date_column is None:
         return {}
-    regime_column = _first_existing_column(normalized, ("regime", "state", "label"))
+    regime_column = _first_existing_column(normalized, ("regime", "state", "label", "regime_label"))
     confidence_column = _first_existing_column(normalized, ("confidence", "regime_confidence"))
-    bear_column = _first_existing_column(normalized, ("prob_bear", "bear_prob", "probability_bear"))
+    bear_column = _first_existing_column(
+        normalized,
+        ("prob_bear", "bear_prob", "probability_bear", "regime_prob_bear"),
+    )
     sideways_column = _first_existing_column(
         normalized,
-        ("prob_sideways", "sideways_prob", "probability_sideways"),
+        ("prob_sideways", "sideways_prob", "probability_sideways", "regime_prob_sideways"),
     )
-    bull_column = _first_existing_column(normalized, ("prob_bull", "bull_prob", "probability_bull"))
+    bull_column = _first_existing_column(
+        normalized,
+        ("prob_bull", "bull_prob", "probability_bull", "regime_prob_bull"),
+    )
     regime_map: dict[str, SemanticReviewRegimeRow] = {}
     for _, row in normalized.iterrows():
         date_text = _optional_str(row.get(date_column))
@@ -626,6 +724,15 @@ def _build_regime_map(frame: pd.DataFrame) -> dict[str, SemanticReviewRegimeRow]
             prob_bear=_maybe_float(row.get(bear_column)) if bear_column else None,
             prob_sideways=_maybe_float(row.get(sideways_column)) if sideways_column else None,
             prob_bull=_maybe_float(row.get(bull_column)) if bull_column else None,
+            readiness_status=_optional_str(row.get("regime_readiness_status")),
+            readiness_reason=_optional_str(row.get("regime_readiness_reason")),
+            required_for_layer2=_maybe_bool(row.get("regime_required_for_layer2")),
+            missing_features=_comma_string_list(row.get("regime_missing_features")),
+            probability_sum=_maybe_float(row.get("regime_probability_sum")),
+            training_rows=_maybe_int(row.get("training_rows")),
+            complete_training_rows=_maybe_int(row.get("complete_training_rows")),
+            min_training_rows=_maybe_int(row.get("min_training_rows")),
+            artifact_key=_optional_str(row.get("_artifact_key")),
         )
     return regime_map
 
@@ -640,6 +747,9 @@ def _build_date_groups(
     article_groups: Sequence[SemanticReviewArticleGroup],
     regime_map: Mapping[str, SemanticReviewRegimeRow],
     semantic_aggregate_rows: Sequence[Mapping[str, object]] = (),
+    *,
+    price_rows: Sequence[SemanticReviewPriceRow] = (),
+    market_regime_rows: Sequence[Mapping[str, object]] = (),
 ) -> list[SemanticReviewDateGroup]:
     grouped: dict[str, list[SemanticReviewArticleGroup]] = defaultdict(list)
     for article_group in article_groups:
@@ -649,9 +759,15 @@ def _build_date_groups(
         date_text = _optional_str(row.get("date"))
         if date_text:
             semantic_by_date[date_text].append(dict(row))
+    price_by_date = {row.date: row.to_dict() for row in price_rows}
+    context_by_date = {
+        str(row["date"]): dict(row)
+        for row in market_regime_rows
+        if _optional_str(row.get("date")) is not None
+    }
 
     date_groups: list[SemanticReviewDateGroup] = []
-    for date_text in sorted(set(grouped) | set(semantic_by_date)):
+    for date_text in sorted(set(grouped) | set(semantic_by_date) | set(price_by_date) | set(regime_map)):
         articles = sorted(grouped[date_text], key=lambda item: (item.article_status, item.article_id))
         accepted_articles = [item.to_dict() for item in articles if item.article_status == "accepted"]
         flagged_articles = [item.to_dict() for item in articles if item.article_status != "accepted"]
@@ -659,6 +775,17 @@ def _build_date_groups(
             SemanticReviewDateGroup(
                 date=date_text,
                 regime=regime_map.get(date_text).to_dict() if date_text in regime_map else None,
+                price=price_by_date.get(date_text),
+                market_regime_context=context_by_date.get(
+                    date_text,
+                    {
+                        "date": date_text,
+                        "ticker": None,
+                        "price": None,
+                        "hmm_regime": None,
+                        "warnings": ["missing_aligned_market_regime_context"],
+                    },
+                ),
                 article_count=len(articles),
                 accepted_article_count=len(accepted_articles),
                 flagged_article_count=len(flagged_articles),
@@ -745,6 +872,434 @@ def _read_first_available_parquet_frame(
         except FileNotFoundError:
             continue
     return None, None
+
+
+def _load_price_rows(
+    *,
+    writer: R2Writer,
+    key: str,
+    ticker: str,
+    dates: Sequence[str],
+    artifact_keys: dict[str, list[str]],
+    load_warnings: list[dict[str, object]],
+) -> list[SemanticReviewPriceRow]:
+    """Load raw price rows for the selected ticker/window."""
+    try:
+        frame = _read_parquet_frame(writer.get_object(key))
+    except FileNotFoundError:
+        load_warnings.append(
+            {
+                "scope": "price_series",
+                "ticker": ticker,
+                "key": key,
+                "message": "Missing raw OHLCV price parquet for the selected ticker.",
+            }
+        )
+        return []
+    if frame.empty:
+        load_warnings.append(
+            {
+                "scope": "price_series",
+                "ticker": ticker,
+                "key": key,
+                "message": "Raw OHLCV price parquet is empty for the selected ticker.",
+            }
+        )
+        return []
+
+    artifact_keys["raw_prices"].append(key)
+    normalized = frame.copy()
+    normalized.columns = [str(column) for column in normalized.columns]
+    if "date" not in normalized.columns:
+        load_warnings.append(
+            {
+                "scope": "price_series",
+                "ticker": ticker,
+                "key": key,
+                "message": "Raw OHLCV price parquet has no date column.",
+            }
+        )
+        return []
+
+    normalized["date"] = normalized["date"].map(lambda value: _optional_str(value) or "")
+    if "ticker" in normalized.columns:
+        normalized["ticker"] = normalized["ticker"].map(lambda value: _optional_str(value) or ticker)
+        normalized = normalized[normalized["ticker"].str.upper() == ticker]
+    expected_dates = set(dates)
+    normalized = normalized[normalized["date"].isin(expected_dates)]
+    if normalized.empty:
+        load_warnings.append(
+            {
+                "scope": "price_series",
+                "ticker": ticker,
+                "key": key,
+                "message": "Raw OHLCV price parquet has no rows in the review window.",
+            }
+        )
+        return []
+
+    normalized = normalized.sort_values("date").drop_duplicates("date").reset_index(drop=True)
+    if "adj_close" not in normalized.columns and "close" not in normalized.columns:
+        load_warnings.append(
+            {
+                "scope": "price_series",
+                "ticker": ticker,
+                "key": key,
+                "message": "Raw OHLCV price parquet has neither adj_close nor close.",
+            }
+        )
+        return []
+    close_column = "adj_close" if "adj_close" in normalized.columns else "close"
+    normalized["_adj_close_for_context"] = normalized[close_column].map(_maybe_float)
+    normalized["_return_1d"] = normalized["_adj_close_for_context"].pct_change()
+    running_high = normalized["_adj_close_for_context"].cummax()
+    normalized["_drawdown_from_window_high"] = normalized["_adj_close_for_context"] / running_high - 1.0
+    rows: list[SemanticReviewPriceRow] = []
+    for _, row in normalized.iterrows():
+        rows.append(
+            SemanticReviewPriceRow(
+                date=str(row["date"]),
+                ticker=ticker,
+                open=_maybe_float(row.get("open")),
+                high=_maybe_float(row.get("high")),
+                low=_maybe_float(row.get("low")),
+                close=_maybe_float(row.get("close")),
+                adj_close=_maybe_float(row.get("adj_close")),
+                volume=_maybe_int(row.get("volume")),
+                dollar_volume=_maybe_float(row.get("dollar_volume")),
+                return_1d=_maybe_float(row.get("_return_1d")),
+                drawdown_from_window_high=_maybe_float(row.get("_drawdown_from_window_high")),
+                artifact_key=key,
+            )
+        )
+    return rows
+
+
+def _load_regime_manifest_context(
+    *,
+    writer: R2Writer,
+    dates: Sequence[str],
+    run_id: str,
+    artifact_keys: dict[str, list[str]],
+    load_warnings: list[dict[str, object]],
+) -> dict[str, object]:
+    """Load HMM regime manifest metadata for the selected date window."""
+    by_date: dict[str, dict[str, object]] = {}
+    manifests: list[dict[str, object]] = []
+    seen_keys: set[str] = set()
+    for date_text in dates:
+        primary_key = pipeline_manifest_path("layer1_5_regime", run_id)
+        fallback_key = pipeline_manifest_path("layer1_5_regime", f"{run_id}-{date_text}")
+        payload, resolved_key = _read_first_available_json_object(
+            writer,
+            (primary_key, fallback_key),
+        )
+        if payload is None:
+            load_warnings.append(
+                {
+                    "scope": "hmm_evaluation_context",
+                    "date": date_text,
+                    "key": primary_key,
+                    "fallback_key": fallback_key,
+                    "tried_keys": [primary_key, fallback_key],
+                    "message": "Missing Layer 1.5 HMM regime manifest for this date.",
+                }
+            )
+            by_date[date_text] = {"manifest_key": None, "metadata": {}}
+            continue
+        if resolved_key is not None and resolved_key not in artifact_keys["regime_manifests"]:
+            artifact_keys["regime_manifests"].append(resolved_key)
+        if resolved_key is not None and resolved_key not in seen_keys:
+            manifests.append(_manifest_summary(payload, resolved_key))
+            seen_keys.add(resolved_key)
+        by_date[date_text] = {
+            "manifest_key": resolved_key,
+            "metadata": _json_mapping(payload.get("metadata")),
+            "status": _optional_str(payload.get("status")),
+            "output_path": _optional_str(payload.get("output_path")),
+            "input_path": _optional_str(payload.get("input_path")),
+            "run_id": _optional_str(payload.get("run_id")),
+        }
+    return {
+        "by_date": by_date,
+        "manifests": manifests,
+        "source_manifest_keys": sorted(seen_keys),
+    }
+
+
+def _empty_regime_manifest_context(dates: Sequence[str]) -> dict[str, object]:
+    """Return an empty manifest-context shape for cached report fallbacks."""
+    return {
+        "by_date": {date_text: {"manifest_key": None, "metadata": {}} for date_text in dates},
+        "manifests": [],
+        "source_manifest_keys": [],
+    }
+
+
+def _read_first_available_json_object(
+    writer: R2Writer,
+    keys: Sequence[str],
+) -> tuple[dict[str, object] | None, str | None]:
+    """Return the first readable JSON object for one of the provided keys."""
+    for key in keys:
+        try:
+            payload = json.loads(writer.get_object(key).decode("utf-8"))
+        except FileNotFoundError:
+            continue
+        if isinstance(payload, Mapping):
+            return {str(item_key): _json_safe(item) for item_key, item in payload.items()}, key
+        return {}, key
+    return None, None
+
+
+def _manifest_summary(payload: Mapping[str, object], key: str) -> dict[str, object]:
+    """Return manifest fields relevant to HMM review evidence."""
+    metadata = _json_mapping(payload.get("metadata"))
+    return {
+        "manifest_key": key,
+        "run_id": _optional_str(payload.get("run_id")),
+        "stage": _optional_str(payload.get("stage")),
+        "status": _optional_str(payload.get("status")),
+        "input_path": _optional_str(payload.get("input_path")),
+        "output_path": _optional_str(payload.get("output_path")),
+        "train_start_date": _optional_str(metadata.get("train_start_date")),
+        "train_end_date": _optional_str(metadata.get("train_end_date")),
+        "macro_load_start_date": _optional_str(metadata.get("macro_load_start_date")),
+        "macro_load_end_date": _optional_str(metadata.get("macro_load_end_date")),
+        "inference_dates": _json_string_list(metadata.get("inference_dates")),
+        "ready_inference_dates": _json_string_list(metadata.get("ready_inference_dates")),
+        "warning_inference_dates": _json_string_list(metadata.get("warning_inference_dates")),
+        "training_rows": _maybe_int(metadata.get("training_rows")),
+        "complete_training_rows": _maybe_int(metadata.get("complete_training_rows")),
+        "dropped_feature_columns": _json_string_list(metadata.get("dropped_feature_columns")),
+        "regime_layer2_ready": _maybe_bool(metadata.get("regime_layer2_ready")),
+    }
+
+
+def _enrich_regime_rows_with_manifests(
+    regime_map: Mapping[str, SemanticReviewRegimeRow],
+    manifest_context: Mapping[str, object],
+) -> None:
+    """Attach source manifest keys and missing-feature metadata to regime rows."""
+    by_date = manifest_context.get("by_date")
+    if not isinstance(by_date, Mapping):
+        return
+    for date_text, row in regime_map.items():
+        context = by_date.get(date_text)
+        if not isinstance(context, Mapping):
+            continue
+        object.__setattr__(row, "manifest_key", _optional_str(context.get("manifest_key")))
+        metadata = _json_mapping(context.get("metadata"))
+        readiness_by_date = _json_mapping(metadata.get("regime_readiness_by_date"))
+        readiness = _json_mapping(readiness_by_date.get(date_text))
+        if readiness and row.readiness_status is None:
+            object.__setattr__(row, "readiness_status", _optional_str(readiness.get("status")))
+            object.__setattr__(row, "readiness_reason", _optional_str(readiness.get("reason")))
+            object.__setattr__(
+                row,
+                "required_for_layer2",
+                _maybe_bool(readiness.get("required_for_layer2")),
+            )
+            object.__setattr__(
+                row,
+                "missing_features",
+                _json_string_list(readiness.get("missing_features")),
+            )
+            object.__setattr__(row, "probability_sum", _maybe_float(readiness.get("probability_sum")))
+
+
+def _append_market_context_warnings(
+    *,
+    dates: Sequence[str],
+    price_rows: Sequence[SemanticReviewPriceRow],
+    regime_map: Mapping[str, SemanticReviewRegimeRow],
+    load_warnings: list[dict[str, object]],
+) -> None:
+    """Add explicit warnings for missing or all-null price/HMM review evidence."""
+    price_dates = {row.date for row in price_rows}
+    for date_text in dates:
+        if date_text not in price_dates:
+            load_warnings.append(
+                {
+                    "scope": "price_series",
+                    "date": date_text,
+                    "message": "No raw price row is available for this review date.",
+                }
+            )
+        regime = regime_map.get(date_text)
+        if regime is None:
+            load_warnings.append(
+                {
+                    "scope": "hmm_regime",
+                    "date": date_text,
+                    "message": "No HMM regime row is available for this review date.",
+                }
+            )
+            continue
+        if all(
+            value is None
+            for value in (
+                regime.regime,
+                regime.confidence,
+                regime.prob_bear,
+                regime.prob_sideways,
+                regime.prob_bull,
+            )
+        ):
+            load_warnings.append(
+                {
+                    "scope": "hmm_regime",
+                    "date": date_text,
+                    "artifact_key": regime.artifact_key,
+                    "manifest_key": regime.manifest_key,
+                    "message": "HMM regime row is present but all label/probability fields are null.",
+                }
+            )
+
+
+def _build_market_regime_rows(
+    *,
+    dates: Sequence[str],
+    price_rows: Sequence[SemanticReviewPriceRow],
+    regime_map: Mapping[str, SemanticReviewRegimeRow],
+) -> list[dict[str, object]]:
+    """Return date-aligned price and HMM regime rows for chart/API consumers."""
+    price_by_date = {row.date: row.to_dict() for row in price_rows}
+    rows: list[dict[str, object]] = []
+    for date_text in dates:
+        price = price_by_date.get(date_text)
+        regime = regime_map.get(date_text)
+        warnings: list[str] = []
+        if price is None:
+            warnings.append("missing_price")
+        if regime is None:
+            warnings.append("missing_hmm_regime")
+            regime_payload = None
+        else:
+            regime_payload = regime.to_dict()
+            if all(
+                regime_payload.get(field) is None
+                for field in ("regime", "confidence", "prob_bear", "prob_sideways", "prob_bull")
+            ):
+                warnings.append("all_null_hmm_regime")
+            if regime.manifest_key is None:
+                warnings.append("missing_hmm_manifest")
+            if regime.missing_features:
+                warnings.append("incomplete_hmm_feature_set")
+        rows.append(
+            {
+                "date": date_text,
+                "ticker": price.get("ticker") if price else None,
+                "price": price,
+                "hmm_regime": regime_payload,
+                "warnings": warnings,
+                "scope": "date-aligned-price-and-hmm",
+            }
+        )
+    return rows
+
+
+def _build_hmm_evaluation_context(
+    *,
+    dates: Sequence[str],
+    regime_map: Mapping[str, SemanticReviewRegimeRow],
+    manifest_context: Mapping[str, object],
+    artifact_keys: Mapping[str, Sequence[str]],
+) -> dict[str, object]:
+    """Return explicit HMM evaluation scope and source metadata for review."""
+    manifests = [
+        dict(item)
+        for item in manifest_context.get("manifests", [])
+        if isinstance(item, Mapping)
+    ]
+    observed_dates = sorted(regime_map)
+    source_manifest_keys = [
+        str(item)
+        for item in manifest_context.get("source_manifest_keys", [])
+        if _optional_str(item) is not None
+    ]
+    by_date = manifest_context.get("by_date")
+    not_evaluated_dates: list[str] = []
+    stale_manifest_dates: list[str] = []
+    if isinstance(by_date, Mapping):
+        for date_text in dates:
+            context = by_date.get(date_text)
+            if not isinstance(context, Mapping):
+                continue
+            status = (_optional_str(context.get("status")) or "").lower()
+            if status and status != "completed":
+                stale_manifest_dates.append(date_text)
+            metadata = _json_mapping(context.get("metadata"))
+            inference_dates = _json_string_list(metadata.get("inference_dates"))
+            if inference_dates and date_text not in set(inference_dates):
+                not_evaluated_dates.append(date_text)
+    dropped_columns = sorted(
+        {
+            column
+            for manifest in manifests
+            for column in _json_string_list(manifest.get("dropped_feature_columns"))
+        }
+    )
+    expected_columns = list(HMM_TRAINING_FEATURE_COLUMNS)
+    active_columns = [column for column in expected_columns if column not in set(dropped_columns)]
+    warnings: list[str] = []
+    if not source_manifest_keys:
+        warnings.append("missing_hmm_manifest")
+    missing_dates = sorted(set(dates) - set(observed_dates))
+    if missing_dates:
+        warnings.append("missing_hmm_inference_dates")
+    unexpected_dates = sorted(set(observed_dates) - set(dates))
+    if unexpected_dates:
+        warnings.append("unexpected_hmm_inference_dates")
+    if not_evaluated_dates:
+        warnings.append("hmm_not_evaluated_for_date")
+    if stale_manifest_dates:
+        warnings.append("stale_hmm_manifest")
+    if dropped_columns:
+        warnings.append("incomplete_hmm_feature_set")
+    if not any(_optional_str(manifest.get("train_end_date")) for manifest in manifests):
+        warnings.append("missing_training_window_metadata")
+    return {
+        "scope": "market-wide-date-level-hmm",
+        "applies_to": "all tickers and sentence rows for each inference date",
+        "expected_input_feature_columns": expected_columns,
+        "input_feature_columns_used": active_columns,
+        "dropped_feature_columns": dropped_columns,
+        "requested_inference_dates": list(dates),
+        "observed_inference_dates": observed_dates,
+        "missing_inference_dates": missing_dates,
+        "unexpected_inference_dates": unexpected_dates,
+        "not_evaluated_dates": not_evaluated_dates,
+        "stale_manifest_dates": stale_manifest_dates,
+        "training_windows": _training_windows_from_manifests(manifests),
+        "source_artifact_keys": list(artifact_keys.get("regime", [])),
+        "source_manifest_keys": source_manifest_keys,
+        "manifest_summaries": manifests,
+        "warnings": warnings,
+    }
+
+
+def _training_windows_from_manifests(
+    manifests: Sequence[Mapping[str, object]],
+) -> list[dict[str, object]]:
+    """Return de-duplicated HMM training/lookback windows from manifest summaries."""
+    windows: list[dict[str, object]] = []
+    seen: set[tuple[object, ...]] = set()
+    for manifest in manifests:
+        window = {
+            "train_start_date": _optional_str(manifest.get("train_start_date")),
+            "train_end_date": _optional_str(manifest.get("train_end_date")),
+            "macro_load_start_date": _optional_str(manifest.get("macro_load_start_date")),
+            "macro_load_end_date": _optional_str(manifest.get("macro_load_end_date")),
+            "training_rows": _maybe_int(manifest.get("training_rows")),
+            "complete_training_rows": _maybe_int(manifest.get("complete_training_rows")),
+        }
+        key = tuple(window.values())
+        if key in seen:
+            continue
+        seen.add(key)
+        windows.append(window)
+    return windows
 
 
 def _load_date_partitioned_artifacts(
@@ -1148,6 +1703,9 @@ def _build_payload_from_report(report: Layer1SemanticReviewReport | Mapping[str,
             "to_date": report_dict.get("to_date"),
         },
         "date_groups": date_groups,
+        "price_series": list(report_dict.get("price_rows", [])),
+        "market_regime_series": list(report_dict.get("market_regime_rows", [])),
+        "hmm_evaluation_context": dict(report_dict.get("hmm_evaluation_context", {})),
         "article_groups": article_groups,
         "accepted_articles": accepted_articles,
         "flagged_articles": flagged_articles,
@@ -1165,6 +1723,8 @@ def _build_payload_from_report(report: Layer1SemanticReviewReport | Mapping[str,
                 report_dict.get("semantic_aggregate_rows", [])
             ),
             "date_level_regime_rows": list(report_dict.get("regime_rows", [])),
+            "stock_price_rows": list(report_dict.get("price_rows", [])),
+            "date_aligned_price_hmm_rows": list(report_dict.get("market_regime_rows", [])),
         },
         "artifact_keys": dict(report_dict.get("artifact_keys", {})),
         "warnings": list(report_dict.get("load_warnings", [])),
@@ -1177,6 +1737,7 @@ __all__ = [
     "Layer1SemanticReviewReport",
     "SemanticReviewArticleGroup",
     "SemanticReviewDateGroup",
+    "SemanticReviewPriceRow",
     "SemanticReviewRegimeRow",
     "SemanticReviewSentenceRow",
     "build_layer1_aapl_evidence_report",
@@ -1384,6 +1945,14 @@ def _json_string_list(value: Any) -> list[str]:
     if isinstance(decoded, Sequence) and not isinstance(decoded, (bytes, bytearray, str)):
         return [str(item).strip() for item in decoded if str(item).strip()]
     return [str(decoded).strip()] if str(decoded).strip() else []
+
+
+def _comma_string_list(value: Any) -> list[str]:
+    """Return a clean string list from comma-delimited or JSON-list input."""
+    items = _json_string_list(value)
+    if len(items) != 1 or "," not in items[0]:
+        return items
+    return [item.strip() for item in items[0].split(",") if item.strip()]
 
 
 def _json_value(value: Any) -> object:

--- a/docs/layer1_semantic_review_dashboard.md
+++ b/docs/layer1_semantic_review_dashboard.md
@@ -25,8 +25,17 @@ the pilot for the broad point-in-time backfill tracked by #202.
   `features/{date}/sentiment_features/{run_id}.parquet`, including parsed
   source-weight summaries, topic sentiment summaries, contributing article ids,
   relevance reason codes, and semantic warning codes.
+- Date-aligned raw stock-price rows from `raw/prices/{ticker}.parquet`, including
+  close/adjusted-close, volume, one-day return, and drawdown from the review-window high.
 - HMM regime is shown once per trading date in a dedicated date header.
   Confidence and probabilities are therefore clearly date-level, not per row.
+- A stock-price/HMM chart synchronizes adjusted-close price with bear/sideways/bull
+  probabilities on the same date axis so reviewers can compare regime labels with
+  prior price behavior.
+- HMM evaluation context is exposed explicitly: expected input feature columns, any
+  dropped feature columns, requested and observed inference dates, training/lookback
+  window metadata, source regime artifact keys, source manifest keys, and warnings for
+  missing, all-null, or incomplete HMM evidence.
 - Articles are split into accepted and flagged groups.
   Flagged articles stay visible with the evidence that caused the flag.
 
@@ -82,8 +91,13 @@ Top-level response fields:
 - `article_groups`: flat article cards for cross-date inspection
 - `accepted_articles`: accepted article cards
 - `flagged_articles`: flagged article cards
+- `price_series`: date-aligned raw stock-price context rows
+- `market_regime_series`: one row per trading date combining stock price and HMM
+  regime evidence plus per-date warnings
+- `hmm_evaluation_context`: HMM scope, input feature columns, training window, source
+  keys, inference date coverage, and warning metadata
 - `pipeline_sections`: stage-separated raw preprocessing, embedding, topic,
-  relevance, FinBERT, semantic aggregate, and regime rows
+  relevance, FinBERT, semantic aggregate, stock-price, and regime rows
 - `artifact_keys`: resolved R2 keys used for each evidence section
 - `human_semantic_review_status`: currently `needs_human_review`
 - `recommendation_for_issue_202`: currently `needs_human_review`
@@ -93,9 +107,20 @@ Each `date_groups[]` entry contains:
 
 - `date`
 - `regime` with `scope: "date-level"`
+- `price` with `scope: "ticker-date"`
+- `market_regime_context` with aligned price/HMM warning flags
 - `semantic_aggregates[]` with ticker-date semantic aggregate rows
 - article counts
 - nested `articles[]`
+
+Each `market_regime_series[]` entry contains:
+
+- `date`
+- `price` with OHLCV, adjusted close, return, drawdown, and source artifact key
+- `hmm_regime` with label, confidence, bear/sideways/bull probabilities, readiness
+  fields, source artifact key, and source manifest key
+- `warnings`, for example `missing_price`, `missing_hmm_regime`,
+  `all_null_hmm_regime`, `missing_hmm_manifest`, or `incomplete_hmm_feature_set`
 
 Each `articles[]` entry contains:
 
@@ -134,11 +159,17 @@ Each `pipeline_sections.semantic_aggregate_rows[]` entry contains parsed:
 
 ## Review guidance
 
-1. Check the date header first for the HMM regime context.
-2. Inspect the pipeline evidence cards to confirm each NLP stage is present.
-3. Expand an article card to inspect preprocessing, topic, relevance, and
+1. Check the stock-price/HMM chart first to compare price behavior with the
+   bull/bear/sideways regime evidence.
+2. Inspect the HMM context and warnings to confirm the feature set, inference
+   dates, source artifacts, and training window are trustworthy.
+3. Check the date header for the date-level HMM regime context.
+4. Inspect the pipeline evidence cards to confirm each NLP stage is present.
+5. Expand an article card to inspect preprocessing, topic, relevance, and
    sentence-level FinBERT rows together.
-4. Use the evidence snippets and ticker-hit fields to decide whether the article
+6. Use the evidence snippets and ticker-hit fields to decide whether the article
    is actually about AAPL.
-5. Do not accept the pilot if the flagged section contains unrelated articles
+7. Do not accept the pilot if the flagged section contains unrelated articles
    that are not explained by source-text evidence.
+8. Do not accept the pilot if price/HMM context is missing, stale, all-null, or
+   evaluated from an unexpected feature set/window without a documented reason.

--- a/tests/fixtures/semantic_review_support.py
+++ b/tests/fixtures/semantic_review_support.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import pandas as pd
 
+from core.contracts.schemas import PipelineManifestRecord, RunStatus
 from services.r2.paths import (
     layer1_news_preprocessing_path,
     layer1_news_relevance_gate_path,
@@ -16,6 +17,8 @@ from services.r2.paths import (
     layer1_sentiment_score_path,
     layer1_text_embedding_path,
     layer1_topic_label_path,
+    pipeline_manifest_path,
+    raw_price_path,
 )
 from services.r2.writer import R2Writer
 
@@ -47,6 +50,7 @@ def seed_semantic_review_fixture(
     writer = R2Writer(local_root=local_root)
     scored_frame = pd.DataFrame(fixture["scored_rows"])
     regime_frame = pd.DataFrame(fixture["regime_rows"])
+    regime_frame = _regime_frame_with_review_metadata(regime_frame)
     preprocessing_frame = _preprocessing_frame(scored_frame)
     embedding_frame = _embedding_frame(scored_frame)
     topic_label_frame = _topic_label_frame(scored_frame)
@@ -79,10 +83,14 @@ def seed_semantic_review_fixture(
             ),
         )
 
+    for date_text, date_frame in regime_frame.groupby("date", sort=True):
+        output_key = layer1_regime_path(str(date_text), active_run_id)
+        writer.put_object(output_key, _dataframe_to_parquet_bytes(date_frame))
     writer.put_object(
-        layer1_regime_path(fixture["regime_rows"][0]["date"], active_run_id),
-        _dataframe_to_parquet_bytes(regime_frame),
+        pipeline_manifest_path("layer1_5_regime", active_run_id),
+        _regime_manifest_json(active_run_id, sorted(regime_frame["date"].astype(str).unique())),
     )
+    writer.put_object(raw_price_path("AAPL"), _dataframe_to_parquet_bytes(_price_frame()))
     return {
         "run_id": active_run_id,
         "writer": writer,
@@ -97,6 +105,90 @@ def _dataframe_to_parquet_bytes(frame: pd.DataFrame) -> bytes:
     buffer = BytesIO()
     frame.to_parquet(buffer, index=False)
     return buffer.getvalue()
+
+
+def _regime_frame_with_review_metadata(frame: pd.DataFrame) -> pd.DataFrame:
+    """Return fixture HMM rows with readiness metadata used by the dashboard."""
+    enriched = frame.copy()
+    enriched["regime_readiness_status"] = "ready"
+    enriched["regime_readiness_reason"] = "ready"
+    enriched["regime_required_for_layer2"] = True
+    enriched["regime_missing_features"] = ""
+    enriched["regime_probability_sum"] = (
+        enriched["prob_bear"] + enriched["prob_sideways"] + enriched["prob_bull"]
+    )
+    enriched["training_rows"] = 42
+    enriched["complete_training_rows"] = 40
+    enriched["min_training_rows"] = 30
+    return enriched
+
+
+def _regime_manifest_json(run_id: str, inference_dates: list[str]) -> str:
+    """Return a completed HMM manifest with fixture training-window metadata."""
+    metadata = {
+        "benchmark_ticker": "SPY",
+        "train_start_date": "2026-02-02",
+        "train_end_date": "2026-05-20",
+        "inference_dates": inference_dates,
+        "ready_inference_dates": inference_dates,
+        "warning_inference_dates": [],
+        "macro_load_start_date": "2026-02-02",
+        "macro_load_end_date": inference_dates[-1],
+        "training_rows": 42,
+        "complete_training_rows": 40,
+        "dropped_feature_columns": [],
+        "regime_layer2_ready": True,
+        "regime_readiness_by_date": {
+            date_text: {
+                "status": "ready",
+                "reason": "ready",
+                "required_for_layer2": True,
+                "missing_features": [],
+                "probability_sum": 1.0,
+            }
+            for date_text in inference_dates
+        },
+    }
+    manifest = PipelineManifestRecord(
+        run_id=run_id,
+        stage="layer1_5_regime",
+        status=RunStatus.COMPLETED,
+        started_at=pd.Timestamp("2026-05-22T20:00:00Z").to_pydatetime(),
+        finished_at=pd.Timestamp("2026-05-22T20:05:00Z").to_pydatetime(),
+        input_path=f"{raw_price_path('SPY')},raw/macro/",
+        output_path=layer1_regime_path(inference_dates[0], run_id),
+        metadata=metadata,
+    )
+    return manifest.model_dump_json()
+
+
+def _price_frame() -> pd.DataFrame:
+    """Return raw AAPL price rows for the semantic-review fixture window."""
+    rows = [
+        {
+            "date": "2026-05-21",
+            "ticker": "AAPL",
+            "open": 189.5,
+            "high": 193.2,
+            "low": 188.8,
+            "close": 192.4,
+            "adj_close": 192.4,
+            "volume": 52_000_000,
+            "dollar_volume": 10_004_800_000.0,
+        },
+        {
+            "date": "2026-05-22",
+            "ticker": "AAPL",
+            "open": 192.2,
+            "high": 195.0,
+            "low": 191.6,
+            "close": 194.8,
+            "adj_close": 194.8,
+            "volume": 48_500_000,
+            "dollar_volume": 9_447_800_000.0,
+        },
+    ]
+    return pd.DataFrame(rows)
 
 
 def _preprocessing_frame(scored_frame: pd.DataFrame) -> pd.DataFrame:

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -15,6 +15,8 @@ from services.r2.paths import (
     layer1_sentiment_score_path,
     layer1_text_embedding_path,
     layer1_topic_label_path,
+    pipeline_manifest_path,
+    raw_price_path,
 )
 from tests.fixtures.semantic_review_support import seed_semantic_review_fixture
 
@@ -39,6 +41,13 @@ def test_semantic_review_report_groups_sentence_rows_and_date_regime(tmp_path: P
     assert report_dict["topic_label_row_count"] == 4
     assert report_dict["relevance_gate_row_count"] == 8
     assert report_dict["semantic_aggregate_row_count"] == 2
+    assert report_dict["summary"]["price_row_count"] == 2
+    assert report_dict["summary"]["hmm_regime_row_count"] == 2
+
+    price_rows = cast(list[dict[str, Any]], report_dict["price_rows"])
+    assert [row["date"] for row in price_rows] == ["2026-05-21", "2026-05-22"]
+    assert price_rows[0]["adj_close"] == 192.4
+    assert price_rows[1]["return_1d"] is not None
 
     article_groups = {
         str(item["article_id"]): cast(dict[str, Any], item)
@@ -60,8 +69,21 @@ def test_semantic_review_report_groups_sentence_rows_and_date_regime(tmp_path: P
     assert regime["scope"] == "date-level"
     assert regime["applies_to"] == "all sentence rows on the trading date"
     assert regime["regime"] == "sideways"
+    assert regime["readiness_status"] == "ready"
+    assert regime["manifest_key"] == pipeline_manifest_path(
+        "layer1_5_regime",
+        str(fixture["run_id"]),
+    )
+    assert date_groups["2026-05-21"]["price"]["close"] == 192.4
+    assert date_groups["2026-05-21"]["market_regime_context"]["warnings"] == []
     assert date_groups["2026-05-21"]["sentence_count"] == 5
     assert date_groups["2026-05-21"]["semantic_aggregates"][0]["source_weight_summary"]
+
+    context = cast(dict[str, Any], report_dict["hmm_evaluation_context"])
+    assert context["requested_inference_dates"] == ["2026-05-21", "2026-05-22"]
+    assert context["observed_inference_dates"] == ["2026-05-21", "2026-05-22"]
+    assert context["warnings"] == []
+    assert context["training_windows"][0]["train_end_date"] == "2026-05-20"
 
 
 def test_semantic_review_report_loads_dated_stage_artifacts_for_parent_run_id(tmp_path: Path) -> None:
@@ -89,8 +111,16 @@ def test_semantic_review_report_loads_dated_stage_artifacts_for_parent_run_id(tm
             )
         writer.put_object(
             layer1_regime_path(date_text, stage_run_id),
-            writer.get_object(layer1_regime_path("2026-05-21", fixture["run_id"])),
+            writer.get_object(layer1_regime_path(date_text, fixture["run_id"])),
         )
+    writer.put_object(
+        pipeline_manifest_path("layer1_5_regime", parent_run_id),
+        writer.get_object(pipeline_manifest_path("layer1_5_regime", fixture["run_id"])),
+    )
+    writer.put_object(
+        raw_price_path("AAPL"),
+        writer.get_object(raw_price_path("AAPL")),
+    )
 
     report = build_layer1_aapl_evidence_report(
         run_id=parent_run_id,
@@ -133,6 +163,11 @@ def test_semantic_review_payload_flags_weak_and_duplicate_articles(tmp_path: Pat
     assert len(cast(list[dict[str, Any]], sections["topic_label_rows"])) == 4
     assert len(cast(list[dict[str, Any]], sections["relevance_gate_rows"])) == 8
     assert len(cast(list[dict[str, Any]], sections["semantic_aggregate_rows"])) == 2
+    assert len(cast(list[dict[str, Any]], payload["price_series"])) == 2
+    assert len(cast(list[dict[str, Any]], payload["market_regime_series"])) == 2
+    assert len(cast(list[dict[str, Any]], sections["stock_price_rows"])) == 2
+    assert len(cast(list[dict[str, Any]], sections["date_aligned_price_hmm_rows"])) == 2
+    assert payload["hmm_evaluation_context"]["warnings"] == []
 
     article_groups = cast(list[dict[str, Any]], payload["article_groups"])
     ferrari = next(item for item in article_groups if item["article_id"] == "ferrari-001")
@@ -144,6 +179,37 @@ def test_semantic_review_payload_flags_weak_and_duplicate_articles(tmp_path: Pat
     duplicate = next(item for item in article_groups if item["article_id"] == "aapl-001")
     assert "duplicate_normalized_headline" in duplicate["contamination_flags"]
     assert duplicate["sentence_rows"][0]["text"].startswith("Apple shares climbed")
+
+
+def test_semantic_review_payload_warns_when_price_or_hmm_context_is_missing(
+    tmp_path: Path,
+) -> None:
+    """Missing price and HMM context should be surfaced as aligned review warnings."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    writer = fixture["writer"]
+    writer.delete_object(raw_price_path("AAPL"))
+    writer.delete_object(layer1_regime_path("2026-05-22", str(fixture["run_id"])))
+
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=writer,
+    )
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    warnings = cast(list[dict[str, Any]], payload["warnings"])
+    aligned_rows = {
+        str(item["date"]): cast(dict[str, Any], item)
+        for item in cast(list[dict[str, Any]], payload["market_regime_series"])
+    }
+
+    assert any(item["scope"] == "price_series" for item in warnings)
+    assert any(item["scope"] == "hmm_regime" and item["date"] == "2026-05-22" for item in warnings)
+    assert "missing_price" in aligned_rows["2026-05-21"]["warnings"]
+    assert "missing_hmm_regime" in aligned_rows["2026-05-22"]["warnings"]
+    assert payload["hmm_evaluation_context"]["missing_inference_dates"] == ["2026-05-22"]
+    assert payload["human_semantic_review_status"] == "needs_human_review"
 
 
 def test_semantic_review_dashboard_html_labels_date_level_regime_and_sentence_rows() -> None:
@@ -161,6 +227,9 @@ def test_semantic_review_dashboard_html_labels_date_level_regime_and_sentence_ro
     assert "Layer 1 semantic-review dashboard" in html
     assert "Raw ticker/entity preprocessing, article embeddings, BERTopic labels" in html
     assert "Date-level HMM regime" in html
+    assert "Stock Price and HMM Regime" in html
+    assert "Stock-price rows" in html
+    assert "date_aligned_price_hmm_rows" in html
     assert "Pipeline Evidence" in html
     assert "needs_human_review" in html
     assert "/api/review" in html


### PR DESCRIPTION
## What this PR does
Adds stock-price and HMM regime-evaluation context to the Layer 1 semantic-review dashboard/API. The review payload now includes date-aligned raw price rows, aligned price/HMM rows, HMM feature/window/source metadata, and explicit warnings for missing, stale, not-evaluated, all-null, or incomplete HMM context. The browser dashboard renders a synchronized stock-price/HMM probability chart while keeping NLP article evidence, semantic aggregates, and date-level HMM rows separate.

## Closes
Closes #236

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, missing price/HMM context, date alignment, and bull/sideways/bear probability payload rendering/API behavior
- [x] No live API calls in unit tests — semantic-review fixture uses local mock R2

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [ ] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>` — using pre-provisioned worker branch `tribunal/issue-236-issue236-20260627-170137`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None. Verification used a local `.venv` with dependencies already declared in existing requirement files.

## Screenshots or sample output
Local mock-R2 API smoke:

```bash
./.venv/bin/python -m app.lab.semantic_review_dashboard \
  --run-id layer1-semantic-review-fixture \
  --from-date 2026-05-21 \
  --to-date 2026-05-22 \
  --ticker AAPL \
  --host 127.0.0.1 \
  --port 8766 \
  --local-root /tmp/semantic-review-r2-issue236
curl -fsS "http://127.0.0.1:8766/api/review?ticker=AAPL"
# checked: price_row_count=2, market_regime_series rows=2, hmm warnings=[]
```

## Verification artifacts
Commands run:
- `./.venv/bin/pytest tests/unit/test_semantic_review_dashboard.py -v --tb=short` → 5 passed
- `./.venv/bin/ruff check app/lab/semantic_review_dashboard.py core/features/semantic_review_dashboard.py core/features/aapl_evidence.py tests/unit/test_semantic_review_dashboard.py` → passed
- `./.venv/bin/pytest tests/unit/ -v --tb=short` → 721 passed, 1 skipped, 62 warnings
- Local mock-R2 dashboard API smoke above → HTTP 200 and expected price/HMM fields

Manifest key(s):
- Fixture smoke: `artifacts/manifests/layer1_5_regime/layer1-semantic-review-fixture.json`

Report path(s):
- N/A; dashboard/API evidence enhancement only

R2 output prefix(es):
- No production R2 writes or mutations
- Read-only source prefixes/keys: `raw/prices/{ticker}.parquet`, `features/{YYYY-MM-DD}/regime/{run_id}.parquet`, `artifacts/manifests/layer1_5_regime/{run_id}.json`

Known skipped/missing data:
- Full unit suite has 1 existing skipped test; no Issue #236-specific skipped tests

## Notes for reviewer
Scope is limited to semantic-review dashboard/API evidence. This does not run #202 backfill, mutate production R2, change contracts, or touch Layer 2+ training/inference/portfolio/risk/execution code.