### PR TITLE
Fix semantic dashboard HMM chart visibility

### DIFF
--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
+from threading import Lock
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
@@ -52,6 +53,8 @@ class _DashboardHTTPServer(ThreadingHTTPServer):
     def __init__(self, server_address: tuple[str, int], defaults: _DashboardDefaults) -> None:
         super().__init__(server_address, _DashboardRequestHandler)
         self.defaults = defaults
+        self.payload_cache: dict[tuple[str, str, str, str], dict[str, object]] = {}
+        self.payload_cache_lock = Lock()
 
 
 class _DashboardRequestHandler(BaseHTTPRequestHandler):
@@ -84,13 +87,19 @@ class _DashboardRequestHandler(BaseHTTPRequestHandler):
         params = parse_qs(query_text, keep_blank_values=False)
         try:
             query = _query_from_params(params=params, defaults=self.server.defaults)
-            payload = _build_dashboard_payload(
-                run_id=query.run_id,
-                from_date=query.from_date,
-                to_date=query.to_date,
-                ticker=query.ticker,
-                local_root=self.server.defaults.local_root,
-            )
+            cache_key = (query.run_id, query.from_date, query.to_date, query.ticker)
+            with self.server.payload_cache_lock:
+                payload = self.server.payload_cache.get(cache_key)
+            if payload is None:
+                payload = _build_dashboard_payload(
+                    run_id=query.run_id,
+                    from_date=query.from_date,
+                    to_date=query.to_date,
+                    ticker=query.ticker,
+                    local_root=self.server.defaults.local_root,
+                )
+                with self.server.payload_cache_lock:
+                    self.server.payload_cache[cache_key] = payload
         except ValueError as exc:
             self._send_json({"error": str(exc)}, status=HTTPStatus.BAD_REQUEST)
             return
@@ -664,14 +673,20 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
           <p class="section-note">HMM applies once per market/inference date and is shared context for every ticker/news row on that date. This tab is intentionally benchmark-first: it uses the market benchmark, usually SPY, so reviewers can validate the regime context without confusing it with company-specific article evidence.</p>
         </div>
         <div class="hero-grid" id="hmm-summary-cards"></div>
-        <div class="compact-grid" id="hmm-context-cards"></div>
-        <div class="row-list" id="hmm-date-rows"></div>
         <section class="panel chart-shell" id="chart-section">
           <h3>Market benchmark and HMM regime</h3>
           <p class="chart-note">HMM regime is market-wide and date-level, so the default chart uses <strong>SPY</strong> as the benchmark instead of the selected company ticker. The line shows the benchmark price trend; the colored markers and bars show which regime was most likely on each date and how confident the model was.</p>
           <div id="chart-meta" class="chart-meta"></div>
           <div id="chart-container" class="loading">Loading benchmark chart…</div>
         </section>
+        <details class="panel" id="hmm-context-section">
+          <summary>Model inputs and date-by-date regime rows</summary>
+          <div class="body">
+            <p class="section-note">These diagnostics stay collapsed by default so the SPY graph is visible first. Open them when you need the model inputs, missing feature summary, and per-date close/probability rows.</p>
+            <div class="compact-grid" id="hmm-context-cards"></div>
+            <div class="row-list" id="hmm-date-rows"></div>
+          </div>
+        </details>
         <details class="panel" id="hmm-advanced-section">
           <summary>Advanced HMM evidence and raw rows</summary>
           <div class="body">
@@ -1355,7 +1370,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
           </summary>
           <div class="body">
             <p class="article-copy">What am I looking at? The evidence trail that decides whether this story belongs to the selected ticker before FinBERT sentiment should count. Why does it matter? Ticker/entity evidence, embeddings, topics, and relevance-gate sub-scores should agree before the row is trusted. What would make this good or bad? Good: direct ticker or entity support, embedding and topic rows, an accepted gate decision, and coherent reason codes. Bad: missing evidence, rejected gate rows, or a default score shown without support.</p>
-            ${{flags.length ? `<div class="chart-blocker"><h3>Evidence blocker</h3><p>${{escapeHtml(row.relevance_score_interpretation || 'missing/default evidence')}}</p><ul>${{flags.map((flag) => `<li>${{escapeHtml(flag)}}</li>`).join('')}}</ul></div>` : ''}}
+            ${{flags.length ? `<details class="row-item"><summary>Evidence flags <span class="badge ${{statusClassName}}">${{flags.length}}</span></summary><div class="body"><p class="article-copy">${{escapeHtml(row.relevance_score_interpretation || 'missing/default evidence')}}</p><ul>${{flags.map((flag) => `<li>${{escapeHtml(flag)}}</li>`).join('')}}</ul></div></details>` : ''}}
             <div class="compact-grid">
               <div class="compact"><div class="k">Evidence status</div><div class="v">${{escapeHtml(status)}}</div><div class="k">raw: evidence_status</div></div>
               <div class="compact"><div class="k">Relevance score</div><div class="v">${{formatNumber(row.relevance_score, 3)}}</div><div class="k">raw: relevance_score</div></div>

--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -588,6 +588,10 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
     .good {{ color: #baf7c9; }}
     .warn {{ color: #fde68a; }}
     .bad {{ color: #fecdd3; }}
+    .sentiment-positive {{ color: #baf7c9; }}
+    .sentiment-negative {{ color: #fecdd3; }}
+    .sentiment-neutral {{ color: #dbeafe; }}
+    .sentiment-unknown {{ color: var(--muted); }}
     .hidden {{ display: none !important; }}
     .section-note {{ color: var(--muted); max-width: 90ch; }}
     .footer-note {{ color: var(--muted); font-size: 0.9rem; }}
@@ -605,7 +609,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       <section class="panel state-card" id="state-panel">
         <div class="state-pill warn" id="review-state">Loading review…</div>
         <h2>What am I looking at?</h2>
-        <p id="state-explainer" class="section-note">This page loads the day-by-day Apple review evidence, plus a market benchmark chart for the HMM regime check.</p>
+        <p id="state-explainer" class="section-note">Only AI/ML/NLP evidence belongs here: article relevance, embeddings/topics, FinBERT sentence sentiment, ticker-date NLP aggregates, and market-wide HMM regime context.</p>
         <div class="hero-grid" id="metrics"></div>
       </section>
 
@@ -639,7 +643,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       <section class="panel tab-panel hidden" id="finbert-sentence-review-tab" role="tabpanel" aria-hidden="true">
         <div>
           <h2>FinBERT Sentence Review</h2>
-          <p class="section-note">This tab shows the full scored sentence rows, sentence/chunk index, source text field/order, sentiment probabilities, sentiment score, relevance score/state, and row granularity. If the scored-news artifact is missing full text, the dashboard shows a warning instead of pretending the evidence is complete.</p>
+          <p class="section-note">Review one scored sentence/chunk at a time. Each row now shows a Sentence sentiment label, positive/negative/neutral probabilities, sentiment score, and the exact text FinBERT scored.</p>
         </div>
         <div id="finbert-sentence-review-content"></div>
         <details class="panel" id="advanced-section">
@@ -654,7 +658,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       <section class="panel tab-panel hidden" id="topic-relevance-tab" role="tabpanel" aria-hidden="true">
         <div>
           <h2>Topic / Relevance Pipeline</h2>
-          <p class="section-note">This tab follows the article from ticker/entity preprocessing through embedding cache, BERTopic label, and pre-FinBERT relevance-gate evidence. A score of 1.0 is not treated as strong evidence when the supporting ticker, entity, embedding, topic, or gate rows are missing.</p>
+          <p class="section-note">This tab follows the article from ticker/entity preprocessing through embedding cache, BERTopic label, and pre-FinBERT relevance-gate evidence. If the Pre-FinBERT relevance gate artifact is missing, this tab is not reviewable yet even when embeddings and topics exist.</p>
         </div>
         <div id="topic-relevance-content"></div>
       </section>
@@ -662,7 +666,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       <section class="panel tab-panel hidden" id="semantic-aggregate-tab" role="tabpanel" aria-hidden="true">
         <div>
           <h2>Ticker-Date Semantic Aggregates</h2>
-          <p class="section-note">This tab shows the final Layer 1 NLP feature rows as one record per <strong>(date, ticker)</strong>. These are repeated context / aggregate values, not article evidence: use them to inspect the ticker-date feature row, its source and stage keys, and the aggregated values that Layer 2 consumes.</p>
+          <p class="section-note">Human-review digest for the final Layer 1 NLP feature rows: one record per <strong>(date, ticker)</strong>, focused on sentiment direction, positive/negative/neutral mix, article/sentence volume, and relevance.</p>
         </div>
         <div id="semantic-aggregate-content"></div>
       </section>
@@ -753,6 +757,23 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       const number = Number(value);
       if (!Number.isFinite(number)) return 'n/a';
       return number.toFixed(digits);
+    }}
+
+    function sentimentClass(label) {{
+      if (label === 'positive') return 'sentiment-positive';
+      if (label === 'negative') return 'sentiment-negative';
+      if (label === 'neutral') return 'sentiment-neutral';
+      return 'sentiment-unknown';
+    }}
+
+    function sentimentBadge(label) {{
+      const safeLabel = label || 'unknown';
+      return `<span class="badge ${{sentimentClass(safeLabel)}}">${{escapeHtml(safeLabel)}}</span>`;
+    }}
+
+    function sentimentLabelCounts(counts) {{
+      const source = counts || {{}};
+      return `positive: ${{Number(source.positive || 0)}} · negative: ${{Number(source.negative || 0)}} · neutral: ${{Number(source.neutral || 0)}} · unknown: ${{Number(source.unknown || 0)}}`;
     }}
 
     function labelState(state) {{
@@ -1231,6 +1252,8 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       const chunkIndex = row.chunk_index ?? 'n/a';
       const rowGranularity = row.row_granularity || 'n/a';
       const relevanceState = row.relevance_state || 'missing';
+      const sentimentLabel = row.sentiment_label || 'unknown';
+      const sentimentConfidence = row.sentiment_label_confidence;
       const probabilities = [
         `pos: ${{formatNumber(row.positive_probability, 2)}}`,
         `neg: ${{formatNumber(row.negative_probability, 2)}}`,
@@ -1240,6 +1263,8 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         <details class="row-item">
           <summary>
             <span class="article-title">Sentence ${{escapeHtml(sentenceIndex)}} / chunk ${{escapeHtml(chunkIndex)}}</span>
+            ${{sentimentBadge(sentimentLabel)}}
+            <span class="badge" title="Raw field: sentiment_label_confidence">confidence: ${{formatNumber(sentimentConfidence, 2)}}</span>
             <span class="badge">${{escapeHtml(rowGranularity)}}</span>
             <span class="badge ${{hasText ? 'good' : 'warn'}}">${{hasText ? 'Text available' : 'Text missing'}}</span>
             <span class="badge" title="Raw field: relevance_state">relevance: ${{escapeHtml(relevanceState)}}</span>
@@ -1250,6 +1275,8 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
             <div class="compact-grid">
               <div class="compact"><div class="k">Source text field</div><div class="v">${{escapeHtml(sourceTextField)}}</div><div class="k">raw: source_text_field</div></div>
               <div class="compact"><div class="k">Source text order</div><div class="v">${{escapeHtml(sourceTextOrder)}}</div><div class="k">raw: source_text_order</div></div>
+              <div class="compact"><div class="k">Sentence sentiment label</div><div class="v ${{sentimentClass(sentimentLabel)}}">${{escapeHtml(sentimentLabel)}}</div><div class="k">raw: sentiment_label</div></div>
+              <div class="compact"><div class="k">Label confidence</div><div class="v">${{formatNumber(sentimentConfidence, 3)}}</div><div class="k">raw: sentiment_label_confidence</div></div>
               <div class="compact"><div class="k">Sentiment score</div><div class="v">${{formatNumber(row.sentiment_score, 2)}}</div><div class="k">raw: sentiment_score</div></div>
               <div class="compact"><div class="k">Relevance score</div><div class="v">${{formatNumber(row.relevance_score, 2)}}</div><div class="k">raw: relevance_score</div></div>
             </div>
@@ -1267,6 +1294,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
           <summary>
             <span class="article-title">${{escapeHtml(article.headline || article.article_id || 'Article')}}</span>
             <span class="badge ${{article.article_status === 'accepted' ? 'good' : 'warn'}}">${{article.article_status === 'accepted' ? 'Accepted for review' : 'Needs a closer look'}}</span>
+            <span class="badge" title="Derived from sentence-level sentiment labels">${{escapeHtml(sentimentLabelCounts(article.sentiment_label_counts))}}</span>
             <span class="badge" title="Raw field: article_id">article_id: ${{escapeHtml(article.article_id || 'n/a')}}</span>
             <span class="badge" title="Raw field: sentence rows">rows: ${{rowCount}}</span>
           </summary>
@@ -1325,10 +1353,12 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       const missingTextWarnings = Array.isArray(review.missing_text_warnings) ? review.missing_text_warnings : [];
       const sourceArtifactGaps = Array.isArray(review.source_artifact_gaps) ? review.source_artifact_gaps : [];
       const rowCount = Number(review.row_count || 0);
+      const labelCounts = sentimentLabelCounts(review.sentiment_label_counts);
       finbertReviewEl.innerHTML = `
         <div class="hero-grid">
           ${{metricCard('Articles', articles.length, 'finbert_sentence_review.article_count', 'How many article-level FinBERT review cards are available.')}}
           ${{metricCard('Sentence rows', rowCount, 'finbert_sentence_review.row_count', 'How many sentence/chunk rows were reviewed.')}}
+          ${{metricCard('Sentence sentiment labels', labelCounts, 'finbert_sentence_review.sentiment_label_counts', 'Positive/negative/neutral labels derived from FinBERT probabilities.')}}
           ${{metricCard('Missing text rows', missingTextWarnings.length, 'finbert_sentence_review.missing_text_warning_count', 'How many scored rows are missing the full scored sentence text.')}}
         </div>
         ${{sourceArtifactGaps.length ? `<div class="chart-blocker"><h3>Source artifact gap</h3><p>The scored-news artifact is incomplete for at least one row, so the dashboard is telling you that instead of inventing missing text.</p><ul>${{sourceArtifactGaps.map((gap) => `<li>${{escapeHtml(gap.date || 'n/a')}} · ${{escapeHtml(gap.article_id || 'n/a')}} · sentence ${{escapeHtml(gap.sentence_index ?? 'n/a')}} / chunk ${{escapeHtml(gap.chunk_index ?? 'n/a')}}${{gap.source_text_field ? ` · source field: ${{escapeHtml(gap.source_text_field)}}` : ''}}${{gap.source_text_order !== undefined && gap.source_text_order !== null ? ` · source order: ${{escapeHtml(gap.source_text_order)}}` : ''}}</li>`).join('')}}</ul></div>` : ''}}
@@ -1412,15 +1442,19 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       const summary = review.summary || {{}};
       const dateGroups = Array.isArray(review.date_groups) ? review.date_groups : [];
       const blockers = Array.isArray(review.missing_evidence_blockers) ? review.missing_evidence_blockers : [];
+      const blockerPreview = blockers.slice(0, 12);
+      const reviewable = summary.reviewable === true;
       topicRelevanceReviewEl.innerHTML = `
         <div class="hero-grid">
           ${{metricCard('Articles', summary.article_count ?? 0, 'topic_relevance_review.summary.article_count', 'Article-level topic/relevance evidence rows.')}}
+          ${{metricCard('Relevance-gate rows', summary.relevance_gate_row_count ?? 0, 'topic_relevance_review.summary.relevance_gate_row_count', 'Rows from the pre-FinBERT relevance gate. Zero means this tab cannot be accepted yet.')}}
+          ${{metricCard('Embeddings / topic rows', `${{summary.embedding_row_count ?? 0}} / ${{summary.topic_label_row_count ?? 0}}`, 'topic_relevance_review.summary.embedding_row_count / topic_label_row_count', 'ML topic evidence available before the missing relevance-gate decision.')}}
           ${{metricCard('Accepted', summary.accepted_count ?? 0, 'topic_relevance_review.summary.accepted_count', 'Rows accepted by the relevance gate with supporting evidence.')}}
           ${{metricCard('Borderline', summary.borderline_count ?? 0, 'topic_relevance_review.summary.borderline_count', 'Rows that need human attention before trust.')}}
           ${{metricCard('Rejected', summary.rejected_count ?? 0, 'topic_relevance_review.summary.rejected_count', 'Rows rejected by the relevance gate.')}}
           ${{metricCard('Missing/default', summary.missing_or_default_count ?? 0, 'topic_relevance_review.summary.missing_or_default_count', 'Rows missing required topic, embedding, or relevance support.')}}
         </div>
-        ${{blockers.length ? `<div class="chart-blocker"><h3>Topic / relevance evidence blockers</h3><p>These articles have missing evidence or default relevance scores that should block final human acceptance until the upstream artifacts are present.</p><ul>${{blockers.map((item) => `<li>${{escapeHtml(item.date || 'n/a')}} · ${{escapeHtml(item.article_id || 'n/a')}} · ${{escapeHtml((item.missing_evidence_flags || []).join(', '))}}</li>`).join('')}}</ul></div>` : ''}}
+        ${{!reviewable ? `<div class="chart-blocker"><h3>Topic / relevance is not reviewable yet</h3><p>${{escapeHtml(summary.review_explanation || 'Required topic/relevance evidence is missing.')}}</p><details><summary>Show sample affected articles (${{blockers.length}} total)</summary><div class="body"><ul>${{blockerPreview.map((item) => `<li>${{escapeHtml(item.date || 'n/a')}} · ${{escapeHtml(item.article_id || 'n/a')}} · ${{escapeHtml((item.missing_evidence_flags || []).join(', '))}}</li>`).join('')}}</ul></div></details></div>` : ''}}
         <div class="date-grid">
           ${{dateGroups.length ? dateGroups.map((group) => `
             <details class="date-card">
@@ -1453,36 +1487,27 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
     function renderSemanticAggregateRow(row) {{
       const features = row.features || {{}};
       const contributingArticleIds = Array.isArray(row.contributing_article_ids) ? row.contributing_article_ids : [];
-      const sourceWeightSummary = Array.isArray(row.source_weight_summary) ? row.source_weight_summary : [];
-      const topicSentimentSummary = Array.isArray(row.topic_sentiment_summary) ? row.topic_sentiment_summary : [];
       const relevanceReasonCodes = Array.isArray(row.relevance_reason_codes) ? row.relevance_reason_codes : [];
       const semanticWarningCodes = Array.isArray(row.semantic_warning_codes) ? row.semantic_warning_codes : [];
+      const reviewCards = Array.isArray(row.review_value_cards) ? row.review_value_cards : [];
       const rowGranularity = row.row_granularity || 'n/a';
       const rowGranularityLabel = rowGranularity === 'ticker-date' ? 'Repeated context / aggregate value' : rowGranularity;
       return `
         <details class="row-item">
           <summary>
             <span class="article-title">${{escapeHtml(row.date || 'n/a')}} · ${{escapeHtml(row.ticker || 'n/a')}}</span>
+            ${{sentimentBadge(row.sentiment_label || 'unknown')}}
             <span class="badge" title="Raw field: row_granularity">${{escapeHtml(rowGranularityLabel)}}</span>
             <span class="badge" title="Raw field: stage">stage: ${{escapeHtml(row.stage || 'n/a')}}</span>
-            <span class="badge" title="Raw field: artifact_key">artifact: ${{escapeHtml(row.artifact_key || 'n/a')}}</span>
           </summary>
           <div class="body">
-            <p class="article-copy">What am I looking at? The final Layer 1 ticker-date feature row for this trading day. Why does it matter? This is the aggregate output that should feed later stages, not article or sentence evidence. What would make this good or bad? Good: the row is present once per <strong>(date, ticker)</strong> and its values are clearly labeled as repeated context / aggregate values. Bad: the row is missing, duplicated, or presented like article-level evidence.</p>
+            <p class="article-copy"><strong>Human-review digest:</strong> ${{escapeHtml(row.human_review_summary || 'No aggregate review summary available.')}}</p>
             <div class="compact-grid">
+              ${{reviewCards.map((card) => `<div class="compact"><div class="k">${{escapeHtml(card.label)}}</div><div class="v">${{escapeHtml(card.value)}}</div><div class="k">raw: ${{escapeHtml(card.field)}}</div></div>`).join('')}}
               <div class="compact"><div class="k">Row granularity</div><div class="v">${{escapeHtml(rowGranularityLabel)}}</div><div class="k">raw: row_granularity</div></div>
               <div class="compact"><div class="k">Stage</div><div class="v">${{escapeHtml(row.stage || 'n/a')}}</div><div class="k">raw: stage</div></div>
               <div class="compact"><div class="k">Artifact key</div><div class="v">${{escapeHtml(row.artifact_key || 'n/a')}}</div><div class="k">raw: artifact_key</div></div>
-              <div class="compact"><div class="k">Sentiment score</div><div class="v">${{formatNumber(features.nlp_sentiment_score, 3)}}</div><div class="k">raw: features.nlp_sentiment_score</div></div>
-              <div class="compact"><div class="k">Article count</div><div class="v">${{formatNumber(features.nlp_article_count, 0)}}</div><div class="k">raw: features.nlp_article_count</div></div>
-              <div class="compact"><div class="k">Sentence count</div><div class="v">${{formatNumber(features.nlp_sentence_count, 0)}}</div><div class="k">raw: features.nlp_sentence_count</div></div>
-              <div class="compact"><div class="k">Relevance score</div><div class="v">${{formatNumber(features.nlp_relevance_score, 3)}}</div><div class="k">raw: features.nlp_relevance_score</div></div>
-              <div class="compact"><div class="k">Source weight mean / sum</div><div class="v">${{formatNumber(features.nlp_source_weight_mean, 2)}} / ${{formatNumber(features.nlp_source_weight_sum, 2)}}</div><div class="k">raw: features.nlp_source_weight_mean / features.nlp_source_weight_sum</div></div>
-              <div class="compact"><div class="k">Effective weight sum</div><div class="v">${{formatNumber(features.nlp_effective_weight_sum, 2)}}</div><div class="k">raw: features.nlp_effective_weight_sum</div></div>
-              <div class="compact"><div class="k">Relevance accepted / borderline</div><div class="v">${{formatNumber(features.nlp_relevance_accepted_count, 0)}} / ${{formatNumber(features.nlp_relevance_borderline_count, 0)}}</div><div class="k">raw: features.nlp_relevance_accepted_count / features.nlp_relevance_borderline_count</div></div>
               <div class="compact"><div class="k">Contributing articles</div><div class="v">${{escapeHtml(contributingArticleIds.length ? contributingArticleIds.join(', ') : 'none')}}</div><div class="k">raw: contributing_article_ids</div></div>
-              <div class="compact"><div class="k">Source weight summary</div><div class="v">${{escapeHtml(semanticAggregateValue(sourceWeightSummary))}}</div><div class="k">raw: source_weight_summary</div></div>
-              <div class="compact"><div class="k">Topic sentiment summary</div><div class="v">${{escapeHtml(semanticAggregateValue(topicSentimentSummary))}}</div><div class="k">raw: topic_sentiment_summary</div></div>
               <div class="compact"><div class="k">Relevance reason codes</div><div class="v">${{escapeHtml(semanticAggregateValue(relevanceReasonCodes))}}</div><div class="k">raw: relevance_reason_codes</div></div>
               <div class="compact"><div class="k">Semantic warning codes</div><div class="v">${{escapeHtml(semanticAggregateValue(semanticWarningCodes))}}</div><div class="k">raw: semantic_warning_codes</div></div>
             </div>
@@ -1497,12 +1522,14 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
     }}
 
     function renderSemanticAggregateReview(payload) {{
-      const sections = payload.pipeline_sections || {{}};
-      const rows = Array.isArray(sections.semantic_aggregate_rows) ? sections.semantic_aggregate_rows : [];
+      const review = payload.semantic_aggregate_review || {{}};
+      const summary = review.summary || {{}};
+      const rows = Array.isArray(review.rows) ? review.rows : [];
       const warnings = semanticAggregateWarnings(payload);
       semanticAggregateReviewEl.innerHTML = `
         <div class="hero-grid">
-          ${{metricCard('Aggregate rows', rows.length, 'pipeline_sections.semantic_aggregate_rows', 'Final ticker-date Layer 1 feature rows available in the review payload.')}}
+          ${{metricCard('Aggregate rows', summary.row_count ?? rows.length, 'semantic_aggregate_review.summary.row_count', 'Final ticker-date Layer 1 feature rows available in the review payload.')}}
+          ${{metricCard('Dates covered', summary.date_count ?? 0, 'semantic_aggregate_review.summary.date_count', 'Dates with ticker-date NLP aggregate rows.')}}
           ${{metricCard('Missing aggregate warnings', warnings.length, 'warnings[scope=sentiment_features]', 'Warnings for missing or incomplete ticker-date aggregate rows.')}}
           ${{metricCard('Row granularity', 'ticker-date', 'row_granularity', 'These rows are repeated ticker-date context, not article evidence.')}}
         </div>

--- a/core/features/aapl_evidence.py
+++ b/core/features/aapl_evidence.py
@@ -2126,6 +2126,7 @@ def _build_finbert_sentence_review_payload(article_groups: Sequence[Mapping[str,
     articles: list[dict[str, object]] = []
     missing_text_warnings: list[dict[str, object]] = []
     source_artifact_gaps: list[dict[str, object]] = []
+    sentiment_label_counts: dict[str, int] = defaultdict(int)
     row_count = 0
 
     for article in article_groups:
@@ -2134,9 +2135,13 @@ def _build_finbert_sentence_review_payload(article_groups: Sequence[Mapping[str,
         article_missing_text = 0
         full_text_parts: list[str] = []
         decorated_rows: list[dict[str, object]] = []
+        article_sentiment_label_counts: dict[str, int] = defaultdict(int)
         for row in sentence_rows:
             text = _optional_str(row.get("text"))
             relevance_score = _maybe_float(row.get("relevance_score"))
+            sentiment_label, sentiment_label_confidence = _sentiment_label_from_probabilities(row)
+            sentiment_label_counts[sentiment_label] += 1
+            article_sentiment_label_counts[sentiment_label] += 1
             missing_text = text is None
             if text is not None:
                 full_text_parts.append(text)
@@ -2161,6 +2166,8 @@ def _build_finbert_sentence_review_payload(article_groups: Sequence[Mapping[str,
             decorated_rows.append(
                 {
                     **row,
+                    "sentiment_label": sentiment_label,
+                    "sentiment_label_confidence": sentiment_label_confidence,
                     "relevance_state": _relevance_state(relevance_score, threshold=DEFAULT_RELEVANCE_THRESHOLD),
                     "has_full_scored_text": not missing_text,
                     "missing_text_warning": (
@@ -2181,6 +2188,7 @@ def _build_finbert_sentence_review_payload(article_groups: Sequence[Mapping[str,
                 **article,
                 "sentence_rows": decorated_rows,
                 "full_scored_text": " ".join(full_text_parts) if has_full_scored_text else None,
+                "sentiment_label_counts": dict(sorted(article_sentiment_label_counts.items())),
                 "full_scored_text_available": has_full_scored_text,
                 "missing_text_row_count": article_missing_text,
                 "full_scored_text_warning": (
@@ -2206,6 +2214,7 @@ def _build_finbert_sentence_review_payload(article_groups: Sequence[Mapping[str,
         "articles": articles,
         "article_count": len(articles),
         "row_count": row_count,
+        "sentiment_label_counts": dict(sorted(sentiment_label_counts.items())),
         "missing_text_warning_count": len(missing_text_warnings),
         "missing_text_warnings": missing_text_warnings,
         "source_artifact_gaps": source_artifact_gaps,
@@ -2271,6 +2280,20 @@ def _maybe_int(value: Any) -> int | None:
     if maybe_value is None:
         return None
     return int(maybe_value)
+
+
+def _sentiment_label_from_probabilities(row: Mapping[str, object]) -> tuple[str, float | None]:
+    """Return the human review sentiment label implied by FinBERT probabilities."""
+    probabilities = {
+        "positive": _maybe_float(row.get("positive_probability")),
+        "negative": _maybe_float(row.get("negative_probability")),
+        "neutral": _maybe_float(row.get("neutral_probability")),
+    }
+    available = {key: value for key, value in probabilities.items() if value is not None}
+    if not available:
+        return "unknown", None
+    label = max(available, key=lambda key: available[key] if available[key] is not None else -1.0)
+    return label, available[label]
 
 
 def _optional_str(value: Any) -> str | None:

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -104,6 +104,7 @@ def build_layer1_semantic_review_dashboard_payload(
     """Return the JSON payload rendered by the semantic-review dashboard UI."""
     payload = _build_payload_from_report(report)
     payload["topic_relevance_review"] = build_layer1_topic_relevance_review(payload)
+    payload["semantic_aggregate_review"] = build_layer1_semantic_aggregate_review(payload)
     payload.update(build_layer1_semantic_review_readiness_summary(payload))
     return payload
 
@@ -122,6 +123,10 @@ def build_layer1_topic_relevance_review(
     embedding_by_article = _rows_by_article(sections.get("article_embedding_rows"))
     topic_by_article = _rows_by_article(sections.get("topic_label_rows"))
     relevance_by_article = _rows_by_article(sections.get("relevance_gate_rows"))
+    preprocessing_rows = _json_list(sections.get("raw_preprocessing_rows"))
+    embedding_rows = _json_list(sections.get("article_embedding_rows"))
+    topic_rows = _json_list(sections.get("topic_label_rows"))
+    relevance_rows = _json_list(sections.get("relevance_gate_rows"))
 
     rows = [
         _topic_relevance_article_row(
@@ -175,6 +180,11 @@ def build_layer1_topic_relevance_review(
     return {
         "summary": {
             "article_count": len(rows),
+            "preprocessing_row_count": len(preprocessing_rows),
+            "embedding_row_count": len(embedding_rows),
+            "topic_label_row_count": len(topic_rows),
+            "relevance_gate_row_count": len(relevance_rows),
+            "relevance_gate_available": bool(relevance_rows),
             "accepted_count": sum(
                 1 for row in rows if row.get("evidence_status") == "accepted"
             ),
@@ -203,10 +213,37 @@ def build_layer1_topic_relevance_review(
                 if "default_relevance_without_supporting_evidence"
                 in _json_string_list(row.get("missing_evidence_flags"))
             ),
+            **_topic_relevance_reviewability_summary(
+                article_count=len(rows),
+                relevance_gate_row_count=len(relevance_rows),
+                embedding_row_count=len(embedding_rows),
+                topic_label_row_count=len(topic_rows),
+            ),
         },
         "date_groups": date_groups,
         "articles": rows,
         "missing_evidence_blockers": missing_blockers,
+    }
+
+
+def build_layer1_semantic_aggregate_review(
+    payload: Mapping[str, object],
+) -> dict[str, object]:
+    """Return human-focused ticker-date NLP aggregate review rows."""
+    sections = _json_mapping(payload.get("pipeline_sections"))
+    rows = [
+        _semantic_aggregate_review_row(row)
+        for row in _json_list(sections.get("semantic_aggregate_rows"))
+        if isinstance(row, Mapping)
+    ]
+    return {
+        "summary": {
+            "row_count": len(rows),
+            "date_count": len({str(row.get("date")) for row in rows if row.get("date") is not None}),
+            "reviewable": bool(rows),
+            "review_focus": "ticker-date NLP summary consumed by later model layers",
+        },
+        "rows": rows,
     }
 
 
@@ -541,6 +578,141 @@ def _relevance_score_interpretation(
     if lowered_decisions & {"borderline", "review", "needs_review"}:
         return "computed_borderline"
     return "computed"
+
+
+def _topic_relevance_reviewability_summary(
+    *,
+    article_count: int,
+    relevance_gate_row_count: int,
+    embedding_row_count: int,
+    topic_label_row_count: int,
+) -> dict[str, object]:
+    if article_count and relevance_gate_row_count == 0:
+        return {
+            "reviewable": False,
+            "review_status": "not_reviewable_missing_relevance_gate",
+            "review_explanation": (
+                "Pre-FinBERT relevance gate artifact is missing. Embeddings and BERTopic "
+                "topic rows are present, but the dashboard cannot prove accept/reject "
+                "relevance decisions or sub-scores for human acceptance."
+            ),
+        }
+    if article_count and (embedding_row_count == 0 or topic_label_row_count == 0):
+        return {
+            "reviewable": False,
+            "review_status": "not_reviewable_missing_topic_or_embedding_evidence",
+            "review_explanation": (
+                "Embedding or BERTopic evidence is missing, so topic relevance cannot be reviewed."
+            ),
+        }
+    return {
+        "reviewable": bool(article_count),
+        "review_status": "reviewable" if article_count else "no_topic_relevance_rows",
+        "review_explanation": (
+            "Review ticker/entity evidence, topic assignment, and pre-FinBERT relevance "
+            "gate decisions before trusting FinBERT sentiment."
+        ),
+    }
+
+
+def _semantic_aggregate_review_row(row: Mapping[str, object]) -> dict[str, object]:
+    features = _json_mapping(row.get("features"))
+    sentiment_score = _maybe_float(features.get("nlp_sentiment_score"))
+    sentiment_label = _sentiment_label_from_score(sentiment_score)
+    cards = _semantic_aggregate_review_cards(features)
+    return {
+        **dict(row),
+        "sentiment_label": sentiment_label,
+        "human_review_summary": _semantic_aggregate_human_summary(
+            sentiment_label=sentiment_label,
+            sentiment_score=sentiment_score,
+            article_count=_maybe_float(features.get("nlp_article_count")),
+            sentence_count=_maybe_float(features.get("nlp_sentence_count")),
+        ),
+        "review_value_cards": cards,
+    }
+
+
+def _sentiment_label_from_score(score: float | None) -> str:
+    if score is None:
+        return "unknown"
+    if score > 0.05:
+        return "positive"
+    if score < -0.05:
+        return "negative"
+    return "neutral"
+
+
+def _semantic_aggregate_human_summary(
+    *,
+    sentiment_label: str,
+    sentiment_score: float | None,
+    article_count: float | None,
+    sentence_count: float | None,
+) -> str:
+    return (
+        f"Overall NLP sentiment is {sentiment_label} "
+        f"(score={_display_number(sentiment_score, 3)}) from "
+        f"{_display_number(article_count, 0)} article(s) and "
+        f"{_display_number(sentence_count, 0)} sentence/chunk row(s)."
+    )
+
+
+def _semantic_aggregate_review_cards(features: Mapping[str, object]) -> list[dict[str, object]]:
+    cards: list[dict[str, object]] = []
+    sentiment_score = _maybe_float(features.get("nlp_sentiment_score"))
+    if sentiment_score is not None:
+        cards.append(
+            {
+                "label": "Overall sentiment",
+                "value": _display_number(sentiment_score, 3),
+                "field": "features.nlp_sentiment_score",
+            }
+        )
+    mix_values = [
+        _maybe_float(features.get("nlp_sentiment_positive")),
+        _maybe_float(features.get("nlp_sentiment_negative")),
+        _maybe_float(features.get("nlp_sentiment_neutral")),
+    ]
+    if all(value is not None for value in mix_values):
+        cards.append(
+            {
+                "label": "Positive / negative / neutral mix",
+                "value": " / ".join(_display_number(value, 3) for value in mix_values),
+                "field": "features.nlp_sentiment_positive / negative / neutral",
+            }
+        )
+    article_count = _maybe_float(features.get("nlp_article_count"))
+    sentence_count = _maybe_float(features.get("nlp_sentence_count"))
+    if article_count is not None or sentence_count is not None:
+        cards.append(
+            {
+                "label": "Articles / sentences",
+                "value": (
+                    f"{_display_number(article_count, 0)} / "
+                    f"{_display_number(sentence_count, 0)}"
+                ),
+                "field": "features.nlp_article_count / features.nlp_sentence_count",
+            }
+        )
+    relevance_score = _maybe_float(features.get("nlp_relevance_score"))
+    if relevance_score is not None:
+        cards.append(
+            {
+                "label": "Relevance score",
+                "value": _display_number(relevance_score, 3),
+                "field": "features.nlp_relevance_score",
+            }
+        )
+    return cards
+
+
+def _display_number(value: float | None, decimals: int) -> str:
+    if value is None:
+        return "n/a"
+    if decimals == 0:
+        return str(int(round(value)))
+    return f"{value:.{decimals}f}"
 
 
 def _rows_by_article(value: object) -> dict[tuple[str, str], list[dict[str, object]]]:

--- a/tests/fixtures/semantic_review_support.py
+++ b/tests/fixtures/semantic_review_support.py
@@ -334,6 +334,9 @@ def _semantic_aggregate_frame(scored_frame: pd.DataFrame) -> pd.DataFrame:
     for date_text, group in scored_frame.groupby("date", sort=True):
         features = {
             "nlp_sentiment_score": float(group["sentiment_score"].mean()),
+            "nlp_sentiment_positive": float(group["positive_probability"].mean()),
+            "nlp_sentiment_negative": float(group["negative_probability"].mean()),
+            "nlp_sentiment_neutral": float(group["neutral_probability"].mean()),
             "nlp_article_count": int(group["article_id"].nunique()),
             "nlp_sentence_count": int(len(group)),
             "nlp_relevance_score": float(group["relevance_score"].mean()),

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -247,9 +247,66 @@ def test_semantic_review_payload_separates_tabs_and_reports_missing_sentence_tex
     assert finbert_review["has_missing_text"] is True
     assert finbert_review["missing_text_warning_count"] == 1
     assert finbert_review["source_artifact_gaps"][0]["gap"] == "missing_full_scored_sentence_text"
+    assert finbert_review["sentiment_label_counts"]["positive"] == 6
+    assert finbert_review["sentiment_label_counts"]["negative"] == 2
     assert missing_article["full_scored_text_available"] is False
     assert missing_article["full_scored_text_warning"]
-    assert any(row["missing_text_warning"] for row in missing_article["sentence_rows"])
+    sentence_rows = cast(list[dict[str, Any]], missing_article["sentence_rows"])
+    assert sentence_rows[0]["sentiment_label"] == "positive"
+    assert sentence_rows[0]["sentiment_label_confidence"] == 0.78
+    assert any(row["missing_text_warning"] for row in sentence_rows)
+
+
+def test_semantic_review_payload_explains_unreviewable_missing_relevance_gate(
+    tmp_path: Path,
+) -> None:
+    """The topic/relevance tab should explain missing gate artifacts once, not as row spam."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    report_dict = cast(dict[str, Any], report.to_dict())
+    report_dict["relevance_gate_rows"] = []
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report_dict))
+    review = cast(dict[str, Any], payload["topic_relevance_review"])
+    summary = cast(dict[str, Any], review["summary"])
+
+    assert summary["relevance_gate_row_count"] == 0
+    assert summary["embedding_row_count"] > 0
+    assert summary["topic_label_row_count"] > 0
+    assert summary["reviewable"] is False
+    assert summary["review_status"] == "not_reviewable_missing_relevance_gate"
+    assert "Pre-FinBERT relevance gate artifact is missing" in summary["review_explanation"]
+
+
+def test_semantic_review_payload_adds_human_focused_aggregate_review(
+    tmp_path: Path,
+) -> None:
+    """Ticker-date aggregates should expose useful NLP review cards instead of mostly n/a fields."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    review = cast(dict[str, Any], payload["semantic_aggregate_review"])
+    rows = cast(list[dict[str, Any]], review["rows"])
+
+    assert review["summary"]["row_count"] == 2
+    assert rows[0]["sentiment_label"] in {"positive", "negative", "neutral"}
+    assert rows[0]["human_review_summary"].startswith("Overall NLP sentiment is")
+    card_labels = {str(card["label"]) for card in cast(list[dict[str, Any]], rows[0]["review_value_cards"])}
+    assert {"Overall sentiment", "Positive / negative / neutral mix", "Articles / sentences", "Relevance score"}.issubset(card_labels)
+    assert "Source weight mean / sum" not in card_labels
 
 
 def test_semantic_review_topic_relevance_tab_flags_default_relevance(
@@ -670,3 +727,22 @@ def test_semantic_review_dashboard_hmm_tab_puts_chart_before_diagnostics() -> No
     assert context_details_index < date_rows_index
     assert "Model inputs and date-by-date regime rows" in html
     assert "Evidence blocker" not in html
+
+
+def test_semantic_review_dashboard_html_names_human_review_outputs() -> None:
+    """Visible dashboard copy should describe exactly what a human can review."""
+    html = _render_dashboard_html(
+        _DashboardDefaults(
+            run_id="run-123",
+            from_date="2026-05-21",
+            to_date="2026-05-22",
+            ticker="AAPL",
+            host="127.0.0.1",
+            port=8766,
+        )
+    )
+
+    assert "Sentence sentiment label" in html
+    assert "Pre-FinBERT relevance gate artifact is missing" in html
+    assert "Human-review digest" in html
+    assert "Only AI/ML/NLP evidence belongs here" in html

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -647,3 +647,26 @@ def test_semantic_review_dashboard_html_is_beginner_friendly_and_collapsed() -> 
     assert "<table" not in html
     assert "date_aligned_price_hmm_rows" in html
     assert "/api/review" in html
+
+
+def test_semantic_review_dashboard_hmm_tab_puts_chart_before_diagnostics() -> None:
+    """The HMM tab should show the SPY chart before raw model/date diagnostics."""
+    html = _render_dashboard_html(
+        _DashboardDefaults(
+            run_id="run-123",
+            from_date="2026-05-21",
+            to_date="2026-05-22",
+            ticker="AAPL",
+            host="127.0.0.1",
+            port=8766,
+        )
+    )
+
+    chart_index = html.index('id="chart-section"')
+    context_details_index = html.index('id="hmm-context-section"')
+    date_rows_index = html.index('id="hmm-date-rows"')
+
+    assert chart_index < context_details_index
+    assert context_details_index < date_rows_index
+    assert "Model inputs and date-by-date regime rows" in html
+    assert "Evidence blocker" not in html


### PR DESCRIPTION
## Summary
- load the HMM tab with the SPY benchmark chart before raw model/date diagnostics
- collapse HMM model-input and date-row diagnostics behind details by default
- replace repeated per-article topic/relevance yellow blocker boxes with collapsed evidence-flag details
- cache API payloads per query in the local dashboard server so repeated tab/browser loads are fast after the first R2 read

## Tests
- `.venv/bin/python -m pytest tests/unit/test_semantic_review_dashboard.py -q`
- `.venv/bin/python -m ruff check app/lab/semantic_review_dashboard.py tests/unit/test_semantic_review_dashboard.py`

## Live QA
- restarted the local dashboard on port 8766 with the real R2 env sourced
- verified `/api/review?ticker=AAPL` returns `benchmark=SPY`, 16 benchmark price rows, and 16 benchmark/HMM rows
- visually verified the HMM tab now shows the SPY graph near the top and the raw diagnostics wall is collapsed
