### PR TITLE
fix(news): clean Layer 1 HTML before splitting

### DIFF
--- a/core/features/news_preprocessing.py
+++ b/core/features/news_preprocessing.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import html
 import json
 import math
 import re
@@ -16,6 +17,26 @@ from services.wikipedia.sp500_universe import canonicalize_ticker
 
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[\"'A-Z0-9])")
 _WHITESPACE = re.compile(r"\s+")
+_HTML_BLOCK_BREAK = re.compile(
+    r"(?is)</?(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|br|hr)[^>]*>"
+)
+_HTML_NOISE_BLOCKS = (
+    re.compile(r"(?is)<script\b[^>]*>.*?</script>"),
+    re.compile(r"(?is)<style\b[^>]*>.*?</style>"),
+    re.compile(r"(?is)<noscript\b[^>]*>.*?</noscript>"),
+    re.compile(r"(?is)<iframe\b[^>]*>.*?</iframe>"),
+    re.compile(
+        r"(?is)<blockquote\b[^>]*class=[\"'][^\"']*"
+        r"(?:twitter-tweet|instagram-media|tiktok-embed|reddit-embed|embed|widget)"
+        r"[^\"']*[\"'][^>]*>.*?</blockquote>"
+    ),
+    re.compile(
+        r"(?is)<div\b[^>]*class=[\"'][^\"']*"
+        r"(?:widget|embed|promo|related|newsletter|ad|advert|sponsored|social-embed)"
+        r"[^\"']*[\"'][^>]*>.*?</div>"
+    ),
+)
+_HTML_TAG = re.compile(r"<[^>]+>")
 _TICKER_TEXT_PATTERN = re.compile(r"\b[A-Z][A-Z0-9.-]{0,6}\b")
 _ENTITY_PHRASE_PATTERN = re.compile(
     r"\b(?:[A-Z][a-z0-9&]+(?:\s+[A-Z][a-z0-9&]+){0,3}|[A-Z]{2,}(?:\s+[A-Z]{2,})*)\b"
@@ -348,7 +369,7 @@ def _normalize_allowed_tickers(tickers: Iterable[str] | None) -> set[str] | None
 
 def _sentences_from_text(value: Any, *, settings: NewsPreprocessingConfig) -> list[str]:
     """Split and normalize one raw text field into sentence strings."""
-    text = _optional_text(value)
+    text = _clean_article_text(value)
     if text is None:
         return []
     normalized = _WHITESPACE.sub(" ", text).strip()
@@ -403,6 +424,22 @@ def _optional_text(value: Any) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _clean_article_text(value: Any) -> str | None:
+    """Return readable plain text from raw provider HTML or text content."""
+    text = _optional_text(value)
+    if text is None:
+        return None
+    cleaned = html.unescape(text)
+    for pattern in _HTML_NOISE_BLOCKS:
+        cleaned = pattern.sub(" ", cleaned)
+    cleaned = _HTML_BLOCK_BREAK.sub(" ", cleaned)
+    cleaned = _HTML_TAG.sub(" ", cleaned)
+    cleaned = cleaned.replace("\xa0", " ")
+    cleaned = _WHITESPACE.sub(" ", cleaned).strip()
+    cleaned = re.sub(r"\s+([,.;:!?])", r"\1", cleaned)
+    return cleaned or None
 
 
 def _optional_datetime(value: Any) -> datetime | None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -364,8 +364,8 @@ migration inputs, but they are not the authoritative production handoff path.
 ```
 RAW ARTICLES (Alpaca news)
   → Step 1: Preprocessing
-      Read raw/news and raw/universe from R2, split into sentences, tag
-      point-in-time tickers, write NewsSentimentRecord rows to
+      Read raw/news and raw/universe from R2, clean provider HTML/entities into plain text,
+      split into sentences, tag point-in-time tickers, write NewsSentimentRecord rows to
       features/{date}/news_sentiment/{run_id}.parquet
   → Step 2a: Sentence Transformers (per article)
       Model: all-mpnet-base-v2

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -254,6 +254,9 @@ Use cases:
 
 Input note:
 - generated from Layer 0 raw point-in-time news archives
+- provider HTML, boilerplate widgets, and common HTML entities are normalized into plain text
+  before sentence/chunk splitting so `text` stores readable article content rather than raw
+  markup
 - preprocessing rows should preserve article provenance in `article_id`, `headline`,
   `normalized_headline`, `source`, `url`, `published_at`, `source_text_field`,
   `source_text_order`, and `source_text_provenance`

--- a/tests/unit/test_news_preprocessing.py
+++ b/tests/unit/test_news_preprocessing.py
@@ -30,6 +30,46 @@ def test_split_article_chunks_preserves_source_field_provenance() -> None:
     assert sentences == ["Apple moves higher."]
 
 
+def test_split_article_sentences_cleans_provider_html_and_preserves_meaningful_text() -> None:
+    """Provider HTML is stripped before splitting without losing useful article text."""
+    article = {
+        "headline": (
+            '<div><a href="https://example.test/apple">Apple</a> shares rise &nbsp; '
+            "on <strong>AI</strong> push.</div>"
+        ),
+        "summary": (
+            '<p>Analyst calls it a "strong quarter" &#8212; target rises to $210.</p>'
+            '<blockquote class="twitter-tweet"><p>Ignore this tweet embed.</p></blockquote>'
+        ),
+        "content": (
+            '<div><p>AAPL traded at <span>$189.20</span>.</p>'
+            '<script>window.widget = true;</script>'
+            '<div class="widget">widget boilerplate</div>'
+            '<p>Source: Benzinga</p></div>'
+        ),
+        "symbols": ["AAPL"],
+    }
+
+    sentences = split_article_sentences(article)
+    records = preprocess_news_articles(
+        [article],
+        as_of_date="2024-01-02",
+        point_in_time_tickers=["AAPL"],
+    )
+
+    assert sentences == [
+        "Apple shares rise on AI push.",
+        'Analyst calls it a "strong quarter" — target rises to $210.',
+        "AAPL traded at $189.20.",
+        "Source: Benzinga",
+    ]
+    assert [record.text for record in records] == sentences
+    assert all("<" not in sentence and ">" not in sentence for sentence in sentences)
+    assert all("twitter" not in sentence.lower() for sentence in sentences)
+    assert all("widget" not in sentence.lower() for sentence in sentences)
+    assert all("&nbsp;" not in sentence for sentence in sentences)
+
+
 def test_preprocess_news_articles_tags_tickers_entities_and_provenance() -> None:
     """AAPL, competitor-only, broad-market, and irrelevant article examples are handled cleanly."""
     articles = [

--- a/tests/unit/test_news_preprocessing_runner.py
+++ b/tests/unit/test_news_preprocessing_runner.py
@@ -92,6 +92,51 @@ def test_run_news_preprocessing_reads_r2_and_writes_outputs(
     assert manifest["metadata"]["sentence_rows"] == 4
 
 
+def test_run_news_preprocessing_honors_requested_ticker_scope(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A scoped pilot only writes sentence rows for requested point-in-time tickers."""
+    writer = _local_writer(tmp_path, monkeypatch)
+    _write_jsonl(
+        writer,
+        raw_news_path("2024-01-02"),
+        [
+            {
+                "id": 1001,
+                "headline": "Apple reports earnings.",
+                "summary": "Microsoft also reports.",
+                "created_at": "2024-01-02T12:00:00+00:00",
+                "source": "benzinga",
+                "symbols": ["AAPL", "MSFT"],
+            }
+        ],
+    )
+    _write_universe(
+        writer,
+        raw_universe_path("2024-01-02"),
+        [
+            {"date": "2024-01-02", "ticker": "AAPL", "in_universe": "True"},
+            {"date": "2024-01-02", "ticker": "MSFT", "in_universe": "True"},
+        ],
+    )
+
+    result = run_news_preprocessing(
+        NewsPreprocessingPipelineConfig(
+            run_id="nlp-aapl-run",
+            as_of_date="2024-01-02",
+            tickers=("AAPL",),
+        ),
+        writer=writer,
+    )
+
+    output = pd.read_parquet(io.BytesIO(writer.get_object(result.output_key)))
+    manifest = json.loads(writer.get_object(result.manifest_key))
+
+    assert output["ticker"].unique().tolist() == ["AAPL"]
+    assert manifest["metadata"]["requested_tickers"] == ["AAPL"]
+
+
 def test_run_news_preprocessing_writes_failure_manifest(
     tmp_path: Path,
     monkeypatch,

--- a/tests/unit/test_news_preprocessing_runner.py
+++ b/tests/unit/test_news_preprocessing_runner.py
@@ -37,8 +37,16 @@ def test_run_news_preprocessing_reads_r2_and_writes_outputs(
         [
             {
                 "id": 1001,
-                "headline": "Apple reports earnings.",
-                "summary": "Shares rose.",
+                "headline": "<div>Apple <a href='https://example.test/apple'>reports</a> earnings today.</div>",
+                "summary": (
+                    '<p>Revenue rose 10% to $100.2B.</p>'
+                    '<blockquote class="twitter-tweet"><p>Tweet boilerplate.</p></blockquote>'
+                ),
+                "content": (
+                    '<div><p>Gross margin improved to 45% &#8212; per the company.</p>'
+                    '<script>window.widget = true;</script>'
+                    '<p>Source: Benzinga</p></div>'
+                ),
                 "created_at": "2024-01-02T12:00:00+00:00",
                 "source": "benzinga",
                 "symbols": ["AAPL", "MSFT"],
@@ -70,55 +78,18 @@ def test_run_news_preprocessing_reads_r2_and_writes_outputs(
     assert result.output_key == news_preprocessing_output_path("nlp-test-run", "2024-01-02")
     assert result.manifest_key == pipeline_manifest_path(NLP_PREPROCESSING_STAGE, "nlp-test-run")
     assert output["ticker"].unique().tolist() == ["AAPL"]
-    assert output["text"].tolist() == ["Apple reports earnings.", "Shares rose."]
+    assert output["text"].tolist() == [
+        "Apple reports earnings today.",
+        "Revenue rose 10% to $100.2B.",
+        "Gross margin improved to 45% — per the company.",
+        "Source: Benzinga",
+    ]
+    assert all("<" not in text and ">" not in text for text in output["text"].tolist())
+    assert all("twitter" not in text.lower() for text in output["text"].tolist())
+    assert all("widget" not in text.lower() for text in output["text"].tolist())
     assert manifest["status"] == RunStatus.COMPLETED
     assert manifest["metadata"]["article_rows"] == 1
-    assert manifest["metadata"]["sentence_rows"] == 2
-
-
-def test_run_news_preprocessing_honors_requested_ticker_scope(
-    tmp_path: Path,
-    monkeypatch,
-) -> None:
-    """A scoped pilot only writes sentence rows for requested point-in-time tickers."""
-    writer = _local_writer(tmp_path, monkeypatch)
-    _write_jsonl(
-        writer,
-        raw_news_path("2024-01-02"),
-        [
-            {
-                "id": 1001,
-                "headline": "Apple reports earnings.",
-                "summary": "Microsoft also reports.",
-                "created_at": "2024-01-02T12:00:00+00:00",
-                "source": "benzinga",
-                "symbols": ["AAPL", "MSFT"],
-            }
-        ],
-    )
-    _write_universe(
-        writer,
-        raw_universe_path("2024-01-02"),
-        [
-            {"date": "2024-01-02", "ticker": "AAPL", "in_universe": "True"},
-            {"date": "2024-01-02", "ticker": "MSFT", "in_universe": "True"},
-        ],
-    )
-
-    result = run_news_preprocessing(
-        NewsPreprocessingPipelineConfig(
-            run_id="nlp-aapl-run",
-            as_of_date="2024-01-02",
-            tickers=("AAPL",),
-        ),
-        writer=writer,
-    )
-
-    output = pd.read_parquet(io.BytesIO(writer.get_object(result.output_key)))
-    manifest = json.loads(writer.get_object(result.manifest_key))
-
-    assert output["ticker"].unique().tolist() == ["AAPL"]
-    assert manifest["metadata"]["requested_tickers"] == ["AAPL"]
+    assert manifest["metadata"]["sentence_rows"] == 4
 
 
 def test_run_news_preprocessing_writes_failure_manifest(


### PR DESCRIPTION
## What this PR does
Cleans raw provider HTML and common HTML entities from Layer 1 news text before sentence splitting so `NewsSentimentRecord.text` contains plain readable text for downstream embeddings, BERTopic, and FinBERT. The preprocessing runner now emits cleaned rows, and regression tests cover Benzinga-style nested tags, links, tweet/widget boilerplate, `&nbsp;`, numeric entities, and sentence boundaries.

## Closes
Closes #255

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/test_news_preprocessing.py tests/unit/test_news_preprocessing_runner.py -v --tb=short` passes with zero failures
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
None

## Notes for reviewer
The cleaning step removes provider HTML tags and boilerplate while preserving visible text, punctuation, ticker symbols, prices, and sentence boundaries.
