### PR TITLE
[Code Monkey] Stop treating default relevance_score=1.0 as proof of ticker relevance

### DIFF
--- a/core/features/sentiment_features.py
+++ b/core/features/sentiment_features.py
@@ -154,14 +154,17 @@ def score_news_sentiment(
     *,
     scorer: SentimentScorer,
     batch_size: int = 32,
-    default_relevance_score: float = 1.0,
+    default_relevance_score: float | None = None,
 ) -> list[NewsSentimentRecord]:
     """Score preprocessed news rows with an injected FinBERT-compatible scorer."""
     if batch_size <= 0:
         raise ValueError("batch_size must be positive")
-    relevance = _to_float_or_none(default_relevance_score)
-    if relevance is None or relevance < 0.0:
-        raise ValueError("default_relevance_score must be a non-negative finite number")
+    if default_relevance_score is None:
+        relevance = None
+    else:
+        relevance = _to_float_or_none(default_relevance_score)
+        if relevance is None or relevance < 0.0:
+            raise ValueError("default_relevance_score must be a non-negative finite number")
 
     scorable_records: list[NewsSentimentRecord] = []
     texts: list[str] = []

--- a/core/features/sentiment_features.py
+++ b/core/features/sentiment_features.py
@@ -758,10 +758,13 @@ def _topic_effective_weight(row: Mapping[str, Any]) -> float:
 
 
 def _relevance_weight(value: Any) -> float:
-    """Return the non-negative article relevance multiplier."""
+    """Return the non-negative article relevance multiplier.
+
+    Missing relevance stays non-direct evidence by contributing zero weight.
+    """
     numeric = _to_float_or_none(value)
     if numeric is None:
-        return 1.0
+        return 0.0
     return max(numeric, 0.0)
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -392,7 +392,8 @@ RAW ARTICLES (Alpaca news)
       Output: (positive, negative, neutral) probabilities per sentence/chunk
   → Step 5: Aggregation
       Combine FinBERT scores + topic assignments + source credibility weights
-      into per-ticker per-day features
+      into per-ticker per-day features; only explicit relevance scores should be
+      treated as direct relevance evidence
 ```
 
 **Output features from NLP branch:**

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -271,6 +271,9 @@ Input note:
   sized or bounded chunk rows, and falls back to smaller chunks for oversized text instead
   of silently truncating important content
 - `published_at` must preserve the raw article timestamp exactly for downstream leakage checks
+- `relevance_score` is optional and may remain null until an explicit relevance computation
+  assigns a non-default value; missing relevance must not be treated as proof of ticker
+  relevance
 
 ### Layer 1 text embeddings and topic labels (non-contract artifacts)
 

--- a/tests/unit/test_sentiment_features.py
+++ b/tests/unit/test_sentiment_features.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from core.contracts.schemas import NewsSentimentRecord
+from core.features.news_preprocessing import records_to_news_sentiment_frame
 from core.features.sentiment_features import (
     SENTIMENT_AGGREGATE_COLUMNS,
     SentimentScore,
@@ -70,8 +71,8 @@ class _BadScorer:
         return []
 
 
-def test_score_news_sentiment_populates_finbert_fields() -> None:
-    """Preprocessed news records are scored without changing identity fields."""
+def test_score_news_sentiment_distinguishes_missing_and_explicit_relevance() -> None:
+    """Preprocessed news records keep explicit relevance separate from missing fallback."""
     records = [
         NewsSentimentRecord(
             date="2024-04-10",
@@ -88,17 +89,45 @@ def test_score_news_sentiment_populates_finbert_fields() -> None:
             article_id="a2",
             sentence_index=0,
             source="Reuters",
+            relevance_score=0.25,
+        ),
+        NewsSentimentRecord(
+            date="2024-04-10",
+            ticker="SPY",
+            text="S&P 500 rises as Fed holds rates.",
+            article_id="a3",
+            sentence_index=0,
+            source="Reuters",
+            relevance_score=0.9,
         ),
     ]
 
     scored = score_news_sentiment(records, scorer=_FakeScorer(), batch_size=1)
 
-    assert [record.ticker for record in scored] == ["AAPL", "MSFT"]
+    assert [record.ticker for record in scored] == ["AAPL", "MSFT", "SPY"]
     assert scored[0].sentiment_positive == pytest.approx(0.8)
     assert scored[0].sentiment_score == pytest.approx(0.7)
     assert scored[1].sentiment_negative == pytest.approx(0.6)
     assert scored[1].sentiment_score == pytest.approx(-0.4)
-    assert scored[0].relevance_score == pytest.approx(1.0)
+    assert scored[0].relevance_score is None
+    assert scored[1].relevance_score == pytest.approx(0.25)
+    assert scored[2].relevance_score == pytest.approx(0.9)
+
+    aggregates = sentiment_feature_records_from_scored_news(
+        records_to_news_sentiment_frame(scored),
+        credibility_config=SourceCredibilityConfig(
+            default_source_weight=1.0,
+            source_weights={},
+        ),
+    )
+    by_ticker = {record.ticker: record for record in aggregates}
+    assert by_ticker["AAPL"].features["nlp_relevance_score"] is None
+    assert by_ticker["MSFT"].features["nlp_relevance_score"] == pytest.approx(0.25)
+    assert by_ticker["SPY"].features["nlp_relevance_score"] == pytest.approx(0.9)
+    assert json.loads(str(by_ticker["AAPL"].features["nlp_semantic_warning_codes"])) == [
+        "missing_relevance_evidence",
+        "missing_topic_artifact",
+    ]
 
 
 def test_score_news_sentiment_skips_rows_without_text_or_headline() -> None:

--- a/tests/unit/test_sentiment_features.py
+++ b/tests/unit/test_sentiment_features.py
@@ -122,6 +122,7 @@ def test_score_news_sentiment_distinguishes_missing_and_explicit_relevance() -> 
     )
     by_ticker = {record.ticker: record for record in aggregates}
     assert by_ticker["AAPL"].features["nlp_relevance_score"] is None
+    assert by_ticker["AAPL"].features["nlp_sentiment_score"] is None
     assert by_ticker["MSFT"].features["nlp_relevance_score"] == pytest.approx(0.25)
     assert by_ticker["SPY"].features["nlp_relevance_score"] == pytest.approx(0.9)
     assert json.loads(str(by_ticker["AAPL"].features["nlp_semantic_warning_codes"])) == [
@@ -314,7 +315,7 @@ def test_aggregate_sentiment_by_ticker_day_rejects_bad_probability() -> None:
 
 
 def test_aggregate_sentiment_by_ticker_day_handles_nan_relevance() -> None:
-    """NaN relevance does not prevent source-weighted sentiment aggregation."""
+    """NaN relevance is treated as non-direct evidence, not full-weight support."""
     scored_news = pd.DataFrame([_row(relevance_score=float("nan"))])
 
     aggregates = aggregate_sentiment_by_ticker_day(
@@ -325,7 +326,7 @@ def test_aggregate_sentiment_by_ticker_day_handles_nan_relevance() -> None:
         ),
     )
 
-    assert aggregates.loc[0, "sentiment_score"] == pytest.approx(0.7)
+    assert aggregates.loc[0, "sentiment_score"] is None
     assert pd.isna(aggregates.loc[0, "relevance_score"])
 
 


### PR DESCRIPTION
## What this PR does
Preserve missing relevance as null instead of silently defaulting new `NewsSentimentRecord` rows to `1.0`, and keep downstream aggregation/review paths from treating fallback relevance as direct ticker evidence. Also updates the relevant docs and unit coverage.

## Closes
Closes #259

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [x] Written by me
- [ ] Generated by Codex — reviewed and approved by me

---

## Codex checklist
*Codex must verify every item before opening this PR*

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
  (`agent_execution.py`, `broker_adapter.py`, `order_builder.py`,
   `fills.py`, `risk_policy.json`, `portfolio_policy.json`)
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes with zero failures
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene  
- [x] Branch named `codex/<issue-number>-<slug>` or `feature/<slug>`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [x] `requirements.txt` updated if new packages added (noted below)

---

## New dependencies
None

## Screenshots or sample output
N/A

## Notes for reviewer
- Commands run:
  - `HOME=/home/juyoungoh gh issue view 259 --repo ohjy1006kenneth/AI-Stock-Trader --json number,title,body,labels,state,author,assignees,projectItems`
  - `/home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/pytest tests/unit/test_sentiment_features.py -v --tb=short -k 'score_news_sentiment_distinguishes_missing_and_explicit_relevance or sentiment_feature_records_from_scored_news_matches_contract'`
  - `/home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/pytest tests/unit/ -v --tb=short`
  - `git diff --check`
- Test result summary: 760 unit tests passed; targeted sentiment regression tests passed.
- Manifest key(s): N/A
- Report path(s): N/A
- R2 output prefix(es): N/A
- Known skipped/missing data: No external artifacts were required for this fix.
