### PR TITLE
Add article and FinBERT sentence review tabs

### DIFF
--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -491,6 +491,12 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       padding: 8px 12px;
       font-weight: 700;
     }}
+    .tab-button.active {{
+      background: rgba(56, 189, 248, 0.24);
+      border-color: rgba(125, 211, 252, 0.72);
+      color: #ffffff;
+      box-shadow: 0 0 0 1px rgba(125, 211, 252, 0.18) inset;
+    }}
     .tab-panel {{ display: grid; gap: 14px; }}
     .readiness-line {{ color: var(--muted); margin-bottom: 0; }}
     .gate-grid {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(230px, 1fr)); gap: 10px; }}
@@ -595,7 +601,9 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       </section>
 
       <nav class="tab-bar" aria-label="Semantic dashboard tabs">
-        <button class="tab-button active" type="button" role="tab" aria-selected="true" aria-controls="summary-gate-tab">Summary / Gate Status</button>
+        <button class="tab-button active" type="button" role="tab" aria-selected="true" aria-controls="summary-gate-tab" data-tab-target="summary-gate-tab">Summary / Gate Status</button>
+        <button class="tab-button" type="button" role="tab" aria-selected="false" aria-controls="article-review-tab" data-tab-target="article-review-tab">Article Review</button>
+        <button class="tab-button" type="button" role="tab" aria-selected="false" aria-controls="finbert-sentence-review-tab" data-tab-target="finbert-sentence-review-tab">FinBERT Sentence Review</button>
       </nav>
 
       <section class="panel tab-panel" id="summary-gate-tab" role="tabpanel">
@@ -608,12 +616,35 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         <div class="gate-grid" id="gate-cards"></div>
       </section>
 
+      <section class="panel tab-panel hidden" id="article-review-tab" role="tabpanel" aria-hidden="true">
+        <div>
+          <h2>Article Review</h2>
+          <p class="section-note">Accepted AAPL article groups appear first. Articles with contamination, weak ticker evidence, or non-AAPL focus are separated below so they cannot be mistaken for clean evidence.</p>
+        </div>
+        <div id="article-review-content"></div>
+      </section>
+
+      <section class="panel tab-panel hidden" id="finbert-sentence-review-tab" role="tabpanel" aria-hidden="true">
+        <div>
+          <h2>FinBERT Sentence Review</h2>
+          <p class="section-note">This tab shows the full scored sentence rows, sentence/chunk index, source text field/order, sentiment probabilities, sentiment score, relevance score/state, and row granularity. If the scored-news artifact is missing full text, the dashboard shows a warning instead of pretending the evidence is complete.</p>
+        </div>
+        <div id="finbert-sentence-review-content"></div>
+        <details class="panel" id="advanced-section">
+          <summary>Advanced evidence and raw rows</summary>
+          <div class="body" id="advanced-content">
+            <p class="section-note">This section stays collapsed by default so the dashboard remains easy to scan. It is only here when you need the raw preprocessing, embeddings, topic labels, relevance-gate rows, FinBERT rows, semantic aggregates, and HMM artifacts for debugging.</p>
+            <div id="pipeline"></div>
+          </div>
+        </details>
+      </section>
+
       <section class="panel">
         <h2>Why does it matter?</h2>
         <div class="explain-grid">
           <div class="explain">
             <h3>Good sign</h3>
-            <p>The page shows a benchmark chart, clear daily article evidence, and the status stays on <strong>Ready to review</strong>.</p>
+            <p>The page shows a benchmark chart, clear article evidence, and the status stays on <strong>Ready to review</strong>.</p>
           </div>
           <div class="explain">
             <h3>Bad sign</h3>
@@ -633,20 +664,6 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         <div id="chart-container" class="loading">Loading benchmark chart…</div>
       </section>
 
-      <section class="panel">
-        <h2>Daily review</h2>
-        <p class="section-note">Each trading day is collapsed by default. Open a day when you want the article-by-article evidence, and open the nested technical details only if you need the raw rows.</p>
-        <div id="dates" class="date-grid"></div>
-      </section>
-
-      <details class="panel" id="advanced-section">
-        <summary>Advanced evidence and raw rows</summary>
-        <div class="body" id="advanced-content">
-          <p class="section-note">This section stays collapsed by default so the dashboard remains easy to scan. It is only here when you need the raw preprocessing, embeddings, topic labels, relevance-gate rows, FinBERT rows, semantic aggregates, and HMM artifacts for debugging.</p>
-          <div id="pipeline"></div>
-        </div>
-      </details>
-
       <p class="footer-note">Tip: if anything in the chart is missing, trust the blocker card instead of guessing. The dashboard is designed to fail loudly when the benchmark or HMM metadata is incomplete.</p>
     </div>
   </main>
@@ -662,8 +679,10 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
     const stateExplainerEl = document.getElementById('state-explainer');
     const chartMetaEl = document.getElementById('chart-meta');
     const chartContainerEl = document.getElementById('chart-container');
-    const datesEl = document.getElementById('dates');
+    const articleReviewEl = document.getElementById('article-review-content');
+    const finbertReviewEl = document.getElementById('finbert-sentence-review-content');
     const pipelineEl = document.getElementById('pipeline');
+    const tabButtons = Array.from(document.querySelectorAll('[data-tab-target]'));
 
     function escapeHtml(value) {{
       return String(value ?? '')
@@ -1056,6 +1075,157 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         </details>`;
     }}
 
+    function renderArticleReviewGroup(group) {{
+      const articles = Array.isArray(group.articles) ? group.articles : [];
+      const summary = group.summary || {{}};
+      return `
+        <details class="date-card">
+          <summary>
+            <span>${{escapeHtml(group.date || 'n/a')}}</span>
+            <span class="badge" title="Accepted article count">accepted: ${{Number(summary.accepted_article_count || 0)}}</span>
+            <span class="badge" title="Flagged article count">flagged: ${{Number(summary.flagged_article_count || 0)}}</span>
+            <span class="badge" title="Sentence count">sentences: ${{Number(summary.sentence_count || 0)}}</span>
+            <span class="badge" title="Article count">articles: ${{Number(group.article_count || 0)}}</span>
+          </summary>
+          <div class="body">
+            <p class="article-copy">What am I looking at? A date bucket for ${{escapeHtml(group.date || 'n/a')}}. Why does it matter? It keeps the accepted Apple articles together and makes contamination easy to separate. What would make this good or bad? Good: the accepted bucket contains Apple-focused stories with strong ticker evidence. Bad: the contamination bucket contains unrelated or weak stories that should not be treated as Apple evidence.</p>
+            <div class="row-list">
+              ${{articles.map(renderArticleDetails).join('') || '<p class="muted">No articles were loaded for this date.</p>'}}
+            </div>
+          </div>
+        </details>`;
+    }}
+
+    function renderSentenceRow(row) {{
+      const text = row.text || '';
+      const hasText = Boolean(String(text).trim());
+      const sourceTextField = row.source_text_field || 'n/a';
+      const sourceTextOrder = row.source_text_order ?? 'n/a';
+      const sentenceIndex = row.sentence_index ?? 'n/a';
+      const chunkIndex = row.chunk_index ?? 'n/a';
+      const rowGranularity = row.row_granularity || 'n/a';
+      const relevanceState = row.relevance_state || 'missing';
+      const probabilities = [
+        `pos: ${{formatNumber(row.positive_probability, 2)}}`,
+        `neg: ${{formatNumber(row.negative_probability, 2)}}`,
+        `neu: ${{formatNumber(row.neutral_probability, 2)}}`,
+      ].join(' · ');
+      return `
+        <details class="row-item">
+          <summary>
+            <span class="article-title">Sentence ${{escapeHtml(sentenceIndex)}} / chunk ${{escapeHtml(chunkIndex)}}</span>
+            <span class="badge">${{escapeHtml(rowGranularity)}}</span>
+            <span class="badge ${{hasText ? 'good' : 'warn'}}">${{hasText ? 'Text available' : 'Text missing'}}</span>
+            <span class="badge" title="Raw field: relevance_state">relevance: ${{escapeHtml(relevanceState)}}</span>
+          </summary>
+          <div class="body">
+            ${{hasText ? `<p class="article-copy"><strong>Full scored text:</strong> ${{escapeHtml(text)}}</p>` : `<div class="chart-blocker"><h3>Full scored text unavailable</h3><p>This row came from the scored-news artifact, but the full text field is missing.</p></div>`}}
+            ${{row.source_artifact_gap ? `<p class="article-copy bad"><strong>Source artifact gap:</strong> ${{escapeHtml(row.source_artifact_gap)}}</p>` : ''}}
+            <div class="compact-grid">
+              <div class="compact"><div class="k">Source text field</div><div class="v">${{escapeHtml(sourceTextField)}}</div><div class="k">raw: source_text_field</div></div>
+              <div class="compact"><div class="k">Source text order</div><div class="v">${{escapeHtml(sourceTextOrder)}}</div><div class="k">raw: source_text_order</div></div>
+              <div class="compact"><div class="k">Sentiment score</div><div class="v">${{formatNumber(row.sentiment_score, 2)}}</div><div class="k">raw: sentiment_score</div></div>
+              <div class="compact"><div class="k">Relevance score</div><div class="v">${{formatNumber(row.relevance_score, 2)}}</div><div class="k">raw: relevance_score</div></div>
+            </div>
+            <p class="article-copy"><strong>Probabilities:</strong> ${{probabilities}}</p>
+            <p class="article-copy"><strong>Sentence/chunk index:</strong> ${{escapeHtml(sentenceIndex)}} / ${{escapeHtml(chunkIndex)}}</p>
+          </div>
+        </details>`;
+    }}
+
+    function renderFinbertArticle(article) {{
+      const rows = Array.isArray(article.sentence_rows) ? article.sentence_rows : [];
+      const rowCount = rows.length;
+      return `
+        <details class="article">
+          <summary>
+            <span class="article-title">${{escapeHtml(article.headline || article.article_id || 'Article')}}</span>
+            <span class="badge ${{article.article_status === 'accepted' ? 'good' : 'warn'}}">${{article.article_status === 'accepted' ? 'Accepted for review' : 'Needs a closer look'}}</span>
+            <span class="badge" title="Raw field: article_id">article_id: ${{escapeHtml(article.article_id || 'n/a')}}</span>
+            <span class="badge" title="Raw field: sentence rows">rows: ${{rowCount}}</span>
+          </summary>
+          <div class="body">
+            <p class="article-copy">What am I looking at? The full FinBERT-scored text for one article and its sentence-level rows. Why does it matter? Reviewers can verify the exact text that was scored, the source-text field/order, and the sentiment/relevance outputs without guessing. What would make this good or bad? Good: all rows have full text and the ordering matches the scored artifact. Bad: the dashboard has to warn about missing text or a source-artifact gap.</p>
+            <div class="compact-grid">
+              <div class="compact"><div class="k">Published</div><div class="v">${{escapeHtml(article.published_at || 'n/a')}}</div><div class="k">raw: published_at</div></div>
+              <div class="compact"><div class="k">Source</div><div class="v">${{escapeHtml(article.source || 'n/a')}}</div><div class="k">raw: source</div></div>
+              <div class="compact"><div class="k">Full text available</div><div class="v">${{article.full_scored_text_available ? 'yes' : 'no'}}</div><div class="k">raw: full_scored_text_available</div></div>
+              <div class="compact"><div class="k">Missing text rows</div><div class="v">${{Number(article.missing_text_row_count || 0)}}</div><div class="k">raw: missing_text_row_count</div></div>
+            </div>
+            ${{article.full_scored_text ? `<p class="article-copy"><strong>Full scored text:</strong> ${{escapeHtml(article.full_scored_text)}}</p>` : ''}}
+            ${{article.full_scored_text_warning ? `<div class="chart-blocker"><h3>Full scored text unavailable</h3><p>${{escapeHtml(article.full_scored_text_warning)}}</p><p>${{escapeHtml(article.source_artifact_gap || 'The source artifact is missing full scored text.')}}</p></div>` : ''}}
+            <div class="row-list">
+              ${{rows.length ? rows.map(renderSentenceRow).join('') : '<p class="muted">No sentence rows were loaded for this article.</p>'}}
+            </div>
+          </div>
+        </details>`;
+    }}
+
+    function renderArticleReview(payload) {{
+      const review = payload.article_review || {{}};
+      const acceptedDateGroups = Array.isArray(review.accepted_date_groups) ? review.accepted_date_groups : [];
+      const contaminationDateGroups = Array.isArray(review.contamination_date_groups) ? review.contamination_date_groups : [];
+      const acceptedArticles = Number(review.accepted_article_count || 0);
+      const contaminationArticles = Number(review.contamination_article_count || 0);
+      const flagCounts = review.contamination_flag_counts || {{}};
+      const flagSummary = Object.keys(flagCounts).length
+        ? Object.entries(flagCounts).map(([flag, count]) => `${{flag}}: ${{count}}`).join(' · ')
+        : 'none';
+      articleReviewEl.innerHTML = `
+        <div class="hero-grid">
+          ${{metricCard('Accepted stories', acceptedArticles, 'article_review.accepted_article_count', 'Accepted Apple article groups that remain in the clean review path.')}}
+          ${{metricCard('Contamination stories', contaminationArticles, 'article_review.contamination_article_count', 'Flagged or off-topic stories that are intentionally separated from the clean article review path.')}}
+          ${{metricCard('Contamination flags', flagSummary, 'article_review.contamination_flag_counts', 'Why the contamination section exists.')}}
+        </div>
+        <div class="panel">
+          <h3>Accepted AAPL article groups</h3>
+          <p class="section-note">These groups are the default article-review path. They should read like Apple evidence, not a mixed pile of unrelated rows.</p>
+          <div class="date-grid">
+            ${{acceptedDateGroups.length ? acceptedDateGroups.map(renderArticleReviewGroup).join('') : '<p class="muted">No accepted article groups were found for this run.</p>'}}
+          </div>
+        </div>
+        <div class="panel">
+          <h3>Contamination / no-ticker-evidence articles</h3>
+          <p class="section-note">These groups are separated on purpose so reviewers can see what should not be treated as clean Apple evidence.</p>
+          <div class="date-grid">
+            ${{contaminationDateGroups.length ? contaminationDateGroups.map(renderArticleReviewGroup).join('') : '<p class="muted">No contamination articles were found for this run.</p>'}}
+          </div>
+        </div>`;
+    }}
+
+    function renderFinbertSentenceReview(payload) {{
+      const review = payload.finbert_sentence_review || {{}};
+      const articles = Array.isArray(review.articles) ? review.articles : [];
+      const missingTextWarnings = Array.isArray(review.missing_text_warnings) ? review.missing_text_warnings : [];
+      const sourceArtifactGaps = Array.isArray(review.source_artifact_gaps) ? review.source_artifact_gaps : [];
+      const rowCount = Number(review.row_count || 0);
+      finbertReviewEl.innerHTML = `
+        <div class="hero-grid">
+          ${{metricCard('Articles', articles.length, 'finbert_sentence_review.article_count', 'How many article-level FinBERT review cards are available.')}}
+          ${{metricCard('Sentence rows', rowCount, 'finbert_sentence_review.row_count', 'How many sentence/chunk rows were reviewed.')}}
+          ${{metricCard('Missing text rows', missingTextWarnings.length, 'finbert_sentence_review.missing_text_warning_count', 'How many scored rows are missing the full scored sentence text.')}}
+        </div>
+        ${{sourceArtifactGaps.length ? `<div class="chart-blocker"><h3>Source artifact gap</h3><p>The scored-news artifact is incomplete for at least one row, so the dashboard is telling you that instead of inventing missing text.</p><ul>${{sourceArtifactGaps.map((gap) => `<li>${{escapeHtml(gap.date || 'n/a')}} · ${{escapeHtml(gap.article_id || 'n/a')}} · sentence ${{escapeHtml(gap.sentence_index ?? 'n/a')}} / chunk ${{escapeHtml(gap.chunk_index ?? 'n/a')}}${{gap.source_text_field ? ` · source field: ${{escapeHtml(gap.source_text_field)}}` : ''}}${{gap.source_text_order !== undefined && gap.source_text_order !== null ? ` · source order: ${{escapeHtml(gap.source_text_order)}}` : ''}}</li>`).join('')}}</ul></div>` : ''}}
+        <div class="row-list">
+          ${{articles.length ? articles.map(renderFinbertArticle).join('') : '<p class="muted">No FinBERT sentence rows were found for this run.</p>'}}
+        </div>`;
+    }}
+
+    function setActiveTab(targetId) {{
+      tabButtons.forEach((button) => {{
+        const isActive = button.dataset.tabTarget === targetId;
+        button.classList.toggle('active', isActive);
+        button.setAttribute('aria-selected', String(isActive));
+        const panel = document.getElementById(button.dataset.tabTarget);
+        if (panel) panel.classList.toggle('hidden', !isActive);
+        if (panel) panel.setAttribute('aria-hidden', String(!isActive));
+      }});
+    }}
+
+    tabButtons.forEach((button) => {{
+      button.addEventListener('click', () => setActiveTab(button.dataset.tabTarget || 'summary-gate-tab'));
+    }});
+
     function renderPipelineSection(sections) {{
       const orderedSections = [
         ['Ticker/entity preprocessing', 'raw_preprocessing_rows'],
@@ -1089,10 +1259,10 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       renderMetrics(payload);
       renderSummaryGateStatus(payload);
       renderChart(payload);
+      renderArticleReview(payload);
+      renderFinbertSentenceReview(payload);
       renderPipelineSection(payload.pipeline_sections || {{}});
-      datesEl.innerHTML = Array.isArray(payload.date_groups) && payload.date_groups.length
-        ? payload.date_groups.map(renderDateGroup).join('')
-        : '<p class="muted">No review dates were found for this run and window.</p>';
+      setActiveTab('summary-gate-tab');
     }}
 
     async function loadReview() {{

--- a/core/features/aapl_evidence.py
+++ b/core/features/aapl_evidence.py
@@ -2039,6 +2039,7 @@ def _build_payload_from_report(report: Layer1SemanticReviewReport | Mapping[str,
         "article_groups": article_groups,
         "accepted_articles": accepted_articles,
         "flagged_articles": flagged_articles,
+        "article_review": _build_article_review_payload(date_groups=date_groups),
         "pipeline_sections": {
             "raw_preprocessing_rows": list(report_dict.get("preprocessing_rows", [])),
             "article_embedding_rows": list(report_dict.get("embedding_rows", [])),
@@ -2059,8 +2060,158 @@ def _build_payload_from_report(report: Layer1SemanticReviewReport | Mapping[str,
         "artifact_keys": dict(report_dict.get("artifact_keys", {})),
         "warnings": list(report_dict.get("load_warnings", [])),
     }
+    payload["finbert_sentence_review"] = _build_finbert_sentence_review_payload(article_groups)
     payload["smoke"] = build_layer1_semantic_review_dashboard_smoke_result(payload)
     return payload
+
+
+def _build_article_review_payload(*, date_groups: Sequence[dict[str, object]]) -> dict[str, object]:
+    """Return tab-ready article-review sections grouped into acceptance and contamination."""
+    accepted_date_groups: list[dict[str, object]] = []
+    contamination_date_groups: list[dict[str, object]] = []
+    accepted_articles: list[dict[str, object]] = []
+    contamination_articles: list[dict[str, object]] = []
+    contamination_flag_counts: dict[str, int] = {}
+
+    for date_group in date_groups:
+        accepted_group_articles = [dict(item) for item in _json_list(date_group.get("accepted_articles")) if isinstance(item, Mapping)]
+        contamination_group_articles = [
+            dict(item) for item in _json_list(date_group.get("flagged_articles")) if isinstance(item, Mapping)
+        ]
+        if accepted_group_articles:
+            accepted_date_groups.append(
+                {
+                    "date": date_group.get("date"),
+                    "article_count": len(accepted_group_articles),
+                    "summary": {
+                        "accepted_article_count": len(accepted_group_articles),
+                        "flagged_article_count": 0,
+                        "sentence_count": _maybe_int(date_group.get("sentence_count")) or 0,
+                    },
+                    "articles": accepted_group_articles,
+                }
+            )
+            accepted_articles.extend(accepted_group_articles)
+        if contamination_group_articles:
+            contamination_date_groups.append(
+                {
+                    "date": date_group.get("date"),
+                    "article_count": len(contamination_group_articles),
+                    "summary": {
+                        "accepted_article_count": 0,
+                        "flagged_article_count": len(contamination_group_articles),
+                        "sentence_count": _maybe_int(date_group.get("sentence_count")) or 0,
+                    },
+                    "articles": contamination_group_articles,
+                }
+            )
+            contamination_articles.extend(contamination_group_articles)
+            for article in contamination_group_articles:
+                for flag in _json_string_list(article.get("contamination_flags")):
+                    contamination_flag_counts[flag] = contamination_flag_counts.get(flag, 0) + 1
+
+    return {
+        "accepted_date_groups": accepted_date_groups,
+        "contamination_date_groups": contamination_date_groups,
+        "accepted_articles": accepted_articles,
+        "contamination_articles": contamination_articles,
+        "accepted_article_count": len(accepted_articles),
+        "contamination_article_count": len(contamination_articles),
+        "contamination_flag_counts": contamination_flag_counts,
+    }
+
+
+def _build_finbert_sentence_review_payload(article_groups: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    """Return FinBERT sentence-review sections with article-level missing-text warnings."""
+    articles: list[dict[str, object]] = []
+    missing_text_warnings: list[dict[str, object]] = []
+    source_artifact_gaps: list[dict[str, object]] = []
+    row_count = 0
+
+    for article in article_groups:
+        sentence_rows = [dict(item) for item in _json_list(article.get("sentence_rows")) if isinstance(item, Mapping)]
+        row_count += len(sentence_rows)
+        article_missing_text = 0
+        full_text_parts: list[str] = []
+        decorated_rows: list[dict[str, object]] = []
+        for row in sentence_rows:
+            text = _optional_str(row.get("text"))
+            relevance_score = _maybe_float(row.get("relevance_score"))
+            missing_text = text is None
+            if text is not None:
+                full_text_parts.append(text)
+            else:
+                article_missing_text += 1
+                gap = {
+                    "article_id": article.get("article_id"),
+                    "date": article.get("date"),
+                    "sentence_index": row.get("sentence_index"),
+                    "chunk_index": row.get("chunk_index"),
+                    "source_text_field": row.get("source_text_field"),
+                    "source_text_order": row.get("source_text_order"),
+                    "gap": "missing_full_scored_sentence_text",
+                }
+                source_artifact_gaps.append(gap)
+                missing_text_warnings.append(
+                    {
+                        **gap,
+                        "warning": "Full scored sentence text is unavailable for this scored-news row.",
+                    }
+                )
+            decorated_rows.append(
+                {
+                    **row,
+                    "relevance_state": _relevance_state(relevance_score, threshold=DEFAULT_RELEVANCE_THRESHOLD),
+                    "has_full_scored_text": not missing_text,
+                    "missing_text_warning": (
+                        "Full scored sentence text is unavailable for this row."
+                        if missing_text
+                        else None
+                    ),
+                    "source_artifact_gap": (
+                        "The scored-news artifact is missing the full sentence text for this row."
+                        if missing_text
+                        else None
+                    ),
+                }
+            )
+        has_full_scored_text = article_missing_text == 0 and bool(sentence_rows)
+        articles.append(
+            {
+                **article,
+                "sentence_rows": decorated_rows,
+                "full_scored_text": " ".join(full_text_parts) if has_full_scored_text else None,
+                "full_scored_text_available": has_full_scored_text,
+                "missing_text_row_count": article_missing_text,
+                "full_scored_text_warning": (
+                    None
+                    if has_full_scored_text
+                    else (
+                        f"Full scored sentence text is unavailable for article {article.get('article_id')} "
+                        "because one or more scored-news rows are missing text."
+                    )
+                ),
+                "source_artifact_gap": (
+                    None
+                    if has_full_scored_text
+                    else (
+                        "The review depends on the scored-news artifact, but one or more rows do not "
+                        "contain full sentence text."
+                    )
+                ),
+            }
+        )
+
+    return {
+        "articles": articles,
+        "article_count": len(articles),
+        "row_count": row_count,
+        "missing_text_warning_count": len(missing_text_warnings),
+        "missing_text_warnings": missing_text_warnings,
+        "source_artifact_gaps": source_artifact_gaps,
+        "has_missing_text": bool(missing_text_warnings),
+        "has_full_scored_text": not missing_text_warnings,
+    }
 
 
 __all__ = [

--- a/docs/layer1_semantic_review_dashboard.md
+++ b/docs/layer1_semantic_review_dashboard.md
@@ -10,6 +10,9 @@ review in plain language before showing raw evidence.
 - A Summary / Gate Status tab that says whether human semantic review can start
   or is `not ready for final human acceptance` because required NLP, HMM, or
   price evidence is missing.
+- Separate Article Review and FinBERT Sentence Review tabs so accepted AAPL
+  article groups do not get mixed with contamination/no-ticker-evidence rows,
+  and sentence-level FinBERT review can show the scored text directly.
 - Stable gate cards for preprocessing, embeddings, topic labels, relevance
   gate rows, FinBERT rows, semantic aggregates, HMM rows, selected-ticker price
   rows, benchmark price rows, and benchmark/HMM chart rows.
@@ -21,8 +24,13 @@ review in plain language before showing raw evidence.
   - What would make this good or bad?
 - A market benchmark chart that uses SPY by default, because the HMM regime is
   market-wide and date-level rather than company-specific.
-- Daily review cards that stay collapsed by default and only expand when a
-  reviewer wants article-level evidence.
+- Article review cards that stay collapsed by default and show accepted AAPL
+  groups first, with flagged/no-ticker-evidence contamination kept separate.
+- FinBERT sentence review cards that show the full scored text, source text
+  field/order, sentiment probabilities, sentiment score, relevance score/state,
+  and row granularity for each scored row.
+- Explicit missing-text warnings and source-artifact gap cards when the scored
+  sentence text is unavailable.
 - Advanced technical sections for preprocessing, embeddings, topic labels,
   relevance-gate rows, FinBERT rows, semantic aggregates, benchmark rows, and
   HMM artifacts.
@@ -43,8 +51,9 @@ shows a blocker card instead of an empty chart.
 
 1. Check the benchmark chart first.
 2. Read the review state.
-3. Open a day only when you want the article-level evidence.
-4. Open the nested technical rows only when you need raw debug details.
+3. Open the Article Review tab when you want article-level evidence.
+4. Open the FinBERT Sentence Review tab when you need the scored sentence text
+   and row-level probabilities.
 
 ## Local run
 
@@ -104,6 +113,9 @@ Top-level response fields include:
 - `article_groups`: flat article cards for cross-date inspection
 - `accepted_articles`: accepted article cards
 - `flagged_articles`: flagged article cards
+- `article_review`: tab-ready accepted and contamination date groups plus counts
+- `finbert_sentence_review`: article-level sentence rows, full-text availability,
+  missing-text warnings, and source-artifact gaps
 - `price_series`: selected-ticker price context rows
 - `benchmark_ticker`: the market benchmark used for the HMM chart
 - `benchmark_price_series`: benchmark price rows
@@ -121,7 +133,7 @@ Top-level response fields include:
 - `smoke`: machine-readable smoke result with required stage row counts, visual/browser QA
   assertions, and exact missing/tried artifact keys when the dashboard cannot be accepted
 
-## What the daily cards contain
+## What the article review cards contain
 
 Each `date_groups[]` entry contains:
 

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -189,6 +189,52 @@ def test_semantic_review_payload_flags_weak_and_duplicate_articles(tmp_path: Pat
     duplicate = next(item for item in article_groups if item["article_id"] == "aapl-001")
     assert "duplicate_normalized_headline" in duplicate["contamination_flags"]
     assert duplicate["sentence_rows"][0]["text"].startswith("Apple shares climbed")
+    assert payload["article_review"]["accepted_article_count"] == 1
+    assert payload["article_review"]["contamination_article_count"] == 3
+
+
+def test_semantic_review_payload_separates_tabs_and_reports_missing_sentence_text(
+    tmp_path: Path,
+) -> None:
+    """The payload should keep article review separate from sentence review and warn on missing text."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    report_dict = cast(dict[str, Any], report.to_dict())
+    article_groups = cast(list[dict[str, Any]], report_dict["article_groups"])
+    date_groups = cast(list[dict[str, Any]], report_dict["date_groups"])
+    for article in article_groups:
+        if article.get("article_id") == "aapl-001":
+            cast(list[dict[str, Any]], article["sentence_rows"])[1]["text"] = None
+            break
+    for date_group in date_groups:
+        articles = cast(list[dict[str, Any]], date_group.get("articles", []))
+        for article in articles:
+            if article.get("article_id") == "aapl-001":
+                cast(list[dict[str, Any]], article["sentence_rows"])[1]["text"] = None
+                break
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report_dict))
+    article_review = cast(dict[str, Any], payload["article_review"])
+    finbert_review = cast(dict[str, Any], payload["finbert_sentence_review"])
+    finbert_articles = cast(list[dict[str, Any]], finbert_review["articles"])
+    missing_article = next(item for item in finbert_articles if item["article_id"] == "aapl-001")
+
+    assert article_review["accepted_date_groups"][0]["articles"][0]["article_id"] == "aapl-003"
+    assert article_review["accepted_article_count"] == 1
+    assert article_review["contamination_article_count"] == 3
+    assert finbert_review["row_count"] == 8
+    assert finbert_review["has_missing_text"] is True
+    assert finbert_review["missing_text_warning_count"] == 1
+    assert finbert_review["source_artifact_gaps"][0]["gap"] == "missing_full_scored_sentence_text"
+    assert missing_article["full_scored_text_available"] is False
+    assert missing_article["full_scored_text_warning"]
+    assert any(row["missing_text_warning"] for row in missing_article["sentence_rows"])
 
 
 def test_semantic_review_summary_gate_status_allows_complete_evidence(tmp_path: Path) -> None:
@@ -315,9 +361,12 @@ def test_semantic_review_summary_gate_status_handles_no_row_runs(tmp_path: Path)
     assert "news_sentiment_scored" in gate_keys
     assert "hmm_regime" in gate_keys
     assert "stock_price_context" in gate_keys
-    assert build_layer1_semantic_review_readiness_summary(payload)["run_readiness"][
-        "recommendation"
-    ] == "not ready for final human acceptance"
+    readiness_summary = cast(
+        dict[str, Any], build_layer1_semantic_review_readiness_summary(payload)
+    )
+    assert readiness_summary["run_readiness"]["recommendation"] == (
+        "not ready for final human acceptance"
+    )
 
 
 def test_semantic_review_payload_suppresses_benchmark_chart_when_benchmark_missing(
@@ -390,6 +439,8 @@ def test_semantic_review_dashboard_html_is_beginner_friendly_and_collapsed() -> 
     )
     assert "Layer 1 semantic-review dashboard" in html
     assert "Summary / Gate Status" in html
+    assert "Article Review" in html
+    assert "FinBERT Sentence Review" in html
     assert "not ready for final human acceptance" in html
     assert "What am I looking at?" in html
     assert "Why does it matter?" in html


### PR DESCRIPTION
## What this PR does
Split the Layer 1 semantic-review dashboard into separate Article Review and FinBERT Sentence Review tabs, and add missing-text warnings so scored sentence gaps are obvious in the UI and payload.

## Closes
Closes #241

## Layer(s) affected
- [x] Layer 1 — Features
- [x] Tests only
- [x] Docs only

## Author
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex verified the relevant items before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/test_semantic_review_dashboard.py -v --tb=short` passes
- [x] `make PYTHON=/DATA/nas/Projects/AI-Stock-Trader/.venv/bin/python test` passes
- [x] New public functions have at least one unit test each
- [x] Tests cover missing-text handling and split-tab payloads
- [x] No live API calls in unit tests

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [ ] `requirements.txt` updated if new packages added (not needed)

## New dependencies
None

## Notes for reviewer
`make typecheck` still fails on existing repository-wide mypy issues unrelated to this change (duplicate module discovery and legacy type errors), but the touched dashboard files and unit tests pass.