### PR TITLE
Add Topic / Relevance Pipeline tab

### DIFF
--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -604,6 +604,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         <button class="tab-button active" type="button" role="tab" aria-selected="true" aria-controls="summary-gate-tab" data-tab-target="summary-gate-tab">Summary / Gate Status</button>
         <button class="tab-button" type="button" role="tab" aria-selected="false" aria-controls="article-review-tab" data-tab-target="article-review-tab">Article Review</button>
         <button class="tab-button" type="button" role="tab" aria-selected="false" aria-controls="finbert-sentence-review-tab" data-tab-target="finbert-sentence-review-tab">FinBERT Sentence Review</button>
+        <button class="tab-button" type="button" role="tab" aria-selected="false" aria-controls="topic-relevance-tab" data-tab-target="topic-relevance-tab">Topic / Relevance Pipeline</button>
         <button class="tab-button" type="button" role="tab" aria-selected="false" aria-controls="semantic-aggregate-tab" data-tab-target="semantic-aggregate-tab">Ticker-Date Semantic Aggregates</button>
         <button class="tab-button" type="button" role="tab" aria-selected="false" aria-controls="hmm-regime-tab" data-tab-target="hmm-regime-tab">HMM Regime</button>
       </nav>
@@ -639,6 +640,14 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
             <div id="nlp-pipeline"></div>
           </div>
         </details>
+      </section>
+
+      <section class="panel tab-panel hidden" id="topic-relevance-tab" role="tabpanel" aria-hidden="true">
+        <div>
+          <h2>Topic / Relevance Pipeline</h2>
+          <p class="section-note">This tab follows the article from ticker/entity preprocessing through embedding cache, BERTopic label, and pre-FinBERT relevance-gate evidence. A score of 1.0 is not treated as strong evidence when the supporting ticker, entity, embedding, topic, or gate rows are missing.</p>
+        </div>
+        <div id="topic-relevance-content"></div>
       </section>
 
       <section class="panel tab-panel hidden" id="semantic-aggregate-tab" role="tabpanel" aria-hidden="true">
@@ -707,6 +716,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
     const chartContainerEl = document.getElementById('chart-container');
     const articleReviewEl = document.getElementById('article-review-content');
     const finbertReviewEl = document.getElementById('finbert-sentence-review-content');
+    const topicRelevanceReviewEl = document.getElementById('topic-relevance-content');
     const semanticAggregateReviewEl = document.getElementById('semantic-aggregate-content');
     const nlpPipelineEl = document.getElementById('nlp-pipeline');
     const hmmSummaryCardsEl = document.getElementById('hmm-summary-cards');
@@ -1312,6 +1322,109 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         </div>`;
     }}
 
+    function evidenceStatusClass(status) {{
+      if (status === 'accepted') return 'good';
+      if (status === 'rejected' || status === 'missing_or_default') return 'bad';
+      return 'warn';
+    }}
+
+    function renderTopicRelevanceArticle(row) {{
+      const flags = Array.isArray(row.missing_evidence_flags) ? row.missing_evidence_flags : [];
+      const reasonCodes = Array.isArray(row.reason_codes) ? row.reason_codes : [];
+      const tickerEvidence = row.ticker_evidence || {{}};
+      const entityEvidence = row.entity_evidence || {{}};
+      const embeddingEvidence = Array.isArray(row.embedding_evidence) ? row.embedding_evidence : [];
+      const topicEvidence = Array.isArray(row.topic_evidence) ? row.topic_evidence : [];
+      const relevanceRows = Array.isArray(row.relevance_gate_rows) ? row.relevance_gate_rows : [];
+      const preprocessingRows = Array.isArray(row.preprocessing_rows) ? row.preprocessing_rows : [];
+      const tickerHits = Array.isArray(tickerEvidence.requested_ticker_term_hits) ? tickerEvidence.requested_ticker_term_hits : [];
+      const sourceTickers = Array.isArray(tickerEvidence.source_tickers) ? tickerEvidence.source_tickers : [];
+      const tickerMentions = Array.isArray(tickerEvidence.preprocessing_ticker_mentions) ? tickerEvidence.preprocessing_ticker_mentions : [];
+      const entityMentions = Array.isArray(entityEvidence.preprocessing_entity_mentions) ? entityEvidence.preprocessing_entity_mentions : [];
+      const gateEntities = Array.isArray(entityEvidence.relevance_gate_entity_mentions) ? entityEvidence.relevance_gate_entity_mentions : [];
+      const status = row.evidence_status || 'missing_or_default';
+      const statusClassName = evidenceStatusClass(status);
+      return `
+        <details class="article">
+          <summary>
+            <span class="article-title">${{escapeHtml(row.headline || row.article_id || 'Article')}}</span>
+            <span class="badge ${{statusClassName}}" title="Raw field: evidence_status">${{escapeHtml(status)}}</span>
+            <span class="badge" title="Raw field: relevance_decision">gate: ${{escapeHtml(row.relevance_decision || 'missing')}}</span>
+            <span class="badge" title="Raw field: relevance_score">score: ${{formatNumber(row.relevance_score, 2)}}</span>
+            <span class="badge" title="Raw field: article_id">article_id: ${{escapeHtml(row.article_id || 'n/a')}}</span>
+          </summary>
+          <div class="body">
+            <p class="article-copy">What am I looking at? The evidence trail that decides whether this story belongs to the selected ticker before FinBERT sentiment should count. Why does it matter? Ticker/entity evidence, embeddings, topics, and relevance-gate sub-scores should agree before the row is trusted. What would make this good or bad? Good: direct ticker or entity support, embedding and topic rows, an accepted gate decision, and coherent reason codes. Bad: missing evidence, rejected gate rows, or a default score shown without support.</p>
+            ${{flags.length ? `<div class="chart-blocker"><h3>Evidence blocker</h3><p>${{escapeHtml(row.relevance_score_interpretation || 'missing/default evidence')}}</p><ul>${{flags.map((flag) => `<li>${{escapeHtml(flag)}}</li>`).join('')}}</ul></div>` : ''}}
+            <div class="compact-grid">
+              <div class="compact"><div class="k">Evidence status</div><div class="v">${{escapeHtml(status)}}</div><div class="k">raw: evidence_status</div></div>
+              <div class="compact"><div class="k">Relevance score</div><div class="v">${{formatNumber(row.relevance_score, 3)}}</div><div class="k">raw: relevance_score</div></div>
+              <div class="compact"><div class="k">Score interpretation</div><div class="v">${{escapeHtml(row.relevance_score_interpretation || 'n/a')}}</div><div class="k">raw: relevance_score_interpretation</div></div>
+              <div class="compact"><div class="k">Ticker / financial / topic scores</div><div class="v">${{formatNumber(row.ticker_relevance_score, 2)}} / ${{formatNumber(row.financial_relevance_score, 2)}} / ${{formatNumber(row.topic_relevance_score, 2)}}</div><div class="k">raw: ticker_relevance_score / financial_relevance_score / topic_relevance_score</div></div>
+              <div class="compact"><div class="k">Reason codes</div><div class="v">${{escapeHtml(reasonCodes.length ? reasonCodes.join(', ') : 'none')}}</div><div class="k">raw: reason_codes</div></div>
+              <div class="compact"><div class="k">Missing evidence flags</div><div class="v">${{escapeHtml(flags.length ? flags.join(', ') : 'none')}}</div><div class="k">raw: missing_evidence_flags</div></div>
+            </div>
+            <div class="compact-grid">
+              <div class="compact"><div class="k">Requested ticker hits</div><div class="v">${{escapeHtml(tickerHits.length ? tickerHits.join(', ') : 'none')}}</div><div class="k">raw: ticker_evidence.requested_ticker_term_hits</div></div>
+              <div class="compact"><div class="k">Preprocessing ticker mentions</div><div class="v">${{escapeHtml(tickerMentions.length ? tickerMentions.join(', ') : 'none')}}</div><div class="k">raw: preprocessing ticker_mentions</div></div>
+              <div class="compact"><div class="k">Source ticker tags</div><div class="v">${{escapeHtml(sourceTickers.length ? sourceTickers.join(', ') : 'none')}}</div><div class="k">raw: ticker_evidence.source_tickers</div></div>
+              <div class="compact"><div class="k">Entity mentions</div><div class="v">${{escapeHtml(entityMentions.length ? entityMentions.join(', ') : 'none')}}</div><div class="k">raw: preprocessing entity_mentions</div></div>
+              <div class="compact"><div class="k">Gate entities</div><div class="v">${{escapeHtml(gateEntities.length ? gateEntities.join(', ') : 'none')}}</div><div class="k">raw: relevance_gate entity_evidence</div></div>
+              <div class="compact"><div class="k">Embedding rows</div><div class="v">${{embeddingEvidence.length}}</div><div class="k">raw: embedding_evidence</div></div>
+              <div class="compact"><div class="k">Topic rows</div><div class="v">${{topicEvidence.length}}</div><div class="k">raw: topic_evidence</div></div>
+              <div class="compact"><div class="k">Relevance-gate rows</div><div class="v">${{relevanceRows.length}}</div><div class="k">raw: relevance_gate_rows</div></div>
+            </div>
+            <details class="row-item">
+              <summary>Embedding cache and BERTopic metadata</summary>
+              <div class="body">
+                <div class="row-item"><strong>Embedding evidence</strong><pre>${{escapeHtml(JSON.stringify(embeddingEvidence, null, 2))}}</pre></div>
+                <div class="row-item"><strong>Topic evidence</strong><pre>${{escapeHtml(JSON.stringify(topicEvidence, null, 2))}}</pre></div>
+              </div>
+            </details>
+            <details class="row-item">
+              <summary>Ticker/entity and relevance-gate raw rows</summary>
+              <div class="body">
+                <div class="row-item"><strong>Preprocessing rows</strong><pre>${{escapeHtml(JSON.stringify(preprocessingRows, null, 2))}}</pre></div>
+                <div class="row-item"><strong>Relevance-gate rows</strong><pre>${{escapeHtml(JSON.stringify(relevanceRows, null, 2))}}</pre></div>
+              </div>
+            </details>
+          </div>
+        </details>`;
+    }}
+
+    function renderTopicRelevanceReview(payload) {{
+      const review = payload.topic_relevance_review || {{}};
+      const summary = review.summary || {{}};
+      const dateGroups = Array.isArray(review.date_groups) ? review.date_groups : [];
+      const blockers = Array.isArray(review.missing_evidence_blockers) ? review.missing_evidence_blockers : [];
+      topicRelevanceReviewEl.innerHTML = `
+        <div class="hero-grid">
+          ${{metricCard('Articles', summary.article_count ?? 0, 'topic_relevance_review.summary.article_count', 'Article-level topic/relevance evidence rows.')}}
+          ${{metricCard('Accepted', summary.accepted_count ?? 0, 'topic_relevance_review.summary.accepted_count', 'Rows accepted by the relevance gate with supporting evidence.')}}
+          ${{metricCard('Borderline', summary.borderline_count ?? 0, 'topic_relevance_review.summary.borderline_count', 'Rows that need human attention before trust.')}}
+          ${{metricCard('Rejected', summary.rejected_count ?? 0, 'topic_relevance_review.summary.rejected_count', 'Rows rejected by the relevance gate.')}}
+          ${{metricCard('Missing/default', summary.missing_or_default_count ?? 0, 'topic_relevance_review.summary.missing_or_default_count', 'Rows missing required topic, embedding, or relevance support.')}}
+        </div>
+        ${{blockers.length ? `<div class="chart-blocker"><h3>Topic / relevance evidence blockers</h3><p>These articles have missing evidence or default relevance scores that should block final human acceptance until the upstream artifacts are present.</p><ul>${{blockers.map((item) => `<li>${{escapeHtml(item.date || 'n/a')}} · ${{escapeHtml(item.article_id || 'n/a')}} · ${{escapeHtml((item.missing_evidence_flags || []).join(', '))}}</li>`).join('')}}</ul></div>` : ''}}
+        <div class="date-grid">
+          ${{dateGroups.length ? dateGroups.map((group) => `
+            <details class="date-card">
+              <summary>
+                <span>${{escapeHtml(group.date || 'n/a')}}</span>
+                <span class="badge">accepted: ${{Number(group.accepted_count || 0)}}</span>
+                <span class="badge">borderline: ${{Number(group.borderline_count || 0)}}</span>
+                <span class="badge">rejected: ${{Number(group.rejected_count || 0)}}</span>
+                <span class="badge">missing/default: ${{Number(group.missing_or_default_count || 0)}}</span>
+              </summary>
+              <div class="body">
+                <div class="row-list">
+                  ${{(Array.isArray(group.articles) ? group.articles : []).map(renderTopicRelevanceArticle).join('') || '<p class="muted">No topic/relevance rows were loaded for this date.</p>'}}
+                </div>
+              </div>
+            </details>`).join('') : '<p class="muted">No topic/relevance rows were loaded for this run.</p>'}}
+        </div>`;
+    }}
+
     function semanticAggregateWarnings(payload) {{
       return (Array.isArray(payload.warnings) ? payload.warnings : []).filter((warning) => String(warning.scope || '') === 'sentiment_features');
     }}
@@ -1452,6 +1565,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       renderChart(payload);
       renderArticleReview(payload);
       renderFinbertSentenceReview(payload);
+      renderTopicRelevanceReview(payload);
       renderSemanticAggregateReview(payload);
       renderHmmOverview(payload);
       renderNlpPipelineSection(payload.pipeline_sections || {{}});

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -103,8 +103,111 @@ def build_layer1_semantic_review_dashboard_payload(
 ) -> dict[str, object]:
     """Return the JSON payload rendered by the semantic-review dashboard UI."""
     payload = _build_payload_from_report(report)
+    payload["topic_relevance_review"] = build_layer1_topic_relevance_review(payload)
     payload.update(build_layer1_semantic_review_readiness_summary(payload))
     return payload
+
+
+def build_layer1_topic_relevance_review(
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    """Return article-level topic, embedding, and relevance-gate review evidence."""
+    sections = _json_mapping(payload.get("pipeline_sections"))
+    articles = [
+        dict(item)
+        for item in _json_list(payload.get("article_groups"))
+        if isinstance(item, Mapping)
+    ]
+    preprocessing_by_article = _rows_by_article(sections.get("raw_preprocessing_rows"))
+    embedding_by_article = _rows_by_article(sections.get("article_embedding_rows"))
+    topic_by_article = _rows_by_article(sections.get("topic_label_rows"))
+    relevance_by_article = _rows_by_article(sections.get("relevance_gate_rows"))
+
+    rows = [
+        _topic_relevance_article_row(
+            article=article,
+            preprocessing_rows=preprocessing_by_article.get(_article_key(article), []),
+            embedding_rows=embedding_by_article.get(_article_key(article), []),
+            topic_rows=topic_by_article.get(_article_key(article), []),
+            relevance_rows=relevance_by_article.get(_article_key(article), []),
+        )
+        for article in articles
+    ]
+    date_groups: list[dict[str, object]] = []
+    for date_text in _dedupe_preserve_order(
+        str(row.get("date")) for row in rows if row.get("date") is not None
+    ):
+        grouped_rows = [row for row in rows if row.get("date") == date_text]
+        date_groups.append(
+            {
+                "date": date_text,
+                "article_count": len(grouped_rows),
+                "accepted_count": sum(
+                    1 for row in grouped_rows if row.get("evidence_status") == "accepted"
+                ),
+                "borderline_count": sum(
+                    1 for row in grouped_rows if row.get("evidence_status") == "borderline"
+                ),
+                "rejected_count": sum(
+                    1 for row in grouped_rows if row.get("evidence_status") == "rejected"
+                ),
+                "missing_or_default_count": sum(
+                    1
+                    for row in grouped_rows
+                    if row.get("evidence_status") == "missing_or_default"
+                ),
+                "articles": grouped_rows,
+            }
+        )
+
+    missing_blockers = [
+        {
+            "date": row.get("date"),
+            "article_id": row.get("article_id"),
+            "headline": row.get("headline"),
+            "missing_evidence_flags": row.get("missing_evidence_flags"),
+            "evidence_status": row.get("evidence_status"),
+            "relevance_score_interpretation": row.get("relevance_score_interpretation"),
+        }
+        for row in rows
+        if _json_string_list(row.get("missing_evidence_flags"))
+    ]
+    return {
+        "summary": {
+            "article_count": len(rows),
+            "accepted_count": sum(
+                1 for row in rows if row.get("evidence_status") == "accepted"
+            ),
+            "borderline_count": sum(
+                1 for row in rows if row.get("evidence_status") == "borderline"
+            ),
+            "rejected_count": sum(
+                1 for row in rows if row.get("evidence_status") == "rejected"
+            ),
+            "missing_or_default_count": sum(
+                1 for row in rows if row.get("evidence_status") == "missing_or_default"
+            ),
+            "missing_embedding_count": sum(
+                1
+                for row in rows
+                if "missing_embedding" in _json_string_list(row.get("missing_evidence_flags"))
+            ),
+            "missing_topic_count": sum(
+                1
+                for row in rows
+                if "missing_topic_label" in _json_string_list(row.get("missing_evidence_flags"))
+            ),
+            "default_relevance_count": sum(
+                1
+                for row in rows
+                if "default_relevance_without_supporting_evidence"
+                in _json_string_list(row.get("missing_evidence_flags"))
+            ),
+        },
+        "date_groups": date_groups,
+        "articles": rows,
+        "missing_evidence_blockers": missing_blockers,
+    }
 
 
 def build_layer1_semantic_review_readiness_summary(
@@ -231,6 +334,260 @@ def _gate_card_payload(
         ),
         "message": _gate_message(definition.label, status, len(rows), matching_failures),
     }
+
+
+def _topic_relevance_article_row(
+    *,
+    article: Mapping[str, object],
+    preprocessing_rows: Sequence[Mapping[str, object]],
+    embedding_rows: Sequence[Mapping[str, object]],
+    topic_rows: Sequence[Mapping[str, object]],
+    relevance_rows: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    relevance_decisions = _dedupe_preserve_order(
+        str(row.get("relevance_decision"))
+        for row in relevance_rows
+        if row.get("relevance_decision") is not None
+    )
+    reason_codes = _dedupe_preserve_order(
+        code
+        for row in relevance_rows
+        for code in _json_string_list(row.get("reason_codes"))
+    )
+    source_tickers = _dedupe_preserve_order(
+        ticker
+        for row in relevance_rows
+        for ticker in _ticker_evidence_values(row.get("ticker_evidence"))
+    )
+    ticker_mentions = _dedupe_preserve_order(
+        ticker
+        for row in preprocessing_rows
+        for ticker in _json_string_list(row.get("ticker_mentions"))
+    )
+    entity_mentions = _dedupe_preserve_order(
+        entity
+        for row in preprocessing_rows
+        for entity in _json_string_list(row.get("entity_mentions"))
+    )
+    relevance_score = _first_float(
+        [row.get("relevance_score") for row in relevance_rows]
+        + [article.get("relevance_score")]
+    )
+    ticker_score = _first_float([row.get("ticker_relevance_score") for row in relevance_rows])
+    financial_score = _first_float(
+        [row.get("financial_relevance_score") for row in relevance_rows]
+    )
+    topic_score = _first_float([row.get("topic_relevance_score") for row in relevance_rows])
+    has_embedding = bool(embedding_rows)
+    has_topic = bool(topic_rows)
+    has_relevance_gate = bool(relevance_rows)
+    has_ticker_evidence = bool(ticker_mentions) or (
+        ticker_score is not None and ticker_score > 0.0
+    )
+    has_entity_evidence = bool(entity_mentions)
+    has_semantic_evidence = has_embedding and has_topic and (
+        topic_score is None or topic_score > 0.0
+    )
+    missing_flags = _topic_relevance_missing_flags(
+        has_embedding=has_embedding,
+        has_topic=has_topic,
+        has_relevance_gate=has_relevance_gate,
+        has_ticker_evidence=has_ticker_evidence,
+        has_entity_evidence=has_entity_evidence,
+        has_semantic_evidence=has_semantic_evidence,
+        relevance_score=relevance_score,
+        relevance_decisions=relevance_decisions,
+    )
+    evidence_status = _topic_relevance_status(
+        relevance_decisions=relevance_decisions,
+        missing_flags=missing_flags,
+    )
+    return {
+        "date": article.get("date"),
+        "ticker": article.get("ticker"),
+        "article_id": article.get("article_id"),
+        "headline": article.get("headline"),
+        "normalized_headline": article.get("normalized_headline"),
+        "article_status": article.get("article_status"),
+        "evidence_status": evidence_status,
+        "relevance_score": relevance_score,
+        "relevance_score_interpretation": _relevance_score_interpretation(
+            relevance_score=relevance_score,
+            missing_flags=missing_flags,
+            relevance_decisions=relevance_decisions,
+        ),
+        "relevance_decision": relevance_decisions[0] if relevance_decisions else "missing",
+        "relevance_decisions": relevance_decisions,
+        "ticker_relevance_score": ticker_score,
+        "financial_relevance_score": financial_score,
+        "topic_relevance_score": topic_score,
+        "reason_codes": reason_codes,
+        "missing_evidence_flags": missing_flags,
+        "ticker_evidence": {
+            "requested_ticker_term_hits": _json_string_list(
+                article.get("requested_ticker_term_hits")
+            ),
+            "preprocessing_ticker_mentions": ticker_mentions,
+            "source_tickers": source_tickers,
+        },
+        "entity_evidence": {
+            "preprocessing_entity_mentions": entity_mentions,
+            "relevance_gate_entity_mentions": _dedupe_preserve_order(
+                entity
+                for row in relevance_rows
+                for entity in _json_string_list(row.get("entity_evidence"))
+            ),
+        },
+        "embedding_evidence": [
+            {
+                "embedding_cache_key": row.get("embedding_cache_key"),
+                "embedding_model": row.get("embedding_model"),
+                "embedding_revision": row.get("embedding_revision"),
+                "embedding_dimension": row.get("embedding_dimension"),
+                "artifact_key": row.get("artifact_key"),
+            }
+            for row in embedding_rows
+        ],
+        "topic_evidence": [
+            {
+                "topic_id": row.get("topic_id"),
+                "topic_probability": row.get("topic_probability"),
+                "topic_label": row.get("topic_label"),
+                "topic_keywords": row.get("topic_keywords"),
+                "topic_model": row.get("topic_model"),
+                "topic_model_version": row.get("topic_model_version"),
+                "embedding_cache_key": row.get("embedding_cache_key"),
+                "artifact_key": row.get("artifact_key"),
+            }
+            for row in topic_rows
+        ],
+        "relevance_gate_rows": [dict(row) for row in relevance_rows],
+        "preprocessing_rows": [dict(row) for row in preprocessing_rows],
+    }
+
+
+def _topic_relevance_missing_flags(
+    *,
+    has_embedding: bool,
+    has_topic: bool,
+    has_relevance_gate: bool,
+    has_ticker_evidence: bool,
+    has_entity_evidence: bool,
+    has_semantic_evidence: bool,
+    relevance_score: float | None,
+    relevance_decisions: Sequence[str],
+) -> list[str]:
+    flags: list[str] = []
+    lowered_decisions = {decision.lower() for decision in relevance_decisions}
+    if not has_relevance_gate:
+        flags.append("missing_relevance_gate")
+    if not has_ticker_evidence:
+        flags.append("missing_ticker_evidence")
+    if not has_entity_evidence:
+        flags.append("missing_entity_evidence")
+    if not has_embedding:
+        flags.append("missing_embedding")
+    if not has_topic:
+        flags.append("missing_topic_label")
+    if lowered_decisions & {"rejected", "reject"}:
+        flags.append("rejected_by_relevance_gate")
+    if lowered_decisions & {"borderline", "review", "needs_review"}:
+        flags.append("borderline_relevance_gate")
+    if relevance_score == 1.0 and (
+        not has_ticker_evidence
+        or not has_entity_evidence
+        or not has_semantic_evidence
+        or lowered_decisions & {"rejected", "reject"}
+    ):
+        flags.append("default_relevance_without_supporting_evidence")
+    return _dedupe_preserve_order(flags)
+
+
+def _topic_relevance_status(
+    *,
+    relevance_decisions: Sequence[str],
+    missing_flags: Sequence[str],
+) -> str:
+    lowered_flags = set(missing_flags)
+    lowered_decisions = {decision.lower() for decision in relevance_decisions}
+    if "default_relevance_without_supporting_evidence" in lowered_flags:
+        return "missing_or_default"
+    if "missing_embedding" in lowered_flags or "missing_topic_label" in lowered_flags:
+        return "missing_or_default"
+    if lowered_decisions & {"rejected", "reject"}:
+        return "rejected"
+    if lowered_decisions & {"borderline", "review", "needs_review"}:
+        return "borderline"
+    if lowered_decisions & {"accepted", "accept"}:
+        return "accepted"
+    if "missing_relevance_gate" in lowered_flags:
+        return "missing_or_default"
+    return "borderline"
+
+
+def _relevance_score_interpretation(
+    *,
+    relevance_score: float | None,
+    missing_flags: Sequence[str],
+    relevance_decisions: Sequence[str],
+) -> str:
+    if relevance_score is None:
+        return "missing"
+    if "default_relevance_without_supporting_evidence" in set(missing_flags):
+        return "default_or_unknown_not_strong_evidence"
+    lowered_decisions = {decision.lower() for decision in relevance_decisions}
+    if lowered_decisions & {"rejected", "reject"}:
+        return "computed_rejected"
+    if lowered_decisions & {"borderline", "review", "needs_review"}:
+        return "computed_borderline"
+    return "computed"
+
+
+def _rows_by_article(value: object) -> dict[tuple[str, str], list[dict[str, object]]]:
+    rows_by_article: dict[tuple[str, str], list[dict[str, object]]] = {}
+    for row in _json_list(value):
+        if not isinstance(row, Mapping):
+            continue
+        row_dict = dict(row)
+        key = _article_key(row_dict)
+        if key == ("", ""):
+            continue
+        rows_by_article.setdefault(key, []).append(row_dict)
+    return rows_by_article
+
+
+def _article_key(row: Mapping[str, object]) -> tuple[str, str]:
+    date_text = str(row.get("date") or "")
+    article_id = str(row.get("article_id") or "")
+    return date_text, article_id
+
+
+def _ticker_evidence_values(value: object) -> list[str]:
+    evidence = _json_mapping(value)
+    values: list[str] = []
+    for key in ("source_tickers", "article_tickers", "ticker_mentions", "chunk_tickers"):
+        values.extend(_json_string_list(evidence.get(key)))
+    return values
+
+
+def _first_float(values: object) -> float | None:
+    for value in _json_list(values):
+        number = _maybe_float(value)
+        if number is not None:
+            return number
+    return None
+
+
+def _maybe_float(value: object) -> float | None:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number != number:
+        return None
+    return number
 
 
 def _summary_cards(run_readiness: Mapping[str, object]) -> list[dict[str, object]]:

--- a/docs/layer1_semantic_review_dashboard.md
+++ b/docs/layer1_semantic_review_dashboard.md
@@ -15,6 +15,12 @@ review in plain language before showing raw evidence.
   contamination/no-ticker-evidence rows, sentence-level FinBERT review can show
   the scored text directly, and the final `(date, ticker)` Layer 1 aggregate
   rows stay clearly distinct from article evidence.
+- A Topic / Relevance Pipeline tab that follows each article from ticker/entity
+  preprocessing through article embeddings, BERTopic labels, and the
+  pre-FinBERT relevance gate. It shows ticker/source ticker evidence, entity
+  evidence, embedding cache/model metadata, topic ID/probability/model metadata,
+  relevance decisions, relevance score components, reason codes, and missing
+  evidence flags.
 - A dedicated HMM Regime tab that stays benchmark-first, uses SPY by default,
   and separates market-wide regime context from article/sentence evidence.
 - A simple status card that says whether the page is ready to review, needs a
@@ -59,8 +65,11 @@ shows a blocker card instead of an empty chart.
    benchmark price rows, and HMM metadata.
 4. Open the Ticker-Date Semantic Aggregates tab when you want the final Layer 1
    `(date, ticker)` feature row and its repeated context / aggregate values.
-5. Open the Article Review tab when you want article-level evidence.
-6. Open the FinBERT Sentence Review tab when you need the scored sentence text
+5. Open the Topic / Relevance Pipeline tab when you need to know why an article
+   was accepted, marked borderline, rejected, or blocked by missing/default
+   relevance evidence.
+6. Open the Article Review tab when you want article-level evidence.
+7. Open the FinBERT Sentence Review tab when you need the scored sentence text
    and row-level probabilities.
 
 ## Local run
@@ -124,6 +133,10 @@ Top-level response fields include:
 - `article_review`: tab-ready accepted and contamination date groups plus counts
 - `finbert_sentence_review`: article-level sentence rows, full-text availability,
   missing-text warnings, and source-artifact gaps
+- `topic_relevance_review`: article-level topic/relevance rows grouped by date,
+  summary counts for accepted/borderline/rejected/missing-or-default states, and
+  blocker rows when embeddings, topic labels, relevance-gate rows, ticker/entity
+  evidence, or supporting semantic evidence are missing
 - `price_series`: selected-ticker price context rows
 - `benchmark_ticker`: the market benchmark used for the HMM chart
 - `benchmark_price_series`: benchmark price rows
@@ -171,6 +184,27 @@ Each `articles[]` entry contains:
 
 The raw rows are intentionally hidden behind expanders so the default page stays
 clean and easy to scan.
+
+## Topic / Relevance Pipeline tab
+
+The Topic / Relevance Pipeline tab is the reviewer-facing evidence trail for
+pre-FinBERT inclusion decisions. Each article row includes:
+
+- ticker evidence from requested ticker hits, preprocessing ticker mentions, and
+  source ticker tags
+- entity evidence from preprocessing and relevance-gate rows
+- article embedding cache metadata, including cache key, model, revision, and
+  dimension when available
+- BERTopic metadata, including topic ID, probability, label, keywords, model,
+  model version, and artifact key when available
+- relevance decision, relevance score, ticker/financial/topic sub-scores, reason
+  codes, and missing evidence flags
+
+If `relevance_score=1.0` appears without supporting ticker/entity/semantic
+evidence, the tab labels the score as `default_or_unknown_not_strong_evidence`
+and flags `default_relevance_without_supporting_evidence`. Missing embedding or
+topic rows appear as evidence blockers and keep final human acceptance blocked
+through the existing gate-card readiness checks.
 
 ## Summary / Gate Status tab
 

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -252,6 +252,107 @@ def test_semantic_review_payload_separates_tabs_and_reports_missing_sentence_tex
     assert any(row["missing_text_warning"] for row in missing_article["sentence_rows"])
 
 
+def test_semantic_review_topic_relevance_tab_flags_default_relevance(
+    tmp_path: Path,
+) -> None:
+    """Topic/relevance review should expose supporting evidence and default relevance flags."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    review = cast(dict[str, Any], payload["topic_relevance_review"])
+    articles = {
+        str(item["article_id"]): cast(dict[str, Any], item)
+        for item in cast(list[dict[str, Any]], review["articles"])
+    }
+
+    accepted = articles["aapl-003"]
+    defaulted = articles["ferrari-001"]
+
+    assert cast(dict[str, Any], review["summary"])["accepted_count"] == 3
+    assert accepted["evidence_status"] == "accepted"
+    assert accepted["ticker_relevance_score"] == 1.0
+    assert accepted["financial_relevance_score"] == 0.8
+    assert accepted["topic_relevance_score"] == 0.82
+    assert accepted["reason_codes"] == ["target_entity_mention"]
+    assert accepted["embedding_evidence"][0]["embedding_model"] == "sentence-transformers/test"
+    assert accepted["topic_evidence"][0]["topic_id"] == 0
+    assert accepted["topic_evidence"][0]["topic_probability"] == 0.82
+    assert accepted["missing_evidence_flags"] == []
+
+    assert defaulted["relevance_score"] == 1.0
+    assert defaulted["evidence_status"] == "missing_or_default"
+    assert defaulted["relevance_score_interpretation"] == "default_or_unknown_not_strong_evidence"
+    assert "missing_ticker_evidence" in defaulted["missing_evidence_flags"]
+    assert "rejected_by_relevance_gate" in defaulted["missing_evidence_flags"]
+    assert "default_relevance_without_supporting_evidence" in defaulted["missing_evidence_flags"]
+    assert defaulted["ticker_evidence"]["source_tickers"] == ["AAPL"]
+    assert defaulted["entity_evidence"]["preprocessing_entity_mentions"] == ["Ferrari"]
+    assert review["missing_evidence_blockers"]
+
+
+def test_semantic_review_topic_relevance_tab_covers_borderline_rejected_and_missing_rows(
+    tmp_path: Path,
+) -> None:
+    """Topic/relevance review should classify borderline, rejected, and missing-evidence rows."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    report_dict = cast(dict[str, Any], report.to_dict())
+    report_dict["embedding_rows"] = [
+        row
+        for row in cast(list[dict[str, Any]], report_dict["embedding_rows"])
+        if row["article_id"] != "aapl-001"
+    ]
+    report_dict["topic_label_rows"] = [
+        row
+        for row in cast(list[dict[str, Any]], report_dict["topic_label_rows"])
+        if row["article_id"] != "aapl-001"
+    ]
+    for row in cast(list[dict[str, Any]], report_dict["relevance_gate_rows"]):
+        if row["article_id"] == "aapl-002":
+            row["relevance_decision"] = "borderline"
+            row["relevance_score"] = 0.64
+            row["reason_codes"] = ["borderline_topic_evidence"]
+        if row["article_id"] == "aapl-003":
+            row["relevance_decision"] = "rejected"
+            row["relevance_score"] = 0.2
+            row["ticker_relevance_score"] = 0.0
+            row["reason_codes"] = ["low_ticker_relevance"]
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report_dict))
+    review = cast(dict[str, Any], payload["topic_relevance_review"])
+    articles = {
+        str(item["article_id"]): cast(dict[str, Any], item)
+        for item in cast(list[dict[str, Any]], review["articles"])
+    }
+    summary = cast(dict[str, Any], review["summary"])
+
+    assert articles["aapl-001"]["evidence_status"] == "missing_or_default"
+    assert "missing_embedding" in articles["aapl-001"]["missing_evidence_flags"]
+    assert "missing_topic_label" in articles["aapl-001"]["missing_evidence_flags"]
+    assert articles["aapl-002"]["evidence_status"] == "borderline"
+    assert articles["aapl-002"]["relevance_score_interpretation"] == "computed_borderline"
+    assert "borderline_relevance_gate" in articles["aapl-002"]["missing_evidence_flags"]
+    assert articles["aapl-003"]["evidence_status"] == "rejected"
+    assert articles["aapl-003"]["relevance_score_interpretation"] == "computed_rejected"
+    assert "rejected_by_relevance_gate" in articles["aapl-003"]["missing_evidence_flags"]
+    assert summary["missing_embedding_count"] == 1
+    assert summary["missing_topic_count"] == 1
+    assert summary["borderline_count"] == 1
+    assert summary["rejected_count"] == 1
+
+
 def test_semantic_review_summary_gate_status_allows_complete_evidence(tmp_path: Path) -> None:
     """Complete raw evidence should produce ready summary and gate-card fields."""
     fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
@@ -520,6 +621,10 @@ def test_semantic_review_dashboard_html_is_beginner_friendly_and_collapsed() -> 
     assert "Summary / Gate Status" in html
     assert "Article Review" in html
     assert "FinBERT Sentence Review" in html
+    assert "Topic / Relevance Pipeline" in html
+    assert "topic-relevance-tab" in html
+    assert "topic-relevance-content" in html
+    assert "default score shown without support" in html
     assert "Ticker-Date Semantic Aggregates" in html
     assert "semantic-aggregate-tab" in html
     assert "Repeated context / aggregate value" in html


### PR DESCRIPTION
## What this PR does
Adds a dedicated Topic / Relevance Pipeline tab to the Layer 1 semantic-review dashboard. The tab exposes article-level ticker/entity evidence, embedding cache metadata, BERTopic labels, relevance-gate decisions and sub-scores, reason codes, and missing evidence flags, including explicit default/unknown labeling when `relevance_score=1.0` is not backed by supporting evidence.

## Closes
Closes #242

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [x] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`, `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: accepted, borderline, rejected, missing-topic, missing-embedding, and default-relevance cases
- [x] No live API calls in unit tests — fixtures used from `tests/fixtures/semantic_review/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None. A local `.venv` was created with `uv` from existing `requirements/dev.txt` only because this clean worktree did not include `./.venv/bin/python`.

## Screenshots or sample output
No browser screenshot generated. Verification used the dashboard payload/unit fixtures rather than production R2.

## Verification artifacts
Commands run:
- `python3 -m py_compile core/features/semantic_review_dashboard.py app/lab/semantic_review_dashboard.py tests/unit/test_semantic_review_dashboard.py`
- `git diff --check`
- `./.venv/bin/ruff check app/lab/semantic_review_dashboard.py core/features/semantic_review_dashboard.py tests/unit/test_semantic_review_dashboard.py`
- `./.venv/bin/python -m pytest tests/unit/test_semantic_review_dashboard.py -v --tb=short`
- `./.venv/bin/python -m pytest tests/unit/ -v --tb=short`

Test result summary:
- Dashboard unit tests: `15 passed in 5.68s`
- Full unit suite: `731 passed, 1 skipped, 12 warnings in 73.18s`
- Ruff: `All checks passed!`
- `git diff --check`: clean

Manifest key(s): none; no R2 manifests were read or written.

Report path(s): none; no durable report generated for this UI-only/test-only change.

R2 output prefix(es): none; no production R2 artifacts were mutated, deleted, or rewritten.

Known skipped/missing data:
- The issue's live dashboard/curl smoke command was not run against the production run id to avoid touching production R2 or depending on external credentials. The new tab is covered by local fixture-backed unit tests.
- Full unit suite emitted existing Modal automount deprecation warnings and NumPy runtime warnings; no test failures.

## Notes for reviewer
The new `topic_relevance_review` payload is additive and derived from existing dashboard sections. It does not change `core/contracts/schemas.py`, Layer 2/model training, production R2 data, or broad point-in-time backfill behavior.
