### PR TITLE
Add semantic dashboard summary gate status

### DIFF
--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -481,6 +481,30 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
     .metric .value {{ font-size: 1.6rem; font-weight: 700; margin-top: 6px; }}
     .metric .raw {{ color: var(--muted); font-size: 0.8rem; margin-top: 4px; }}
     .state-card {{ display: grid; gap: 8px; }}
+    .tab-bar {{ display: flex; gap: 8px; flex-wrap: wrap; }}
+    .tab-button {{
+      appearance: none;
+      border: 1px solid rgba(56, 189, 248, 0.42);
+      border-radius: 999px;
+      background: rgba(56, 189, 248, 0.14);
+      color: #dff7ff;
+      padding: 8px 12px;
+      font-weight: 700;
+    }}
+    .tab-panel {{ display: grid; gap: 14px; }}
+    .readiness-line {{ color: var(--muted); margin-bottom: 0; }}
+    .gate-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 10px; }}
+    .gate {{
+      padding: 13px;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: rgba(11, 18, 32, 0.84);
+      min-height: 132px;
+    }}
+    .gate .name {{ font-weight: 750; margin-bottom: 6px; }}
+    .gate .message {{ color: var(--muted); font-size: 0.9rem; margin: 8px 0 0; }}
+    .gate.good {{ border-color: rgba(74, 222, 128, 0.36); }}
+    .gate.bad {{ border-color: rgba(251, 113, 133, 0.42); }}
     .state-pill {{
       width: fit-content;
       padding: 6px 12px;
@@ -570,6 +594,20 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         <div class="hero-grid" id="metrics"></div>
       </section>
 
+      <nav class="tab-bar" aria-label="Semantic dashboard tabs">
+        <button class="tab-button active" type="button" role="tab" aria-selected="true" aria-controls="summary-gate-tab">Summary / Gate Status</button>
+      </nav>
+
+      <section class="panel tab-panel" id="summary-gate-tab" role="tabpanel">
+        <div>
+          <h2>Summary / Gate Status</h2>
+          <p class="readiness-line" id="readiness-line">Loading run readiness…</p>
+        </div>
+        <div class="hero-grid" id="summary-cards"></div>
+        <div id="missing-sections"></div>
+        <div class="gate-grid" id="gate-cards"></div>
+      </section>
+
       <section class="panel">
         <h2>Why does it matter?</h2>
         <div class="explain-grid">
@@ -616,6 +654,10 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
     const defaults = {defaults_json};
     const metaEl = document.getElementById('meta');
     const metricsEl = document.getElementById('metrics');
+    const summaryCardsEl = document.getElementById('summary-cards');
+    const gateCardsEl = document.getElementById('gate-cards');
+    const readinessLineEl = document.getElementById('readiness-line');
+    const missingSectionsEl = document.getElementById('missing-sections');
     const stateEl = document.getElementById('review-state');
     const stateExplainerEl = document.getElementById('state-explainer');
     const chartMetaEl = document.getElementById('chart-meta');
@@ -732,6 +774,45 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         metricCard('Flagged stories', summary.flagged_article_count ?? 0, 'flagged_article_count', 'Stories that need a closer look because their evidence is weak or off-topic.'),
         metricCard('Market benchmark', benchmarkTicker, 'benchmark_ticker', 'The benchmark ticker used for the HMM regime chart.'),
       ].join('');
+    }}
+
+    function renderSummaryGateStatus(payload) {{
+      const readiness = payload.run_readiness || {{}};
+      const cards = Array.isArray(payload.summary_cards) ? payload.summary_cards : [];
+      const gates = Array.isArray(payload.gate_cards) ? payload.gate_cards : [];
+      const missingSections = Array.isArray(payload.missing_pipeline_sections) ? payload.missing_pipeline_sections : [];
+      const ready = readiness.ready_for_final_human_acceptance === true;
+      const recommendation = readiness.recommendation || (ready ? 'ready for final human acceptance' : 'not ready for final human acceptance');
+      readinessLineEl.innerHTML = `
+        <strong class="${{ready ? 'good' : 'bad'}}">${{escapeHtml(recommendation)}}</strong>
+        <span class="muted"> · human review status: ${{escapeHtml(readiness.human_review_status || 'unknown')}}</span>`;
+      summaryCardsEl.innerHTML = cards.map((card) => metricCard(
+        card.label || card.field || 'Summary',
+        card.value ?? 'n/a',
+        card.field || card.label || 'summary',
+        card.field || card.label || 'summary'
+      )).join('');
+      missingSectionsEl.innerHTML = missingSections.length
+        ? `<div class="chart-blocker">
+            <h3>Human review remains blocked</h3>
+            <p>The run is <strong>not ready for final human acceptance</strong> because required NLP, HMM, or price evidence is missing.</p>
+            <ul>${{missingSections.map((section) => `<li>${{escapeHtml(section.label || section.key)}}: ${{escapeHtml(section.reason || 'missing required evidence')}}</li>`).join('')}}</ul>
+          </div>`
+        : `<p class="readiness-line good">Required NLP, HMM, and price evidence is present. Human semantic review can start.</p>`;
+      gateCardsEl.innerHTML = gates.map((gate) => {{
+        const blocked = gate.status === 'blocked';
+        const keys = Array.isArray(gate.missing_or_tried_keys) ? gate.missing_or_tried_keys : [];
+        const artifacts = Array.isArray(gate.artifact_keys) ? gate.artifact_keys : [];
+        return `
+          <div class="gate ${{blocked ? 'bad' : 'good'}}">
+            <div class="name">${{escapeHtml(gate.label || gate.key || 'Gate')}}</div>
+            <span class="state-pill ${{blocked ? 'bad' : 'good'}}">${{blocked ? 'Blocked' : 'Ready'}}</span>
+            <div class="message">rows: ${{Number(gate.row_count || 0)}} · required: ${{gate.required === false ? 'no' : 'yes'}}</div>
+            <div class="message">${{escapeHtml(gate.message || '')}}</div>
+            ${{keys.length ? `<div class="message">missing/tried: ${{escapeHtml(keys.slice(0, 3).join(', '))}}${{keys.length > 3 ? '…' : ''}}</div>` : ''}}
+            ${{!keys.length && artifacts.length ? `<div class="message">artifact: ${{escapeHtml(artifacts[0])}}</div>` : ''}}
+          </div>`;
+      }}).join('');
     }}
 
     function renderChart(payload) {{
@@ -1006,6 +1087,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       document.body.dataset.smokeStatus = payload.smoke?.status || 'unknown';
       renderTopline(payload, reviewState);
       renderMetrics(payload);
+      renderSummaryGateStatus(payload);
       renderChart(payload);
       renderPipelineSection(payload.pipeline_sections || {{}});
       datesEl.innerHTML = Array.isArray(payload.date_groups) && payload.date_groups.length

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -1,7 +1,9 @@
 """UI payload helpers for the Layer 1 semantic-review dashboard."""
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
 
 from core.features.aapl_evidence import (
     Layer1SemanticReviewReport,
@@ -10,11 +12,170 @@ from core.features.aapl_evidence import (
 )
 
 
+@dataclass(frozen=True)
+class _GateDefinition:
+    """Static metadata for one dashboard readiness gate."""
+
+    key: str
+    label: str
+    section_key: str
+    artifact_key: str
+    failure_stages: tuple[str, ...]
+    required: bool = True
+
+
+_GATE_DEFINITIONS = (
+    _GateDefinition(
+        key="news_preprocessing",
+        label="Ticker/entity preprocessing",
+        section_key="raw_preprocessing_rows",
+        artifact_key="news_preprocessing",
+        failure_stages=("news_preprocessing",),
+    ),
+    _GateDefinition(
+        key="text_embeddings",
+        label="Article embeddings",
+        section_key="article_embedding_rows",
+        artifact_key="text_embeddings",
+        failure_stages=("text_embeddings",),
+    ),
+    _GateDefinition(
+        key="topic_labels",
+        label="BERTopic labels",
+        section_key="topic_label_rows",
+        artifact_key="topic_labels",
+        failure_stages=("topic_labels",),
+    ),
+    _GateDefinition(
+        key="news_relevance_gate",
+        label="Pre-FinBERT relevance gate",
+        section_key="relevance_gate_rows",
+        artifact_key="news_relevance_gate",
+        failure_stages=("news_relevance_gate",),
+    ),
+    _GateDefinition(
+        key="news_sentiment_scored",
+        label="Sentence/chunk FinBERT rows",
+        section_key="finbert_sentence_rows",
+        artifact_key="news_sentiment_scored",
+        failure_stages=("news_sentiment_scored",),
+    ),
+    _GateDefinition(
+        key="sentiment_features",
+        label="Ticker-date semantic aggregates",
+        section_key="semantic_aggregate_rows",
+        artifact_key="sentiment_features",
+        failure_stages=("sentiment_features",),
+    ),
+    _GateDefinition(
+        key="hmm_regime",
+        label="Date-level HMM regime",
+        section_key="date_level_regime_rows",
+        artifact_key="regime",
+        failure_stages=("hmm_regime", "hmm_manifest", "hmm_evaluation_context"),
+    ),
+    _GateDefinition(
+        key="stock_price_context",
+        label="Selected-ticker price rows",
+        section_key="stock_price_rows",
+        artifact_key="raw_prices",
+        failure_stages=("raw_price_context",),
+    ),
+    _GateDefinition(
+        key="benchmark_price_context",
+        label="Benchmark price rows",
+        section_key="benchmark_price_series",
+        artifact_key="raw_prices",
+        failure_stages=("benchmark_price_context",),
+    ),
+    _GateDefinition(
+        key="benchmark_hmm_context",
+        label="Benchmark/HMM chart rows",
+        section_key="benchmark_market_regime_series",
+        artifact_key="regime",
+        failure_stages=("benchmark_hmm_chart",),
+    ),
+)
+
+
 def build_layer1_semantic_review_dashboard_payload(
     report: Layer1SemanticReviewReport | Mapping[str, object],
 ) -> dict[str, object]:
     """Return the JSON payload rendered by the semantic-review dashboard UI."""
-    return _build_payload_from_report(report)
+    payload = _build_payload_from_report(report)
+    payload.update(build_layer1_semantic_review_readiness_summary(payload))
+    return payload
+
+
+def build_layer1_semantic_review_readiness_summary(
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    """Return stable run-readiness and gate-card fields for dashboard consumers."""
+    summary = _json_mapping(payload.get("summary"))
+    smoke = _json_mapping(payload.get("smoke"))
+    failures = [dict(item) for item in _json_list(smoke.get("failures")) if isinstance(item, Mapping)]
+    failure_map = _failures_by_stage(failures)
+    gate_cards = [
+        _gate_card_payload(
+            definition=definition,
+            payload=payload,
+            failure_map=failure_map,
+        )
+        for definition in _GATE_DEFINITIONS
+    ]
+    blocked_gates = [card for card in gate_cards if card["status"] == "blocked"]
+    smoke_passed = str(smoke.get("status")) == "pass"
+    ready_for_final_acceptance = smoke_passed and not blocked_gates
+    readiness_status = (
+        "ready_for_final_human_acceptance"
+        if ready_for_final_acceptance
+        else "not_ready_for_final_human_acceptance"
+    )
+    recommendation = (
+        "ready for final human acceptance"
+        if ready_for_final_acceptance
+        else "not ready for final human acceptance"
+    )
+    human_review_status = (
+        "can_start"
+        if ready_for_final_acceptance
+        else "blocked_by_missing_pipeline_evidence"
+    )
+    missing_pipeline_sections = [
+        {
+            "key": str(card["key"]),
+            "label": str(card["label"]),
+            "reason": str(card["message"]),
+            "missing_or_tried_keys": list(_json_string_list(card.get("missing_or_tried_keys"))),
+        }
+        for card in blocked_gates
+    ]
+    run_readiness = {
+        "run_id": payload.get("run_id") or _json_mapping(payload.get("controls")).get("run_id"),
+        "ticker": payload.get("ticker") or _json_mapping(payload.get("controls")).get("ticker"),
+        "from_date": payload.get("from_date") or _json_mapping(payload.get("controls")).get("from_date"),
+        "to_date": payload.get("to_date") or _json_mapping(payload.get("controls")).get("to_date"),
+        "readiness_status": readiness_status,
+        "recommendation": recommendation,
+        "human_review_status": human_review_status,
+        "human_review_can_start": ready_for_final_acceptance,
+        "ready_for_final_human_acceptance": ready_for_final_acceptance,
+        "smoke_status": smoke.get("status") or "unknown",
+        "sentence_row_count": int(summary.get("row_count") or 0),
+        "article_count": int(summary.get("article_count") or 0),
+        "date_count": int(summary.get("date_count") or 0),
+        "accepted_article_count": int(summary.get("accepted_article_count") or 0),
+        "flagged_article_count": int(summary.get("flagged_article_count") or 0),
+        "blocked_gate_count": len(blocked_gates),
+        "missing_pipeline_section_count": len(missing_pipeline_sections),
+        "status_reason": _readiness_status_reason(ready_for_final_acceptance),
+    }
+    return {
+        "run_readiness": run_readiness,
+        "summary_cards": _summary_cards(run_readiness),
+        "gate_cards": gate_cards,
+        "missing_pipeline_sections": missing_pipeline_sections,
+    }
 
 
 def validate_layer1_semantic_review_dashboard_payload(
@@ -22,3 +183,185 @@ def validate_layer1_semantic_review_dashboard_payload(
 ) -> dict[str, object]:
     """Return the smoke gate result for a dashboard payload."""
     return build_layer1_semantic_review_dashboard_smoke_result(payload)
+
+
+def _gate_card_payload(
+    *,
+    definition: _GateDefinition,
+    payload: Mapping[str, object],
+    failure_map: Mapping[str, Sequence[Mapping[str, object]]],
+) -> dict[str, object]:
+    rows = _section_rows(payload, definition.section_key)
+    matching_failures = [
+        dict(failure)
+        for stage in definition.failure_stages
+        for failure in failure_map.get(stage, [])
+    ]
+    missing_keys = _dedupe_preserve_order(
+        key
+        for failure in matching_failures
+        for key in _json_string_list(failure.get("missing_or_tried_keys"))
+    )
+    resolved_keys = _dedupe_preserve_order(
+        [
+            *(
+                key
+                for failure in matching_failures
+                for key in _json_string_list(failure.get("resolved_artifact_keys"))
+            ),
+            *_json_string_list(_json_mapping(payload.get("artifact_keys")).get(definition.artifact_key)),
+        ]
+    )
+    if matching_failures or (definition.required and not rows):
+        status = "blocked"
+    else:
+        status = "ready"
+    return {
+        "key": definition.key,
+        "label": definition.label,
+        "status": status,
+        "required": definition.required,
+        "row_count": len(rows),
+        "artifact_keys": resolved_keys,
+        "missing_or_tried_keys": missing_keys,
+        "failure_reasons": _dedupe_preserve_order(
+            str(failure.get("reason"))
+            for failure in matching_failures
+            if failure.get("reason") is not None
+        ),
+        "message": _gate_message(definition.label, status, len(rows), matching_failures),
+    }
+
+
+def _summary_cards(run_readiness: Mapping[str, object]) -> list[dict[str, object]]:
+    return [
+        {"label": "Run ID", "value": run_readiness.get("run_id") or "n/a", "field": "run_id"},
+        {"label": "Ticker", "value": run_readiness.get("ticker") or "n/a", "field": "ticker"},
+        {
+            "label": "Date range",
+            "value": (
+                f"{run_readiness.get('from_date') or 'n/a'} to "
+                f"{run_readiness.get('to_date') or 'n/a'}"
+            ),
+            "field": "from_date,to_date",
+        },
+        {
+            "label": "Recommendation",
+            "value": run_readiness.get("recommendation") or "n/a",
+            "field": "recommendation",
+        },
+        {
+            "label": "Human review",
+            "value": run_readiness.get("human_review_status") or "n/a",
+            "field": "human_review_status",
+        },
+        {
+            "label": "Sentence rows",
+            "value": int(run_readiness.get("sentence_row_count") or 0),
+            "field": "sentence_row_count",
+        },
+        {
+            "label": "Articles",
+            "value": int(run_readiness.get("article_count") or 0),
+            "field": "article_count",
+        },
+        {
+            "label": "Dates",
+            "value": int(run_readiness.get("date_count") or 0),
+            "field": "date_count",
+        },
+        {
+            "label": "Accepted",
+            "value": int(run_readiness.get("accepted_article_count") or 0),
+            "field": "accepted_article_count",
+        },
+        {
+            "label": "Flagged",
+            "value": int(run_readiness.get("flagged_article_count") or 0),
+            "field": "flagged_article_count",
+        },
+    ]
+
+
+def _gate_message(
+    label: str,
+    status: str,
+    row_count: int,
+    failures: Sequence[Mapping[str, object]],
+) -> str:
+    if status == "ready":
+        return f"{label} is present with {row_count} row(s)."
+    if failures:
+        reasons = ", ".join(
+            _dedupe_preserve_order(
+                str(failure.get("reason"))
+                for failure in failures
+                if failure.get("reason") is not None
+            )
+        )
+        if reasons:
+            return f"{label} is blocked: {reasons}."
+    return f"{label} is blocked because required rows are missing."
+
+
+def _readiness_status_reason(ready_for_final_acceptance: bool) -> str:
+    if ready_for_final_acceptance:
+        return "Required Layer 1 NLP, HMM, and price evidence is present for review."
+    return (
+        "Required Layer 1 NLP, HMM, or price evidence is missing, so human semantic "
+        "review remains blocked."
+    )
+
+
+def _section_rows(payload: Mapping[str, object], section_key: str) -> list[object]:
+    top_level = payload.get(section_key)
+    if isinstance(top_level, Sequence) and not isinstance(top_level, (bytes, bytearray, str)):
+        return list(top_level)
+    sections = _json_mapping(payload.get("pipeline_sections"))
+    rows = sections.get(section_key)
+    if isinstance(rows, Sequence) and not isinstance(rows, (bytes, bytearray, str)):
+        return list(rows)
+    return []
+
+
+def _failures_by_stage(
+    failures: Sequence[Mapping[str, object]],
+) -> dict[str, list[dict[str, object]]]:
+    grouped: dict[str, list[dict[str, object]]] = {}
+    for failure in failures:
+        stage = failure.get("stage")
+        if stage is None:
+            continue
+        grouped.setdefault(str(stage), []).append(dict(failure))
+    return grouped
+
+
+def _json_mapping(value: Any) -> dict[str, object]:
+    if isinstance(value, Mapping):
+        return {str(key): item for key, item in value.items()}
+    return {}
+
+
+def _json_list(value: Any) -> list[object]:
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return list(value)
+    return []
+
+
+def _json_string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value] if value else []
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return [str(item) for item in value if str(item)]
+    return []
+
+
+def _dedupe_preserve_order(items: Sequence[str]) -> list[str]:
+    seen: set[str] = set()
+    values: list[str] = []
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        values.append(item)
+    return values

--- a/docs/layer1_semantic_review_dashboard.md
+++ b/docs/layer1_semantic_review_dashboard.md
@@ -7,6 +7,12 @@ review in plain language before showing raw evidence.
 
 ## What the dashboard shows
 
+- A Summary / Gate Status tab that says whether human semantic review can start
+  or is `not ready for final human acceptance` because required NLP, HMM, or
+  price evidence is missing.
+- Stable gate cards for preprocessing, embeddings, topic labels, relevance
+  gate rows, FinBERT rows, semantic aggregates, HMM rows, selected-ticker price
+  rows, benchmark price rows, and benchmark/HMM chart rows.
 - A simple status card that says whether the page is ready to review, needs a
   data fix, needs a model/pipeline fix, or does not yet have enough evidence.
 - Plain-language overview cards that answer:
@@ -85,6 +91,15 @@ Top-level response fields include:
 
 - `report`: the canonical report payload
 - `summary`: aggregate counts
+- `run_readiness`: stable run-level readiness fields including run ID, ticker,
+  date range, recommendation, human-review status, row/article/date counts,
+  accepted/flagged counts, blocked-gate count, and final-acceptance boolean
+- `summary_cards`: display-ready run ID, ticker, date range, recommendation,
+  human-review status, row/article/date, accepted, and flagged cards
+- `gate_cards`: one stable card per required evidence gate with status, row
+  count, artifact keys, missing/tried keys, failure reasons, and message
+- `missing_pipeline_sections`: blocked gate summaries used by the browser to
+  show why review remains blocked
 - `date_groups`: one entry per trading date
 - `article_groups`: flat article cards for cross-date inspection
 - `accepted_articles`: accepted article cards
@@ -136,3 +151,16 @@ Each `articles[]` entry contains:
 
 The raw rows are intentionally hidden behind expanders so the default page stays
 clean and easy to scan.
+
+## Summary / Gate Status tab
+
+The Summary / Gate Status tab is the first explicit readiness surface. It does
+not infer readiness from browser-only logic; it renders the API fields listed
+above.
+
+Human semantic review can start only when required NLP, HMM, selected-ticker
+price, and benchmark price evidence gates are ready. If any required section is
+empty, missing, loaded from the cached AAPL bundle, or blocked by HMM manifest /
+training-window warnings, the recommendation is `not ready for final human
+acceptance` and `human_review_status` is
+`blocked_by_missing_pipeline_evidence`.

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -8,6 +8,7 @@ from app.lab.semantic_review_dashboard import _DashboardDefaults, _render_dashbo
 from core.features.aapl_evidence import build_layer1_aapl_evidence_report
 from core.features.semantic_review_dashboard import (
     build_layer1_semantic_review_dashboard_payload,
+    build_layer1_semantic_review_readiness_summary,
     validate_layer1_semantic_review_dashboard_payload,
 )
 from services.r2.paths import (
@@ -21,6 +22,7 @@ from services.r2.paths import (
     pipeline_manifest_path,
     raw_price_path,
 )
+from services.r2.writer import R2Writer
 from tests.fixtures.semantic_review_support import seed_semantic_review_fixture
 
 
@@ -189,6 +191,135 @@ def test_semantic_review_payload_flags_weak_and_duplicate_articles(tmp_path: Pat
     assert duplicate["sentence_rows"][0]["text"].startswith("Apple shares climbed")
 
 
+def test_semantic_review_summary_gate_status_allows_complete_evidence(tmp_path: Path) -> None:
+    """Complete raw evidence should produce ready summary and gate-card fields."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    readiness = cast(dict[str, Any], payload["run_readiness"])
+    gates = {
+        str(item["key"]): cast(dict[str, Any], item)
+        for item in cast(list[dict[str, Any]], payload["gate_cards"])
+    }
+
+    assert readiness["ready_for_final_human_acceptance"] is True
+    assert readiness["recommendation"] == "ready for final human acceptance"
+    assert readiness["human_review_status"] == "can_start"
+    assert readiness["article_count"] == 4
+    assert readiness["sentence_row_count"] == 8
+    assert payload["missing_pipeline_sections"] == []
+    assert gates["news_preprocessing"]["status"] == "ready"
+    assert gates["text_embeddings"]["row_count"] == 4
+    assert gates["topic_labels"]["status"] == "ready"
+    assert gates["news_relevance_gate"]["status"] == "ready"
+    assert gates["sentiment_features"]["status"] == "ready"
+    assert gates["hmm_regime"]["status"] == "ready"
+    assert gates["stock_price_context"]["status"] == "ready"
+    assert gates["benchmark_price_context"]["status"] == "ready"
+
+
+def test_semantic_review_summary_gate_status_blocks_missing_evidence(tmp_path: Path) -> None:
+    """Missing stage and benchmark artifacts should be surfaced as blocked gate cards."""
+    fixture = seed_semantic_review_fixture(
+        local_root=tmp_path / "r2",
+        include_benchmark_price_rows=False,
+    )
+    writer = fixture["writer"]
+    run_id = str(fixture["run_id"])
+    writer.delete_object(layer1_topic_label_path("2026-05-21", run_id))
+    report = build_layer1_aapl_evidence_report(
+        run_id=run_id,
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=writer,
+    )
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    readiness = cast(dict[str, Any], payload["run_readiness"])
+    gates = {
+        str(item["key"]): cast(dict[str, Any], item)
+        for item in cast(list[dict[str, Any]], payload["gate_cards"])
+    }
+    missing_labels = {
+        str(item["label"])
+        for item in cast(list[dict[str, Any]], payload["missing_pipeline_sections"])
+    }
+
+    assert readiness["ready_for_final_human_acceptance"] is False
+    assert readiness["recommendation"] == "not ready for final human acceptance"
+    assert readiness["human_review_status"] == "blocked_by_missing_pipeline_evidence"
+    assert gates["topic_labels"]["status"] == "blocked"
+    assert gates["benchmark_price_context"]["status"] == "blocked"
+    assert "BERTopic labels" in missing_labels
+    assert "Benchmark price rows" in missing_labels
+    assert layer1_topic_label_path("2026-05-21", run_id) in gates["topic_labels"][
+        "missing_or_tried_keys"
+    ]
+
+
+def test_semantic_review_summary_gate_status_blocks_cached_bundle_fallback(
+    tmp_path: Path,
+) -> None:
+    """Cached bundles should be prominent and remain blocked for final acceptance."""
+    run_id = "layer1-aapl-accuracy-2026-05-06-to-2026-05-28-v4-after-pr221"
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "empty-r2", run_id="unused")
+    report = build_layer1_aapl_evidence_report(
+        run_id=run_id,
+        from_date="2026-05-06",
+        to_date="2026-05-28",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    readiness = cast(dict[str, Any], payload["run_readiness"])
+    sections = {
+        str(item["key"]): cast(dict[str, Any], item)
+        for item in cast(list[dict[str, Any]], payload["missing_pipeline_sections"])
+    }
+
+    assert any(item["scope"] == "cached_bundle" for item in cast(list[dict[str, Any]], payload["warnings"]))
+    assert readiness["ready_for_final_human_acceptance"] is False
+    assert readiness["recommendation"] == "not ready for final human acceptance"
+    assert "news_preprocessing" in sections
+    assert "sentiment_features" in sections
+    assert "stock_price_context" in sections
+
+
+def test_semantic_review_summary_gate_status_handles_no_row_runs(tmp_path: Path) -> None:
+    """A run with no loaded rows should return stable blocked readiness fields."""
+    writer = R2Writer(local_root=tmp_path / "empty-r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id="semantic-review-no-row-run",
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=writer,
+    )
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    readiness = cast(dict[str, Any], payload["run_readiness"])
+    gate_keys = {
+        str(item["key"])
+        for item in cast(list[dict[str, Any]], payload["missing_pipeline_sections"])
+    }
+
+    assert readiness["sentence_row_count"] == 0
+    assert readiness["article_count"] == 0
+    assert readiness["date_count"] == 0
+    assert readiness["ready_for_final_human_acceptance"] is False
+    assert "news_sentiment_scored" in gate_keys
+    assert "hmm_regime" in gate_keys
+    assert "stock_price_context" in gate_keys
+    assert build_layer1_semantic_review_readiness_summary(payload)["run_readiness"][
+        "recommendation"
+    ] == "not ready for final human acceptance"
+
+
 def test_semantic_review_payload_suppresses_benchmark_chart_when_benchmark_missing(
     tmp_path: Path,
 ) -> None:
@@ -258,6 +389,8 @@ def test_semantic_review_dashboard_html_is_beginner_friendly_and_collapsed() -> 
         )
     )
     assert "Layer 1 semantic-review dashboard" in html
+    assert "Summary / Gate Status" in html
+    assert "not ready for final human acceptance" in html
     assert "What am I looking at?" in html
     assert "Why does it matter?" in html
     assert "What would make this good or bad?" in html


### PR DESCRIPTION
## What this PR does
Adds a Summary / Gate Status tab and stable API readiness fields for the Layer 1 semantic-review dashboard. The payload now exposes run_readiness, summary_cards, gate_cards, and missing_pipeline_sections so the browser does not infer final readiness from raw row arrays.

## Closes
Closes #240

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in core/contracts/schemas.py
- [x] No logic added to forbidden files
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No print() statements — logger used throughout
- [x] No bare except: or silent exception swallowing

### Tests
- [x] ./.venv/bin/pytest tests/unit/ -v --tb=short passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover happy path, cached/missing evidence, and no-row input for the new readiness fields
- [x] No live API calls in unit tests — fixtures used from tests/fixtures/semantic_review/

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch named codex/240-semantic-summary-gate-status
- [x] Issue label updated to review
- [x] No unrelated files modified
- [x] requirements.txt updated if new packages added (not applicable)

---

## New dependencies
None

## Verification artifacts
- Commands run:
  - ./.venv/bin/pytest tests/unit/test_semantic_review_dashboard.py -v --tb=short
  - ./.venv/bin/pytest tests/unit/ -v --tb=short
  - ./.venv/bin/ruff check app/lab/semantic_review_dashboard.py core/features/semantic_review_dashboard.py tests/unit/test_semantic_review_dashboard.py
  - ./.venv/bin/python -m app.lab.semantic_review_dashboard --run-id layer1-semantic-review-fixture --from-date 2026-05-21 --to-date 2026-05-22 --ticker AAPL --host 127.0.0.1 --port 8766 --local-root /tmp/semantic_review_smoke_r2 --smoke --browser-binary chromium --smoke-screenshot /tmp/semantic_review_dashboard_smoke.png
- Test result summary: 726 passed, 1 skipped, 62 warnings in 67.72s; focused dashboard tests 10 passed; rendered dashboard smoke passed
- Manifest key(s): artifacts/manifests/layer1_5_regime/layer1-semantic-review-fixture.json in local mock R2 fixture
- Report path(s): /tmp/semantic_review_dashboard_smoke.png
- R2 output prefix(es): local mock only, /tmp/semantic_review_smoke_r2
- Known skipped/missing data: full production AAPL R2 run was not mutated or rerun; tests use local fixtures and cached-bundle regression coverage

## Notes for reviewer
The sibling tab issues still own Article/FinBERT, Topic/Relevance, Semantic Aggregates, and dedicated HMM tab details. This PR only adds the top-level summary/gate readiness surface and the stable payload fields it needs.