### PR TITLE
fix(news): split Layer 1 news into bounded chunks

### DIFF
--- a/app/lab/data_pipelines/run_news_preprocessing.py
+++ b/app/lab/data_pipelines/run_news_preprocessing.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -71,6 +71,9 @@ class NewsPreprocessingPipelineConfig:
     as_of_date: str
     tickers: tuple[str, ...] = ()
     min_sentence_chars: int = 2
+    target_chunk_chars: int = 240
+    max_chunk_chars: int = 360
+    fallback_chunk_chars: int = 160
 
     def __post_init__(self) -> None:
         """Validate run identity and date settings."""
@@ -85,6 +88,16 @@ class NewsPreprocessingPipelineConfig:
                 raise ValueError("tickers cannot contain empty strings")
         if self.min_sentence_chars <= 0:
             raise ValueError("min_sentence_chars must be positive")
+        if self.target_chunk_chars <= 0:
+            raise ValueError("target_chunk_chars must be positive")
+        if self.max_chunk_chars <= 0:
+            raise ValueError("max_chunk_chars must be positive")
+        if self.fallback_chunk_chars <= 0:
+            raise ValueError("fallback_chunk_chars must be positive")
+        if self.target_chunk_chars > self.max_chunk_chars:
+            raise ValueError("target_chunk_chars must be <= max_chunk_chars")
+        if self.fallback_chunk_chars > self.target_chunk_chars:
+            raise ValueError("fallback_chunk_chars must be <= target_chunk_chars")
 
 
 @dataclass(frozen=True)
@@ -138,7 +151,12 @@ def run_news_preprocessing(
             articles,
             as_of_date=config.as_of_date,
             point_in_time_tickers=tickers,
-            config=NewsPreprocessingConfig(min_sentence_chars=config.min_sentence_chars),
+            config=NewsPreprocessingConfig(
+                min_sentence_chars=config.min_sentence_chars,
+                target_chunk_chars=config.target_chunk_chars,
+                max_chunk_chars=config.max_chunk_chars,
+                fallback_chunk_chars=config.fallback_chunk_chars,
+            ),
         )
         active_writer.put_object(output_key, _records_to_parquet_bytes(records))
         metadata.update({"article_rows": len(articles), "sentence_rows": len(records)})
@@ -189,6 +207,18 @@ def load_modal_runtime_config(path: Path = MODAL_CONFIG_PATH) -> ModalRuntimeCon
         python_version=str(payload.get("python_version", "3.11")),
         requirements_path=str(payload.get("requirements_path", "requirements/modal.txt")),
     )
+
+
+def _load_news_preprocessing_settings(path: Path = MODAL_CONFIG_PATH) -> dict[str, int]:
+    """Load sentence/chunk defaults for Layer 1 news preprocessing."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    settings = payload.get("news_preprocessing", {})
+    return {
+        "min_sentence_chars": int(settings.get("min_sentence_chars", 2)),
+        "target_chunk_chars": int(settings.get("target_chunk_chars", 240)),
+        "max_chunk_chars": int(settings.get("max_chunk_chars", 360)),
+        "fallback_chunk_chars": int(settings.get("fallback_chunk_chars", 160)),
+    }
 
 
 def _load_raw_news_articles(writer: ObjectStore, as_of_date: str) -> list[dict[str, object]]:
@@ -294,11 +324,15 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def _config_from_args(args: argparse.Namespace) -> NewsPreprocessingPipelineConfig:
     """Build a validated pipeline config from CLI arguments."""
+    defaults = _load_news_preprocessing_settings()
     return NewsPreprocessingPipelineConfig(
         run_id=args.run_id,
         as_of_date=args.as_of_date,
         tickers=tuple(ticker.strip().upper() for ticker in (args.tickers or [])),
         min_sentence_chars=args.min_sentence_chars,
+        target_chunk_chars=defaults["target_chunk_chars"],
+        max_chunk_chars=defaults["max_chunk_chars"],
+        fallback_chunk_chars=defaults["fallback_chunk_chars"],
     )
 
 
@@ -335,12 +369,16 @@ def _modal_run_news_preprocessing_entry(
     tickers: Sequence[str] | None = None,
 ) -> dict[str, object]:
     """Run Layer 1 news preprocessing on Modal."""
+    defaults = _load_news_preprocessing_settings()
     result = run_news_preprocessing(
         NewsPreprocessingPipelineConfig(
             run_id=run_id,
             as_of_date=as_of_date,
             tickers=tuple(str(ticker).strip().upper() for ticker in (tickers or ())),
             min_sentence_chars=min_sentence_chars,
+            target_chunk_chars=defaults["target_chunk_chars"],
+            max_chunk_chars=defaults["max_chunk_chars"],
+            fallback_chunk_chars=defaults["fallback_chunk_chars"],
         )
     )
     return {
@@ -380,7 +418,7 @@ def _define_modal_app() -> object | None:
     return app
 
 
-def _build_modal_image(modal_module: object, runtime: ModalRuntimeConfig):
+def _build_modal_image(modal_module: Any, runtime: ModalRuntimeConfig):
     """Build the Modal image while preserving local `-r base.txt` includes."""
     requirements_path = Path(runtime.requirements_path)
     requirements_dir = requirements_path.parent

--- a/config/news_preprocessing.json
+++ b/config/news_preprocessing.json
@@ -1,5 +1,11 @@
 {
   "app_name": "ai-stock-trader-news-preprocessing",
   "r2_secret_name": "ai-stock-trader-r2",
-  "timeout_seconds": 1800
+  "timeout_seconds": 1800,
+  "news_preprocessing": {
+    "min_sentence_chars": 2,
+    "target_chunk_chars": 240,
+    "max_chunk_chars": 360,
+    "fallback_chunk_chars": 160
+  }
 }

--- a/core/features/news_preprocessing.py
+++ b/core/features/news_preprocessing.py
@@ -12,14 +12,18 @@ from datetime import date as Date
 from datetime import datetime
 from typing import Any
 
+from pydantic import TypeAdapter
+
 from core.contracts.schemas import NewsSentimentRecord
 from services.wikipedia.sp500_universe import canonicalize_ticker
 
-_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[\"'A-Z0-9])")
-_WHITESPACE = re.compile(r"\s+")
-_HTML_BLOCK_BREAK = re.compile(
-    r"(?is)</?(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|br|hr)[^>]*>"
+_HTML_BLOCK_BREAK_START = re.compile(
+    r"(?is)<\s*(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|ul|ol)\b[^>]*>"
 )
+_HTML_BLOCK_BREAK_END = re.compile(
+    r"(?is)</\s*(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|ul|ol)\b[^>]*>"
+)
+_HTML_LINE_BREAK = re.compile(r"(?is)<\s*(?:br|hr)\b[^>]*>")
 _HTML_NOISE_BLOCKS = (
     re.compile(r"(?is)<script\b[^>]*>.*?</script>"),
     re.compile(r"(?is)<style\b[^>]*>.*?</style>"),
@@ -70,13 +74,43 @@ _ENTITY_ALIAS_RULES: tuple[tuple[str, str], ...] = (
     ("spdr s&p 500 etf trust", "SPY"),
     ("sec", "SEC"),
 )
+_INLINE_WHITESPACE = re.compile(r"[ \t\f\v]+")
+_PARAGRAPH_BREAK = re.compile(r"\n+")
+_SENTENCE_BOUNDARY = re.compile(r'([.!?]+(?:["\')\]]+)?)\s+')
+_ABBREVIATION_TOKENS = {
+    "a.m",
+    "co",
+    "corp",
+    "dr",
+    "e.u",
+    "fig",
+    "inc",
+    "jr",
+    "ltd",
+    "mr",
+    "mrs",
+    "ms",
+    "mt",
+    "no",
+    "p.m",
+    "prof",
+    "sr",
+    "st",
+    "u.k",
+    "u.s",
+    "vs",
+}
+_DATETIME_ADAPTER = TypeAdapter(datetime)
 
 
 @dataclass(frozen=True)
 class NewsPreprocessingConfig:
-    """Text and filtering settings for sentence-level news preprocessing."""
+    """Text splitting and filtering settings for sentence-level news preprocessing."""
 
     min_sentence_chars: int = 2
+    target_chunk_chars: int = 240
+    max_chunk_chars: int = 360
+    fallback_chunk_chars: int = 160
     include_headline: bool = True
     include_summary: bool = True
     include_content: bool = True
@@ -85,6 +119,16 @@ class NewsPreprocessingConfig:
         """Validate text preprocessing settings."""
         if self.min_sentence_chars <= 0:
             raise ValueError("min_sentence_chars must be positive")
+        if self.target_chunk_chars <= 0:
+            raise ValueError("target_chunk_chars must be positive")
+        if self.max_chunk_chars <= 0:
+            raise ValueError("max_chunk_chars must be positive")
+        if self.fallback_chunk_chars <= 0:
+            raise ValueError("fallback_chunk_chars must be positive")
+        if self.target_chunk_chars > self.max_chunk_chars:
+            raise ValueError("target_chunk_chars must be <= max_chunk_chars")
+        if self.fallback_chunk_chars > self.target_chunk_chars:
+            raise ValueError("fallback_chunk_chars must be <= target_chunk_chars")
         if not (self.include_headline or self.include_summary or self.include_content):
             raise ValueError("At least one text field must be included")
 
@@ -229,7 +273,6 @@ def split_article_sentences(
         chunk.text for chunk in split_article_chunks(article, config=config)
     )
 
-
 def records_to_news_sentiment_frame(records: Sequence[NewsSentimentRecord]) -> Any:
     """Return a pandas DataFrame with Parquet-ready NewsSentimentRecord rows."""
     pd = _require_pandas()
@@ -368,17 +411,127 @@ def _normalize_allowed_tickers(tickers: Iterable[str] | None) -> set[str] | None
 
 
 def _sentences_from_text(value: Any, *, settings: NewsPreprocessingConfig) -> list[str]:
-    """Split and normalize one raw text field into sentence strings."""
+    """Split and normalize one raw text field into bounded sentence/chunk strings."""
     text = _clean_article_text(value)
     if text is None:
         return []
-    normalized = _WHITESPACE.sub(" ", text).strip()
-    sentences = [
-        sentence.strip(" \t\r\n")
-        for sentence in _SENTENCE_BOUNDARY.split(normalized)
-        if len(sentence.strip(" \t\r\n")) >= settings.min_sentence_chars
-    ]
-    return sentences
+
+    chunks: list[str] = []
+    for block in _split_text_blocks(text):
+        block_chunks = _split_block_into_chunks(block, settings=settings)
+        chunks.extend(block_chunks)
+    return chunks
+
+
+def _split_text_blocks(text: str) -> list[str]:
+    """Return paragraph- and list-level blocks from cleaned article text."""
+    blocks: list[str] = []
+    for raw_block in _PARAGRAPH_BREAK.split(text):
+        block = _INLINE_WHITESPACE.sub(" ", raw_block).strip()
+        if block:
+            blocks.append(block)
+    return blocks
+
+
+def _split_block_into_chunks(
+    block: str,
+    *,
+    settings: NewsPreprocessingConfig,
+) -> list[str]:
+    """Split one paragraph-like block into bounded chunks."""
+    sentence_like = _split_sentence_candidates(block, settings=settings)
+    chunks: list[str] = []
+    for sentence in sentence_like:
+        if len(sentence) > settings.max_chunk_chars:
+            chunks.extend(_split_oversized_text(sentence, settings=settings))
+        else:
+            chunks.append(sentence)
+    return chunks
+
+
+def _split_sentence_candidates(
+    text: str,
+    *,
+    settings: NewsPreprocessingConfig,
+) -> list[str]:
+    """Split a cleaned block into sentence-like units while honoring abbreviations."""
+    sentences: list[str] = []
+    start = 0
+    for match in _SENTENCE_BOUNDARY.finditer(text):
+        boundary_end = match.end(1)
+        candidate = text[start:boundary_end].strip()
+        remainder = text[match.end():]
+        if not candidate:
+            start = match.end()
+            continue
+        if _should_split_sentence(candidate, remainder):
+            sentences.append(candidate)
+            start = match.end()
+    tail = text[start:].strip()
+    if tail:
+        sentences.append(tail)
+    return [sentence for sentence in sentences if len(sentence) >= settings.min_sentence_chars]
+
+
+def _should_split_sentence(candidate: str, remainder: str) -> bool:
+    """Return True when a punctuation boundary should end the current sentence."""
+    if not remainder.strip():
+        return True
+    return not _looks_like_abbreviation(candidate)
+
+
+def _looks_like_abbreviation(text: str) -> bool:
+    """Return True when trailing punctuation belongs to a known abbreviation."""
+    stripped = text.rstrip('"\'”’)]}')
+    if not stripped.endswith((".", "!", "?")):
+        return False
+    last_token = stripped.split()[-1]
+    normalized = re.sub(r"[^A-Za-z0-9]", "", last_token).lower()
+    if normalized in _ABBREVIATION_TOKENS:
+        return True
+    if re.fullmatch(r"(?:[A-Za-z]\.){2,}", last_token):
+        return True
+    return False
+
+
+def _split_oversized_text(text: str, *, settings: NewsPreprocessingConfig) -> list[str]:
+    """Split an oversized sentence into readable fallback chunks."""
+    if len(text) <= settings.max_chunk_chars:
+        return [text]
+
+    words = text.split()
+    if len(words) <= 1:
+        return _split_single_token(text, limit=settings.fallback_chunk_chars)
+
+    chunks: list[str] = []
+    current_words: list[str] = []
+    current_length = 0
+    for word in words:
+        candidate_length = len(word) if not current_words else current_length + 1 + len(word)
+        if current_words and candidate_length > settings.target_chunk_chars:
+            chunks.append(" ".join(current_words))
+            current_words = [word]
+            current_length = len(word)
+            continue
+        current_words.append(word)
+        current_length = candidate_length
+
+    if current_words:
+        chunks.append(" ".join(current_words))
+
+    if all(len(chunk) <= settings.max_chunk_chars for chunk in chunks):
+        return chunks
+    return [chunk for piece in chunks for chunk in _split_single_token(piece, limit=settings.fallback_chunk_chars)]
+
+
+def _split_single_token(text: str, *, limit: int) -> list[str]:
+    """Split a long token into fixed-size pieces without dropping text."""
+    if len(text) <= limit:
+        return [text]
+    pieces: list[str] = []
+    for start in range(0, len(text), limit):
+        pieces.append(text[start : start + limit])
+    return pieces
 
 
 def _dedupe_preserving_order(values: Iterable[str]) -> list[str]:
@@ -431,14 +584,21 @@ def _clean_article_text(value: Any) -> str | None:
     text = _optional_text(value)
     if text is None:
         return None
+
     cleaned = html.unescape(text)
     for pattern in _HTML_NOISE_BLOCKS:
         cleaned = pattern.sub(" ", cleaned)
-    cleaned = _HTML_BLOCK_BREAK.sub(" ", cleaned)
+    cleaned = _HTML_LINE_BREAK.sub("\n", cleaned)
+    cleaned = _HTML_BLOCK_BREAK_START.sub("\n", cleaned)
+    cleaned = _HTML_BLOCK_BREAK_END.sub("\n", cleaned)
     cleaned = _HTML_TAG.sub(" ", cleaned)
     cleaned = cleaned.replace("\xa0", " ")
-    cleaned = _WHITESPACE.sub(" ", cleaned).strip()
+    cleaned = re.sub(r"[ \t\f\v]*\n[ \t\f\v]*", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    cleaned = _INLINE_WHITESPACE.sub(" ", cleaned)
+    cleaned = re.sub(r" *\n *", "\n", cleaned)
     cleaned = re.sub(r"\s+([,.;:!?])", r"\1", cleaned)
+    cleaned = cleaned.strip(" \n\t\r")
     return cleaned or None
 
 
@@ -447,7 +607,7 @@ def _optional_datetime(value: Any) -> datetime | None:
     text = _optional_text(value)
     if text is None:
         return None
-    return NewsSentimentRecord(date="2000-01-01", ticker="SPY", published_at=text).published_at
+    return _DATETIME_ADAPTER.validate_python(text)
 
 
 def _optional_float(value: Any) -> float | None:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,7 +206,7 @@ r2/
     YYYY-MM-DD/       # Canonical date-first Layer 1 feature partition
       TICKER.parquet  # Complete FeatureRecord shard for one date/ticker
       regime/         # Colocated Layer 1.5 regime artifacts for the date
-      news_sentiment/ # Layer 1 news preprocessing rows with article and chunk provenance
+      news_sentiment/ # Layer 1 news preprocessing rows with readable sentence/chunk provenance
       text_embeddings/# Article embedding cache keyed by pinned model/version
       topic_labels/   # Article-level BERTopic labels from Modal
       topic_features/ # Ticker-day FeatureRecord topic summaries
@@ -359,13 +359,19 @@ migration inputs, but they are not the authoritative production handoff path.
 
 #### Text / NLP branch
 
+Layer 1 news preprocessing is driven by `config/news_preprocessing.json`. The configured
+`target_chunk_chars` sets the preferred chunk size, `max_chunk_chars` is the hard upper
+bound before fallback splitting, and `fallback_chunk_chars` is the last-resort split size for
+oversized tokens or text that still exceeds the hard limit.
+
 **Pipeline order (must be executed in this sequence):**
 
 ```
 RAW ARTICLES (Alpaca news)
   → Step 1: Preprocessing
       Read raw/news and raw/universe from R2, clean provider HTML/entities into plain text,
-      split into sentences, tag point-in-time tickers, write NewsSentimentRecord rows to
+      split cleaned article text into bounded sentence/chunk rows, preserve paragraph/list
+      breaks where possible, tag point-in-time tickers, write NewsSentimentRecord rows to
       features/{date}/news_sentiment/{run_id}.parquet
   → Step 2a: Sentence Transformers (per article)
       Model: all-mpnet-base-v2

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -222,6 +222,8 @@ Notes:
 ### NewsSentimentRecord
 
 Represents one sentence-level, article-level, or aggregated ticker-day sentiment view.
+Layer 1 preprocessing now emits bounded, human-reviewable sentence/chunk rows from cleaned
+article text rather than large raw HTML paragraphs.
 
 Fields:
 - `date`
@@ -263,6 +265,11 @@ Input note:
 - sentence/chunk rows should populate `text`, `sentence_index`, `chunk_index`,
   `ticker_mentions`, and `entity_mentions`; aggregated ticker-day rows may leave those
   fields unset
+- splitting is configured by `config/news_preprocessing.json` using
+  `target_chunk_chars`, `max_chunk_chars`, and `fallback_chunk_chars`
+- the splitter keeps paragraph and list boundaries when possible, emits readable sentence-
+  sized or bounded chunk rows, and falls back to smaller chunks for oversized text instead
+  of silently truncating important content
 - `published_at` must preserve the raw article timestamp exactly for downstream leakage checks
 
 ### Layer 1 text embeddings and topic labels (non-contract artifacts)

--- a/tests/unit/test_news_preprocessing.py
+++ b/tests/unit/test_news_preprocessing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import UTC
 
 from core.features.news_preprocessing import (
@@ -28,6 +29,45 @@ def test_split_article_chunks_preserves_source_field_provenance() -> None:
     assert [chunk.chunk_index for chunk in chunks] == [0, 1, 2]
     assert [chunk.text for chunk in chunks] == ["Apple moves higher."] * 3
     assert sentences == ["Apple moves higher."]
+
+
+def test_preprocess_news_articles_emits_sentence_records_for_multiple_alias_tickers() -> None:
+    """Raw Alpaca symbols are normalized and expanded into per-ticker sentence rows."""
+    articles = [
+        {
+            "id": 1001,
+            "headline": "Apple and Berkshire rally.",
+            "summary": "Apple Inc. reported earnings.",
+            "content": "Berkshire also gained!",
+            "source": "benzinga",
+            "url": "https://example.test/article",
+            "created_at": "2024-01-02T12:00:00+00:00",
+            "symbols": ["AAPL", "BRK.B", "FB", "NOTIN"],
+        }
+    ]
+
+    records = preprocess_news_articles(
+        articles,
+        as_of_date="2024-01-02",
+        point_in_time_tickers=["AAPL", "BRK-B", "META"],
+    )
+
+    assert {(record.ticker, record.sentence_index) for record in records} == {
+        ("AAPL", 0),
+        ("BRK-B", 0),
+        ("META", 0),
+        ("AAPL", 1),
+        ("BRK-B", 1),
+        ("META", 1),
+        ("AAPL", 2),
+        ("BRK-B", 2),
+        ("META", 2),
+    }
+    assert all(record.article_id == "1001" for record in records)
+    assert all(record.headline == "Apple and Berkshire rally." for record in records)
+    assert all(record.published_at is not None for record in records)
+    assert records[0].published_at is not None
+    assert records[0].published_at.isoformat() == "2024-01-02T12:00:00+00:00"
 
 
 def test_split_article_sentences_cleans_provider_html_and_preserves_meaningful_text() -> None:
@@ -145,6 +185,86 @@ def test_preprocess_news_articles_tags_tickers_entities_and_provenance() -> None
     assert all(record.ticker_mentions == ("SPY",) for record in spy_records)
 
 
+def test_split_article_sentences_preserves_headings_lists_and_quote_punctuation() -> None:
+    """Headings, list items, abbreviations, and quoted sentences stay readable."""
+    article = {
+        "headline": '<h1><a href="https://example.test/aapl">AAPL</a> gains on AI rollout.</h1>',
+        "summary": '<p>Analyst says, "Buy now." Revenue may accelerate.</p>',
+        "content": (
+            "<h2>Key points</h2>"
+            "<p>U.S. regulators review the deal.</p>"
+            "<ul><li>Revenue beat expectations.</li><li>Margins improved.</li></ul>"
+        ),
+        "symbols": ["AAPL"],
+    }
+
+    sentences = split_article_sentences(article)
+
+    assert sentences == [
+        "AAPL gains on AI rollout.",
+        'Analyst says, "Buy now."',
+        "Revenue may accelerate.",
+        "Key points",
+        "U.S. regulators review the deal.",
+        "Revenue beat expectations.",
+        "Margins improved.",
+    ]
+    assert all("<" not in sentence and ">" not in sentence for sentence in sentences)
+    assert all("aapl" not in sentence.lower() or sentence == "AAPL gains on AI rollout." for sentence in sentences)
+
+
+def test_split_article_sentences_handles_abbreviations_and_deduplicates() -> None:
+    """Sentence splitting avoids common abbreviation splits and removes duplicate text."""
+    article = {
+        "headline": "U.S. stocks rose.",
+        "summary": "Apple Inc. reported earnings. Shares rose!",
+        "content": "Apple Inc. reported earnings. Shares rose!",
+    }
+
+    sentences = split_article_sentences(article)
+
+    assert sentences == [
+        "U.S. stocks rose.",
+        "Apple Inc. reported earnings.",
+        "Shares rose!",
+    ]
+
+
+def test_preprocess_news_articles_chunks_oversized_paragraphs_without_truncation() -> None:
+    """Oversized blocks are split into bounded chunks without dropping content."""
+    paragraph = " ".join(
+        [
+            "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu",
+            "nu xi omicron pi rho sigma tau upsilon phi chi psi omega",
+        ]
+        * 6
+    )
+    article = {
+        "id": "chunk-limit",
+        "content": f"<p>{paragraph}</p>",
+        "symbols": ["AAPL"],
+    }
+    config = NewsPreprocessingConfig(
+        target_chunk_chars=80,
+        max_chunk_chars=120,
+        fallback_chunk_chars=60,
+    )
+
+    records = preprocess_news_articles(
+        [article],
+        as_of_date="2024-01-02",
+        point_in_time_tickers=["AAPL"],
+        config=config,
+    )
+
+    assert len(records) > 1
+    assert all(len(record.text or "") <= 120 for record in records)
+    reconstructed = re.sub(r"\s+", " ", " ".join(record.text or "" for record in records)).strip()
+    expected = re.sub(r"\s+", " ", paragraph).strip()
+    assert reconstructed == expected
+    assert [record.sentence_index for record in records] == list(range(len(records)))
+
+
 def test_preprocess_news_articles_filters_empty_text_and_missing_universe_symbols() -> None:
     """Articles without allowed point-in-time ticker tags are skipped."""
     records = preprocess_news_articles(
@@ -179,6 +299,7 @@ def test_news_sentiment_frame_round_trips_records_with_provenance() -> None:
     restored = news_sentiment_frame_to_records(frame)
 
     assert restored == records
+    assert restored[0].published_at is not None
     assert restored[0].published_at.tzinfo == UTC
     assert restored[0].ticker_mentions == ("AAPL",)
     assert restored[0].entity_mentions == ("Apple",)


### PR DESCRIPTION
## Summary
- Preserves Layer 1 HTML/entity cleaning from #255 while adding bounded sentence/chunk splitting.
- Keeps per-field chunk provenance, normalized headlines, ticker/entity mentions, and Parquet-compatible round-trips.
- Wires chunk defaults through the Modal runner and config.

## Tests
- /home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/pytest tests/unit/test_news_preprocessing.py -v --tb=short
- /home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/pytest tests/unit/ -v --tb=short
- /home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/ruff check app/lab/data_pipelines/run_news_preprocessing.py core/features/news_preprocessing.py tests/unit/test_news_preprocessing.py

Closes #256
