### PR TITLE
[Code Monkey] Repair Layer 1 sentence/chunk splitting to avoid huge article-paragraph chunks

### DIFF
--- a/app/lab/data_pipelines/run_news_preprocessing.py
+++ b/app/lab/data_pipelines/run_news_preprocessing.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -70,6 +70,9 @@ class NewsPreprocessingPipelineConfig:
     run_id: str
     as_of_date: str
     min_sentence_chars: int = 2
+    target_chunk_chars: int = 240
+    max_chunk_chars: int = 360
+    fallback_chunk_chars: int = 160
 
     def __post_init__(self) -> None:
         """Validate run identity and date settings."""
@@ -81,6 +84,16 @@ class NewsPreprocessingPipelineConfig:
             raise ValueError("as_of_date must be YYYY-MM-DD") from exc
         if self.min_sentence_chars <= 0:
             raise ValueError("min_sentence_chars must be positive")
+        if self.target_chunk_chars <= 0:
+            raise ValueError("target_chunk_chars must be positive")
+        if self.max_chunk_chars <= 0:
+            raise ValueError("max_chunk_chars must be positive")
+        if self.fallback_chunk_chars <= 0:
+            raise ValueError("fallback_chunk_chars must be positive")
+        if self.target_chunk_chars > self.max_chunk_chars:
+            raise ValueError("target_chunk_chars must be <= max_chunk_chars")
+        if self.fallback_chunk_chars > self.target_chunk_chars:
+            raise ValueError("fallback_chunk_chars must be <= target_chunk_chars")
 
 
 @dataclass(frozen=True)
@@ -129,7 +142,12 @@ def run_news_preprocessing(
             articles,
             as_of_date=config.as_of_date,
             point_in_time_tickers=tickers,
-            config=NewsPreprocessingConfig(min_sentence_chars=config.min_sentence_chars),
+            config=NewsPreprocessingConfig(
+                min_sentence_chars=config.min_sentence_chars,
+                target_chunk_chars=config.target_chunk_chars,
+                max_chunk_chars=config.max_chunk_chars,
+                fallback_chunk_chars=config.fallback_chunk_chars,
+            ),
         )
         active_writer.put_object(output_key, _records_to_parquet_bytes(records))
         metadata.update({"article_rows": len(articles), "sentence_rows": len(records)})
@@ -180,6 +198,18 @@ def load_modal_runtime_config(path: Path = MODAL_CONFIG_PATH) -> ModalRuntimeCon
         python_version=str(payload.get("python_version", "3.11")),
         requirements_path=str(payload.get("requirements_path", "requirements/modal.txt")),
     )
+
+
+def _load_news_preprocessing_settings(path: Path = MODAL_CONFIG_PATH) -> dict[str, int]:
+    """Load sentence/chunk defaults for Layer 1 news preprocessing."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    settings = payload.get("news_preprocessing", {})
+    return {
+        "min_sentence_chars": int(settings.get("min_sentence_chars", 2)),
+        "target_chunk_chars": int(settings.get("target_chunk_chars", 240)),
+        "max_chunk_chars": int(settings.get("max_chunk_chars", 360)),
+        "fallback_chunk_chars": int(settings.get("fallback_chunk_chars", 160)),
+    }
 
 
 def _load_raw_news_articles(writer: ObjectStore, as_of_date: str) -> list[dict[str, object]]:
@@ -272,10 +302,14 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def _config_from_args(args: argparse.Namespace) -> NewsPreprocessingPipelineConfig:
     """Build a validated pipeline config from CLI arguments."""
+    defaults = _load_news_preprocessing_settings()
     return NewsPreprocessingPipelineConfig(
         run_id=args.run_id,
         as_of_date=args.as_of_date,
         min_sentence_chars=args.min_sentence_chars,
+        target_chunk_chars=defaults["target_chunk_chars"],
+        max_chunk_chars=defaults["max_chunk_chars"],
+        fallback_chunk_chars=defaults["fallback_chunk_chars"],
     )
 
 
@@ -301,11 +335,15 @@ def _modal_run_news_preprocessing_entry(
     min_sentence_chars: int = 2,
 ) -> dict[str, object]:
     """Run Layer 1 news preprocessing on Modal."""
+    defaults = _load_news_preprocessing_settings()
     result = run_news_preprocessing(
         NewsPreprocessingPipelineConfig(
             run_id=run_id,
             as_of_date=as_of_date,
             min_sentence_chars=min_sentence_chars,
+            target_chunk_chars=defaults["target_chunk_chars"],
+            max_chunk_chars=defaults["max_chunk_chars"],
+            fallback_chunk_chars=defaults["fallback_chunk_chars"],
         )
     )
     return {
@@ -345,7 +383,7 @@ def _define_modal_app() -> object | None:
     return app
 
 
-def _build_modal_image(modal_module: object, runtime: ModalRuntimeConfig):
+def _build_modal_image(modal_module: Any, runtime: ModalRuntimeConfig):
     """Build the Modal image while preserving local `-r base.txt` includes."""
     requirements_path = Path(runtime.requirements_path)
     requirements_dir = requirements_path.parent

--- a/config/news_preprocessing.json
+++ b/config/news_preprocessing.json
@@ -1,5 +1,11 @@
 {
   "app_name": "ai-stock-trader-news-preprocessing",
   "r2_secret_name": "ai-stock-trader-r2",
-  "timeout_seconds": 1800
+  "timeout_seconds": 1800,
+  "news_preprocessing": {
+    "min_sentence_chars": 2,
+    "target_chunk_chars": 240,
+    "max_chunk_chars": 360,
+    "fallback_chunk_chars": 160
+  }
 }

--- a/core/features/news_preprocessing.py
+++ b/core/features/news_preprocessing.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import html
 import math
 import re
 from collections.abc import Iterable, Mapping, Sequence
@@ -15,6 +16,26 @@ from services.wikipedia.sp500_universe import canonicalize_ticker
 
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[\"'A-Z0-9])")
 _WHITESPACE = re.compile(r"\s+")
+_HTML_BLOCK_BREAK = re.compile(
+    r"(?is)</?(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|br|hr)[^>]*>"
+)
+_HTML_NOISE_BLOCKS = (
+    re.compile(r"(?is)<script\b[^>]*>.*?</script>"),
+    re.compile(r"(?is)<style\b[^>]*>.*?</style>"),
+    re.compile(r"(?is)<noscript\b[^>]*>.*?</noscript>"),
+    re.compile(r"(?is)<iframe\b[^>]*>.*?</iframe>"),
+    re.compile(
+        r"(?is)<blockquote\b[^>]*class=[\"'][^\"']*"
+        r"(?:twitter-tweet|instagram-media|tiktok-embed|reddit-embed|embed|widget)"
+        r"[^\"']*[\"'][^>]*>.*?</blockquote>"
+    ),
+    re.compile(
+        r"(?is)<div\b[^>]*class=[\"'][^\"']*"
+        r"(?:widget|embed|promo|related|newsletter|ad|advert|sponsored|social-embed)"
+        r"[^\"']*[\"'][^>]*>.*?</div>"
+    ),
+)
+_HTML_TAG = re.compile(r"<[^>]+>")
 
 
 @dataclass(frozen=True)
@@ -59,7 +80,7 @@ def preprocess_news_articles(
             continue
 
         article_id = _article_id(article)
-        headline = _optional_text(article.get("headline"))
+        headline = _clean_article_text(article.get("headline"))
         source = _optional_text(article.get("source") or article.get("author"))
         url = _optional_text(article.get("url"))
         published_at = _published_at(article)
@@ -203,7 +224,7 @@ def _normalize_allowed_tickers(tickers: Iterable[str] | None) -> set[str] | None
 
 def _sentences_from_text(value: Any, *, settings: NewsPreprocessingConfig) -> list[str]:
     """Split and normalize one raw text field into sentence strings."""
-    text = _optional_text(value)
+    text = _clean_article_text(value)
     if text is None:
         return []
     normalized = _WHITESPACE.sub(" ", text).strip()
@@ -259,6 +280,21 @@ def _optional_text(value: Any) -> str | None:
     text = str(value).strip()
     return text or None
 
+
+def _clean_article_text(value: Any) -> str | None:
+    """Return readable plain text from raw provider HTML or text content."""
+    text = _optional_text(value)
+    if text is None:
+        return None
+    cleaned = html.unescape(text)
+    for pattern in _HTML_NOISE_BLOCKS:
+        cleaned = pattern.sub(" ", cleaned)
+    cleaned = _HTML_BLOCK_BREAK.sub(" ", cleaned)
+    cleaned = _HTML_TAG.sub(" ", cleaned)
+    cleaned = cleaned.replace("\xa0", " ")
+    cleaned = _WHITESPACE.sub(" ", cleaned).strip()
+    cleaned = re.sub(r"\s+([,.;:!?])", r"\1", cleaned)
+    return cleaned or None
 
 def _optional_datetime(value: Any) -> datetime | None:
     """Return an ISO timestamp parsed by Pydantic, or None when missing."""

--- a/core/features/news_preprocessing.py
+++ b/core/features/news_preprocessing.py
@@ -11,14 +11,18 @@ from datetime import date as Date
 from datetime import datetime
 from typing import Any
 
+from pydantic import TypeAdapter
+
 from core.contracts.schemas import NewsSentimentRecord
 from services.wikipedia.sp500_universe import canonicalize_ticker
 
-_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[\"'A-Z0-9])")
-_WHITESPACE = re.compile(r"\s+")
-_HTML_BLOCK_BREAK = re.compile(
-    r"(?is)</?(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|br|hr)[^>]*>"
+_HTML_BLOCK_BREAK_START = re.compile(
+    r"(?is)<\s*(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|ul|ol)\b[^>]*>"
 )
+_HTML_BLOCK_BREAK_END = re.compile(
+    r"(?is)</\s*(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|ul|ol)\b[^>]*>"
+)
+_HTML_LINE_BREAK = re.compile(r"(?is)<\s*(?:br|hr)\b[^>]*>")
 _HTML_NOISE_BLOCKS = (
     re.compile(r"(?is)<script\b[^>]*>.*?</script>"),
     re.compile(r"(?is)<style\b[^>]*>.*?</style>"),
@@ -36,13 +40,43 @@ _HTML_NOISE_BLOCKS = (
     ),
 )
 _HTML_TAG = re.compile(r"<[^>]+>")
+_INLINE_WHITESPACE = re.compile(r"[ \t\f\v]+")
+_PARAGRAPH_BREAK = re.compile(r"\n+")
+_SENTENCE_BOUNDARY = re.compile(r'([.!?]+(?:["\')\]]+)?)\s+')
+_ABBREVIATION_TOKENS = {
+    "a.m",
+    "co",
+    "corp",
+    "dr",
+    "e.u",
+    "fig",
+    "inc",
+    "jr",
+    "ltd",
+    "mr",
+    "mrs",
+    "ms",
+    "mt",
+    "no",
+    "p.m",
+    "prof",
+    "sr",
+    "st",
+    "u.k",
+    "u.s",
+    "vs",
+}
+_DATETIME_ADAPTER = TypeAdapter(datetime)
 
 
 @dataclass(frozen=True)
 class NewsPreprocessingConfig:
-    """Text and filtering settings for sentence-level news preprocessing."""
+    """Text splitting and filtering settings for sentence-level news preprocessing."""
 
     min_sentence_chars: int = 2
+    target_chunk_chars: int = 240
+    max_chunk_chars: int = 360
+    fallback_chunk_chars: int = 160
     include_headline: bool = True
     include_summary: bool = True
     include_content: bool = True
@@ -51,6 +85,16 @@ class NewsPreprocessingConfig:
         """Validate text preprocessing settings."""
         if self.min_sentence_chars <= 0:
             raise ValueError("min_sentence_chars must be positive")
+        if self.target_chunk_chars <= 0:
+            raise ValueError("target_chunk_chars must be positive")
+        if self.max_chunk_chars <= 0:
+            raise ValueError("max_chunk_chars must be positive")
+        if self.fallback_chunk_chars <= 0:
+            raise ValueError("fallback_chunk_chars must be positive")
+        if self.target_chunk_chars > self.max_chunk_chars:
+            raise ValueError("target_chunk_chars must be <= max_chunk_chars")
+        if self.fallback_chunk_chars > self.target_chunk_chars:
+            raise ValueError("fallback_chunk_chars must be <= target_chunk_chars")
         if not (self.include_headline or self.include_summary or self.include_content):
             raise ValueError("At least one text field must be included")
 
@@ -62,7 +106,7 @@ def preprocess_news_articles(
     point_in_time_tickers: Iterable[str] | None,
     config: NewsPreprocessingConfig | None = None,
 ) -> list[NewsSentimentRecord]:
-    """Convert raw Layer 0 news articles into sentence-level sentiment records."""
+    """Convert raw Layer 0 news articles into sentence/chunk sentiment records."""
     normalized_date = _validate_date(as_of_date)
     settings = config or NewsPreprocessingConfig()
     allowed_tickers = _normalize_allowed_tickers(point_in_time_tickers)
@@ -75,8 +119,8 @@ def preprocess_news_articles(
         if not article_tickers:
             continue
 
-        sentences = split_article_sentences(article, config=settings)
-        if not sentences:
+        chunks = split_article_sentences(article, config=settings)
+        if not chunks:
             continue
 
         article_id = _article_id(article)
@@ -85,14 +129,14 @@ def preprocess_news_articles(
         url = _optional_text(article.get("url"))
         published_at = _published_at(article)
 
-        for sentence_index, sentence in enumerate(sentences):
+        for sentence_index, chunk in enumerate(chunks):
             for ticker in article_tickers:
                 records.append(
                     NewsSentimentRecord(
                         date=normalized_date,
                         ticker=ticker,
                         headline=headline,
-                        text=sentence,
+                        text=chunk,
                         article_id=article_id,
                         sentence_index=sentence_index,
                         source=source,
@@ -117,7 +161,7 @@ def split_article_sentences(
     *,
     config: NewsPreprocessingConfig | None = None,
 ) -> list[str]:
-    """Return normalized article sentences from configured raw text fields."""
+    """Return normalized article sentences/chunks from configured raw text fields."""
     settings = config or NewsPreprocessingConfig()
     chunks: list[str] = []
     if settings.include_headline:
@@ -223,17 +267,127 @@ def _normalize_allowed_tickers(tickers: Iterable[str] | None) -> set[str] | None
 
 
 def _sentences_from_text(value: Any, *, settings: NewsPreprocessingConfig) -> list[str]:
-    """Split and normalize one raw text field into sentence strings."""
+    """Split and normalize one raw text field into bounded sentence/chunk strings."""
     text = _clean_article_text(value)
     if text is None:
         return []
-    normalized = _WHITESPACE.sub(" ", text).strip()
-    sentences = [
-        sentence.strip(" \t\r\n")
-        for sentence in _SENTENCE_BOUNDARY.split(normalized)
-        if len(sentence.strip(" \t\r\n")) >= settings.min_sentence_chars
-    ]
-    return sentences
+
+    chunks: list[str] = []
+    for block in _split_text_blocks(text):
+        block_chunks = _split_block_into_chunks(block, settings=settings)
+        chunks.extend(block_chunks)
+    return chunks
+
+
+def _split_text_blocks(text: str) -> list[str]:
+    """Return paragraph- and list-level blocks from cleaned article text."""
+    blocks: list[str] = []
+    for raw_block in _PARAGRAPH_BREAK.split(text):
+        block = _INLINE_WHITESPACE.sub(" ", raw_block).strip()
+        if block:
+            blocks.append(block)
+    return blocks
+
+
+def _split_block_into_chunks(
+    block: str,
+    *,
+    settings: NewsPreprocessingConfig,
+) -> list[str]:
+    """Split one paragraph-like block into bounded chunks."""
+    sentence_like = _split_sentence_candidates(block, settings=settings)
+    chunks: list[str] = []
+    for sentence in sentence_like:
+        if len(sentence) > settings.max_chunk_chars:
+            chunks.extend(_split_oversized_text(sentence, settings=settings))
+        else:
+            chunks.append(sentence)
+    return chunks
+
+
+def _split_sentence_candidates(
+    text: str,
+    *,
+    settings: NewsPreprocessingConfig,
+) -> list[str]:
+    """Split a cleaned block into sentence-like units while honoring abbreviations."""
+    sentences: list[str] = []
+    start = 0
+    for match in _SENTENCE_BOUNDARY.finditer(text):
+        boundary_end = match.end(1)
+        candidate = text[start:boundary_end].strip()
+        remainder = text[match.end():]
+        if not candidate:
+            start = match.end()
+            continue
+        if _should_split_sentence(candidate, remainder):
+            sentences.append(candidate)
+            start = match.end()
+    tail = text[start:].strip()
+    if tail:
+        sentences.append(tail)
+    return [sentence for sentence in sentences if len(sentence) >= settings.min_sentence_chars]
+
+
+def _should_split_sentence(candidate: str, remainder: str) -> bool:
+    """Return True when a punctuation boundary should end the current sentence."""
+    if not remainder.strip():
+        return True
+    return not _looks_like_abbreviation(candidate)
+
+
+def _looks_like_abbreviation(text: str) -> bool:
+    """Return True when trailing punctuation belongs to a known abbreviation."""
+    stripped = text.rstrip('"\'”’)]}')
+    if not stripped.endswith((".", "!", "?")):
+        return False
+    last_token = stripped.split()[-1]
+    normalized = re.sub(r"[^A-Za-z0-9]", "", last_token).lower()
+    if normalized in _ABBREVIATION_TOKENS:
+        return True
+    if re.fullmatch(r"(?:[A-Za-z]\.){2,}", last_token):
+        return True
+    return False
+
+
+def _split_oversized_text(text: str, *, settings: NewsPreprocessingConfig) -> list[str]:
+    """Split an oversized sentence into readable fallback chunks."""
+    if len(text) <= settings.max_chunk_chars:
+        return [text]
+
+    words = text.split()
+    if len(words) <= 1:
+        return _split_single_token(text, limit=settings.fallback_chunk_chars)
+
+    chunks: list[str] = []
+    current_words: list[str] = []
+    current_length = 0
+    for word in words:
+        candidate_length = len(word) if not current_words else current_length + 1 + len(word)
+        if current_words and candidate_length > settings.target_chunk_chars:
+            chunks.append(" ".join(current_words))
+            current_words = [word]
+            current_length = len(word)
+            continue
+        current_words.append(word)
+        current_length = candidate_length
+
+    if current_words:
+        chunks.append(" ".join(current_words))
+
+    if all(len(chunk) <= settings.max_chunk_chars for chunk in chunks):
+        return chunks
+    return [chunk for piece in chunks for chunk in _split_single_token(piece, limit=settings.fallback_chunk_chars)]
+
+
+def _split_single_token(text: str, *, limit: int) -> list[str]:
+    """Split a long token into fixed-size pieces without dropping text."""
+    if len(text) <= limit:
+        return [text]
+    pieces: list[str] = []
+    for start in range(0, len(text), limit):
+        pieces.append(text[start : start + limit])
+    return pieces
 
 
 def _dedupe_preserving_order(values: Sequence[str]) -> list[str]:
@@ -286,22 +440,30 @@ def _clean_article_text(value: Any) -> str | None:
     text = _optional_text(value)
     if text is None:
         return None
+
     cleaned = html.unescape(text)
     for pattern in _HTML_NOISE_BLOCKS:
         cleaned = pattern.sub(" ", cleaned)
-    cleaned = _HTML_BLOCK_BREAK.sub(" ", cleaned)
+    cleaned = _HTML_LINE_BREAK.sub("\n", cleaned)
+    cleaned = _HTML_BLOCK_BREAK_START.sub("\n", cleaned)
+    cleaned = _HTML_BLOCK_BREAK_END.sub("\n", cleaned)
     cleaned = _HTML_TAG.sub(" ", cleaned)
     cleaned = cleaned.replace("\xa0", " ")
-    cleaned = _WHITESPACE.sub(" ", cleaned).strip()
+    cleaned = re.sub(r"[ \t\f\v]*\n[ \t\f\v]*", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    cleaned = _INLINE_WHITESPACE.sub(" ", cleaned)
+    cleaned = re.sub(r" *\n *", "\n", cleaned)
     cleaned = re.sub(r"\s+([,.;:!?])", r"\1", cleaned)
+    cleaned = cleaned.strip(" \n\t\r")
     return cleaned or None
+
 
 def _optional_datetime(value: Any) -> datetime | None:
     """Return an ISO timestamp parsed by Pydantic, or None when missing."""
     text = _optional_text(value)
     if text is None:
         return None
-    return NewsSentimentRecord(date="2000-01-01", ticker="SPY", published_at=text).published_at
+    return _DATETIME_ADAPTER.validate_python(text)
 
 
 def _optional_float(value: Any) -> float | None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -360,9 +360,9 @@ history file is refreshed.
 ```
 RAW ARTICLES (Alpaca news)
   → Step 1: Preprocessing
-      Read raw/news and raw/universe from R2, split into sentences, tag
-      point-in-time tickers, write NewsSentimentRecord rows to
-      features/layer1/news_sentiment/{date}/{run_id}.parquet
+      Read raw/news and raw/universe from R2, clean provider HTML/entities,
+      split into sentences, tag point-in-time tickers, write NewsSentimentRecord rows to
+      features/{date}/news_sentiment/{run_id}.parquet
   → Step 2a: Sentence Transformers (per article)
       Model: all-mpnet-base-v2
       Output: pinned-version sentence embedding cache in R2

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -247,8 +247,8 @@ Use cases:
 
 Input note:
 - generated from Layer 0 raw point-in-time news archives
-- sentence-level preprocessing rows should populate `text`, `article_id`, and
-  `sentence_index`; aggregated ticker-day rows may leave those fields unset
+- sentence-level preprocessing rows should populate `text` with cleaned plain text,
+  `article_id`, and `sentence_index`; aggregated ticker-day rows may leave those fields unset
 - `published_at` must preserve the raw article timestamp exactly for downstream leakage checks
 
 ### FeatureRecord

--- a/tests/unit/test_news_preprocessing.py
+++ b/tests/unit/test_news_preprocessing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import re
 from datetime import UTC
 
 import pandas as pd
@@ -94,6 +95,34 @@ def test_split_article_sentences_cleans_provider_html_and_preserves_meaningful_t
     assert all("&nbsp;" not in sentence for sentence in sentences)
 
 
+def test_split_article_sentences_preserves_headings_lists_and_quote_punctuation() -> None:
+    """Headings, list items, abbreviations, and quoted sentences stay readable."""
+    article = {
+        "headline": '<h1><a href="https://example.test/aapl">AAPL</a> gains on AI rollout.</h1>',
+        "summary": '<p>Analyst says, "Buy now." Revenue may accelerate.</p>',
+        "content": (
+            "<h2>Key points</h2>"
+            "<p>U.S. regulators review the deal.</p>"
+            "<ul><li>Revenue beat expectations.</li><li>Margins improved.</li></ul>"
+        ),
+        "symbols": ["AAPL"],
+    }
+
+    sentences = split_article_sentences(article)
+
+    assert sentences == [
+        "AAPL gains on AI rollout.",
+        'Analyst says, "Buy now."',
+        "Revenue may accelerate.",
+        "Key points",
+        "U.S. regulators review the deal.",
+        "Revenue beat expectations.",
+        "Margins improved.",
+    ]
+    assert all("<" not in sentence and ">" not in sentence for sentence in sentences)
+    assert all("aapl" not in sentence.lower() or sentence == "AAPL gains on AI rollout." for sentence in sentences)
+
+
 def test_split_article_sentences_handles_abbreviations_and_deduplicates() -> None:
     """Sentence splitting avoids common abbreviation splits and removes duplicate text."""
     article = {
@@ -109,6 +138,41 @@ def test_split_article_sentences_handles_abbreviations_and_deduplicates() -> Non
         "Apple Inc. reported earnings.",
         "Shares rose!",
     ]
+
+
+def test_preprocess_news_articles_chunks_oversized_paragraphs_without_truncation() -> None:
+    """Oversized blocks are split into bounded chunks without dropping content."""
+    paragraph = " ".join(
+        [
+            "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu",
+            "nu xi omicron pi rho sigma tau upsilon phi chi psi omega",
+        ]
+        * 6
+    )
+    article = {
+        "id": "chunk-limit",
+        "content": f"<p>{paragraph}</p>",
+        "symbols": ["AAPL"],
+    }
+    config = NewsPreprocessingConfig(
+        target_chunk_chars=80,
+        max_chunk_chars=120,
+        fallback_chunk_chars=60,
+    )
+
+    records = preprocess_news_articles(
+        [article],
+        as_of_date="2024-01-02",
+        point_in_time_tickers=["AAPL"],
+        config=config,
+    )
+
+    assert len(records) > 1
+    assert all(len(record.text or "") <= 120 for record in records)
+    reconstructed = re.sub(r"\s+", " ", " ".join(record.text or "" for record in records)).strip()
+    expected = re.sub(r"\s+", " ", paragraph).strip()
+    assert reconstructed == expected
+    assert [record.sentence_index for record in records] == list(range(len(records)))
 
 
 def test_preprocess_news_articles_filters_empty_text_and_missing_universe_symbols() -> None:

--- a/tests/unit/test_news_preprocessing.py
+++ b/tests/unit/test_news_preprocessing.py
@@ -54,6 +54,46 @@ def test_preprocess_news_articles_emits_sentence_records_for_multiple_alias_tick
     assert records[0].published_at.isoformat() == "2024-01-02T12:00:00+00:00"
 
 
+def test_split_article_sentences_cleans_provider_html_and_preserves_meaningful_text() -> None:
+    """Provider HTML is stripped before splitting without losing useful article text."""
+    article = {
+        "headline": (
+            '<div><a href="https://example.test/apple">Apple</a> shares rise &nbsp; '
+            "on <strong>AI</strong> push.</div>"
+        ),
+        "summary": (
+            '<p>Analyst calls it a "strong quarter" &#8212; target rises to $210.</p>'
+            '<blockquote class="twitter-tweet"><p>Ignore this tweet embed.</p></blockquote>'
+        ),
+        "content": (
+            '<div><p>AAPL traded at <span>$189.20</span>.</p>'
+            '<script>window.widget = true;</script>'
+            '<div class="widget">widget boilerplate</div>'
+            '<p>Source: Benzinga</p></div>'
+        ),
+        "symbols": ["AAPL"],
+    }
+
+    sentences = split_article_sentences(article)
+    records = preprocess_news_articles(
+        [article],
+        as_of_date="2024-01-02",
+        point_in_time_tickers=["AAPL"],
+    )
+
+    assert sentences == [
+        "Apple shares rise on AI push.",
+        'Analyst calls it a "strong quarter" — target rises to $210.',
+        "AAPL traded at $189.20.",
+        "Source: Benzinga",
+    ]
+    assert [record.text for record in records] == sentences
+    assert all("<" not in sentence and ">" not in sentence for sentence in sentences)
+    assert all("twitter" not in sentence.lower() for sentence in sentences)
+    assert all("widget" not in sentence.lower() for sentence in sentences)
+    assert all("&nbsp;" not in sentence for sentence in sentences)
+
+
 def test_split_article_sentences_handles_abbreviations_and_deduplicates() -> None:
     """Sentence splitting avoids common abbreviation splits and removes duplicate text."""
     article = {

--- a/tests/unit/test_news_preprocessing_runner.py
+++ b/tests/unit/test_news_preprocessing_runner.py
@@ -37,8 +37,16 @@ def test_run_news_preprocessing_reads_r2_and_writes_outputs(
         [
             {
                 "id": 1001,
-                "headline": "Apple reports earnings.",
-                "summary": "Shares rose.",
+                "headline": "<div>Apple <a href='https://example.test/apple'>reports</a> earnings today.</div>",
+                "summary": (
+                    '<p>Revenue rose 10% to $100.2B.</p>'
+                    '<blockquote class="twitter-tweet"><p>Tweet boilerplate.</p></blockquote>'
+                ),
+                "content": (
+                    '<div><p>Gross margin improved to 45% &#8212; per the company.</p>'
+                    '<script>window.widget = true;</script>'
+                    '<p>Source: Benzinga</p></div>'
+                ),
                 "created_at": "2024-01-02T12:00:00+00:00",
                 "source": "benzinga",
                 "symbols": ["AAPL", "MSFT"],
@@ -70,10 +78,18 @@ def test_run_news_preprocessing_reads_r2_and_writes_outputs(
     assert result.output_key == news_preprocessing_output_path("nlp-test-run", "2024-01-02")
     assert result.manifest_key == pipeline_manifest_path(NLP_PREPROCESSING_STAGE, "nlp-test-run")
     assert output["ticker"].unique().tolist() == ["AAPL"]
-    assert output["text"].tolist() == ["Apple reports earnings.", "Shares rose."]
+    assert output["text"].tolist() == [
+        "Apple reports earnings today.",
+        "Revenue rose 10% to $100.2B.",
+        "Gross margin improved to 45% — per the company.",
+        "Source: Benzinga",
+    ]
+    assert all("<" not in text and ">" not in text for text in output["text"].tolist())
+    assert all("twitter" not in text.lower() for text in output["text"].tolist())
+    assert all("widget" not in text.lower() for text in output["text"].tolist())
     assert manifest["status"] == RunStatus.COMPLETED
     assert manifest["metadata"]["article_rows"] == 1
-    assert manifest["metadata"]["sentence_rows"] == 2
+    assert manifest["metadata"]["sentence_rows"] == 4
 
 
 def test_run_news_preprocessing_writes_failure_manifest(


### PR DESCRIPTION
## What this PR does
Repairs Layer 1 news preprocessing so cleaned Alpaca/Benzinga text is split into bounded, readable sentence/chunk rows instead of giant paragraph blobs. The splitter now preserves paragraph and list boundaries, handles quote punctuation and common abbreviations, and falls back to size-bounded chunking without truncating text. I also wired the chunk defaults into `config/news_preprocessing.json` and the Modal/local runner path.

## Closes
Closes #256

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [ ] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [ ] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
N/A

## Notes for reviewer
Commands run:
- `./.venv/bin/pytest tests/unit/test_news_preprocessing.py -v --tb=short`
- `./.venv/bin/pytest tests/unit/ -v --tb=short`
- `./.venv/bin/ruff check core/features/news_preprocessing.py app/lab/data_pipelines/run_news_preprocessing.py tests/unit/test_news_preprocessing.py`
- `./.venv/bin/mypy --explicit-package-bases --follow-imports=skip core/features/news_preprocessing.py app/lab/data_pipelines/run_news_preprocessing.py`
- `make lint` (failed because `ruff` is not on PATH in this environment; direct `.venv/bin/ruff` passed)
- `make typecheck` (fails on many pre-existing unrelated repository errors outside this change set)

Test summary:
- Unit suite: 624 passed
- Targeted news preprocessing suite: 7 passed
- Ruff: passed on touched files
- Targeted mypy: passed on touched files with `--follow-imports=skip`

Known skipped/missing external artifacts:
- None
