### PR TITLE
fix(news): add relevance gate before FinBERT aggregation

### DIFF
--- a/core/features/sentiment_features.py
+++ b/core/features/sentiment_features.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any, Protocol
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from core.contracts.schemas import FeatureRecord, NewsSentimentRecord
+from services.wikipedia.sp500_universe import canonicalize_ticker
 
 if TYPE_CHECKING:
     import pandas as pd
@@ -99,6 +100,47 @@ SENTIMENT_FEATURE_COLUMNS: tuple[str, ...] = (
     "nlp_semantic_warning_codes",
 )
 
+DIRECT_RELEVANCE_SCORE = 1.0
+CONTEXTUAL_RELEVANCE_SCORE = 0.25
+
+_CONTEXTUAL_EVIDENCE_TERMS: tuple[str, ...] = (
+    "ai",
+    "analyst",
+    "broad market",
+    "chip",
+    "competitor",
+    "etf",
+    "equities",
+    "guidance",
+    "index",
+    "investor",
+    "market",
+    "peer",
+    "rally",
+    "rival",
+    "sector",
+    "semiconductor",
+    "stocks",
+    "tech",
+    "technology",
+)
+
+_TICKER_ENTITY_ALIASES: dict[str, tuple[str, ...]] = {
+    "AAPL": ("apple", "apple inc", "apple inc.", "apple computer"),
+    "AMD": ("amd", "advanced micro devices"),
+    "AMZN": ("amazon", "amazon.com", "amazon inc"),
+    "BRK-B": ("berkshire hathaway", "berkshire"),
+    "GOOGL": ("alphabet", "google", "google parent"),
+    "INTC": ("intel", "intel corp", "intel corporation"),
+    "META": ("meta", "facebook"),
+    "MSFT": ("microsoft", "microsoft corp", "microsoft corporation"),
+    "NVDA": ("nvidia", "nvidia corp", "nvidia corporation"),
+    "QQQ": ("nasdaq 100", "invesco qqq", "qqq etf"),
+    "SNAP": ("snap", "snap inc", "snapchat"),
+    "SPY": ("spdr s&p 500", "s&p 500 etf", "spy etf"),
+    "TSLA": ("tesla", "tesla inc"),
+}
+
 
 @dataclass(frozen=True)
 class SourceCredibilityConfig:
@@ -185,9 +227,10 @@ def score_news_sentiment(
 
     scored_records: list[NewsSentimentRecord] = []
     for record, score in zip(scorable_records, scores, strict=True):
-        active_relevance = record.relevance_score
-        if active_relevance is None:
-            active_relevance = relevance
+        active_relevance = _resolve_relevance_score(
+            record,
+            default_relevance_score=relevance,
+        )
         scored_records.append(
             NewsSentimentRecord(
                 date=record.date,
@@ -765,7 +808,86 @@ def _relevance_weight(value: Any) -> float:
     numeric = _to_float_or_none(value)
     if numeric is None:
         return 0.0
-    return max(numeric, 0.0)
+    return min(max(numeric, 0.0), 1.0)
+
+
+def _resolve_relevance_score(
+    record: NewsSentimentRecord,
+    *,
+    default_relevance_score: float | None,
+) -> float | None:
+    """Return a conservative relevance score inferred from explicit evidence.
+
+    Rows that already carry a relevance score keep it, while rows without
+    explicit relevance are only scored when the text contains direct ticker or
+    entity evidence. Broad-market or competitor context is allowed only as a
+    weaker contextual signal. Rows with no evidence remain unset so they carry
+    no direct aggregation weight.
+    """
+    existing = _to_float_or_none(record.relevance_score)
+    if existing is not None:
+        return min(max(existing, 0.0), 1.0)
+
+    text = _scoring_text(record)
+    if text is None:
+        return None
+
+    evidence = _ticker_relevance_evidence(record.ticker, text)
+    if evidence == "direct":
+        return DIRECT_RELEVANCE_SCORE
+    if evidence == "contextual":
+        if default_relevance_score is None:
+            return CONTEXTUAL_RELEVANCE_SCORE
+        return min(max(default_relevance_score, 0.0), CONTEXTUAL_RELEVANCE_SCORE)
+    return None
+
+
+def _ticker_relevance_evidence(ticker: str, text: str) -> str | None:
+    """Classify ticker evidence as direct, contextual, or absent."""
+    normalized_ticker = canonicalize_ticker(ticker)
+    if not normalized_ticker:
+        return None
+
+    normalized_text = text.lower()
+    if _contains_ticker_mention(normalized_ticker, normalized_text):
+        return "direct"
+    if _contains_alias_mention(normalized_ticker, normalized_text):
+        return "direct"
+    if _contains_contextual_evidence(normalized_text):
+        return "contextual"
+    return None
+
+
+def _contains_ticker_mention(ticker: str, text: str) -> bool:
+    """Return True when the article explicitly mentions the ticker symbol."""
+    aliases = {ticker}
+    if "-" in ticker:
+        aliases.add(ticker.replace("-", "."))
+        aliases.add(ticker.replace("-", ""))
+    for alias in aliases:
+        pattern = rf"(?<![A-Z0-9]){re.escape(alias)}(?![A-Z0-9])"
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def _contains_alias_mention(ticker: str, text: str) -> bool:
+    """Return True when the article explicitly names the company entity."""
+    aliases = _TICKER_ENTITY_ALIASES.get(ticker, ())
+    for alias in aliases:
+        pattern = rf"(?<![A-Z0-9]){re.escape(alias)}(?![A-Z0-9])"
+        if re.search(pattern, text, flags=re.IGNORECASE):
+            return True
+    return False
+
+
+def _contains_contextual_evidence(text: str) -> bool:
+    """Return True when the article only offers broad-market or peer context."""
+    for term in _CONTEXTUAL_EVIDENCE_TERMS:
+        pattern = rf"(?<![a-z0-9]){re.escape(term)}(?![a-z0-9])"
+        if re.search(pattern, text):
+            return True
+    return False
 
 
 def _weighted_average(values: pd.Series, weights: pd.Series) -> float | None:

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -274,6 +274,9 @@ Input note:
 - `relevance_score` is optional and may remain null until an explicit relevance computation
   assigns a non-default value; missing relevance must not be treated as proof of ticker
   relevance
+- `relevance_score` should only be populated when there is explicit ticker/entity evidence or
+  a deliberate contextual classification; downstream ticker-day aggregation treats unset
+  relevance as zero direct weight
 
 ### Layer 1 text embeddings and topic labels (non-contract artifacts)
 

--- a/tests/unit/test_finbert_sentiment_runner.py
+++ b/tests/unit/test_finbert_sentiment_runner.py
@@ -78,6 +78,8 @@ def test_run_finbert_sentiment_reads_preprocessed_news_and_writes_outputs(
     )
     assert result.manifest_key == pipeline_manifest_path(FINBERT_SENTIMENT_STAGE, "finbert-run")
     assert len(scored) == 3
+    assert all(scored["relevance_score"].iloc[:2] == 0.8)
+    assert scored["relevance_score"].iloc[2] == pytest.approx(0.48)
     assert set(features["ticker"]) == {"AAPL", "MSFT"}
     assert json.loads(features.loc[features["ticker"] == "AAPL", "features"].iloc[0])[
         "nlp_sentence_count"

--- a/tests/unit/test_sentiment_features.py
+++ b/tests/unit/test_sentiment_features.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
 
 import pandas as pd
@@ -52,7 +53,7 @@ def _row(
 class _FakeScorer:
     """Deterministic test scorer."""
 
-    def score(self, texts: list[str]) -> list[SentimentScore]:
+    def score(self, texts: Sequence[str]) -> Sequence[SentimentScore]:
         """Return positive scores for bullish text and negative otherwise."""
         scores: list[SentimentScore] = []
         for text in texts:
@@ -66,7 +67,7 @@ class _FakeScorer:
 class _BadScorer:
     """Test scorer that returns the wrong output cardinality."""
 
-    def score(self, texts: list[str]) -> list[SentimentScore]:
+    def score(self, texts: Sequence[str]) -> Sequence[SentimentScore]:
         """Return too few scores."""
         return []
 
@@ -109,7 +110,7 @@ def test_score_news_sentiment_distinguishes_missing_and_explicit_relevance() -> 
     assert scored[0].sentiment_score == pytest.approx(0.7)
     assert scored[1].sentiment_negative == pytest.approx(0.6)
     assert scored[1].sentiment_score == pytest.approx(-0.4)
-    assert scored[0].relevance_score is None
+    assert scored[0].relevance_score == pytest.approx(1.0)
     assert scored[1].relevance_score == pytest.approx(0.25)
     assert scored[2].relevance_score == pytest.approx(0.9)
 
@@ -121,14 +122,64 @@ def test_score_news_sentiment_distinguishes_missing_and_explicit_relevance() -> 
         ),
     )
     by_ticker = {record.ticker: record for record in aggregates}
-    assert by_ticker["AAPL"].features["nlp_relevance_score"] is None
-    assert by_ticker["AAPL"].features["nlp_sentiment_score"] is None
+    assert by_ticker["AAPL"].features["nlp_relevance_score"] == pytest.approx(1.0)
+    assert by_ticker["AAPL"].features["nlp_sentiment_score"] == pytest.approx(0.7)
     assert by_ticker["MSFT"].features["nlp_relevance_score"] == pytest.approx(0.25)
     assert by_ticker["SPY"].features["nlp_relevance_score"] == pytest.approx(0.9)
     assert json.loads(str(by_ticker["AAPL"].features["nlp_semantic_warning_codes"])) == [
         "missing_relevance_evidence",
         "missing_topic_artifact",
     ]
+
+
+def test_score_news_sentiment_requires_explicit_relevance_evidence() -> None:
+    """Direct ticker/entity evidence gets full weight while generic context stays conservative."""
+    records = [
+        NewsSentimentRecord(
+            date="2024-04-10",
+            ticker="AAPL",
+            headline="Apple says AAPL revenue improved.",
+            text="Apple says AAPL revenue improved.",
+            article_id="direct-aapl",
+            sentence_index=0,
+            source="Reuters",
+        ),
+        NewsSentimentRecord(
+            date="2024-04-10",
+            ticker="AAPL",
+            headline="Intel and Snap rally as ETF inflows lift tech.",
+            text="Intel and Snap rally as ETF inflows lift tech.",
+            article_id="context-aapl",
+            sentence_index=0,
+            source="Reuters",
+        ),
+        NewsSentimentRecord(
+            date="2024-04-10",
+            ticker="MSFT",
+            headline="AI and tech stocks rally on market hopes.",
+            text="AI and tech stocks rally on market hopes.",
+            article_id="context-msft",
+            sentence_index=0,
+            source="Reuters",
+        ),
+        NewsSentimentRecord(
+            date="2024-04-10",
+            ticker="NVDA",
+            headline="Weekend weather update.",
+            text="Weekend weather update.",
+            article_id="noise-nvda",
+            sentence_index=0,
+            source="Reuters",
+        ),
+    ]
+
+    scored = score_news_sentiment(records, scorer=_FakeScorer(), batch_size=2)
+    relevance_by_article = {record.article_id: record.relevance_score for record in scored}
+
+    assert relevance_by_article["direct-aapl"] == pytest.approx(1.0)
+    assert relevance_by_article["context-aapl"] == pytest.approx(0.25)
+    assert relevance_by_article["context-msft"] == pytest.approx(0.25)
+    assert relevance_by_article["noise-nvda"] is None
 
 
 def test_score_news_sentiment_skips_rows_without_text_or_headline() -> None:
@@ -190,6 +241,55 @@ def test_aggregate_sentiment_by_ticker_day_multiplies_relevance_weight() -> None
 
     assert aggregates.loc[0, "sentiment_score"] == pytest.approx(0.6)
     assert aggregates.loc[0, "relevance_score"] == pytest.approx(0.625)
+
+
+def test_aggregate_sentiment_by_ticker_day_excludes_contamination_from_direct_weight() -> None:
+    """Direct ticker sentiment only uses explicit evidence and downweights context."""
+    scored_news = pd.DataFrame(
+        [
+            _row(
+                article_id="direct",
+                source="Reuters",
+                sentiment_positive=1.0,
+                sentiment_negative=0.0,
+                sentiment_neutral=0.0,
+                sentiment_score=1.0,
+                relevance_score=1.0,
+            ),
+            _row(
+                article_id="context",
+                source="Reuters",
+                sentiment_positive=0.0,
+                sentiment_negative=1.0,
+                sentiment_neutral=0.0,
+                sentiment_score=-1.0,
+                relevance_score=0.25,
+            ),
+            _row(
+                article_id="noise",
+                source="Reuters",
+                sentiment_positive=0.0,
+                sentiment_negative=1.0,
+                sentiment_neutral=0.0,
+                sentiment_score=-1.0,
+                relevance_score=float("nan"),
+            ),
+        ]
+    )
+
+    records = sentiment_feature_records_from_scored_news(
+        scored_news,
+        credibility_config=SourceCredibilityConfig(
+            default_source_weight=1.0,
+            source_weights={"reuters": 1.0},
+        ),
+    )
+
+    assert len(records) == 1
+    assert records[0].ticker == "AAPL"
+    assert records[0].features["nlp_sentence_count"] == 3
+    assert records[0].features["nlp_sentiment_score"] == pytest.approx(0.6)
+    assert records[0].features["nlp_relevance_score"] == pytest.approx(0.625)
 
 
 def test_aggregate_sentiment_by_ticker_day_uses_default_weight_for_unknown_source() -> None:
@@ -326,7 +426,7 @@ def test_aggregate_sentiment_by_ticker_day_handles_nan_relevance() -> None:
         ),
     )
 
-    assert aggregates.loc[0, "sentiment_score"] is None
+    assert pd.isna(aggregates.loc[0, "sentiment_score"])
     assert pd.isna(aggregates.loc[0, "relevance_score"])
 
 


### PR DESCRIPTION
## What this PR does
Adds an explicit ticker/entity relevance gate before FinBERT aggregation. Rows without direct ticker/entity evidence are no longer treated as full direct sentiment; broad-market or competitor context is downweighted conservatively, and rows with no evidence remain unset so they carry no direct aggregation weight.

## Closes
Closes #257

## Layer(s) affected
- [ ] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [ ] Infrastructure / services
- [ ] Tests only
- [ ] Docs only

## Author
- [ ] Written by me
- [x] Generated by Codex — reviewed and approved by me

---

## Codex checklist

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py`
- [x] No logic added to forbidden files
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `./.venv/bin/pytest tests/unit/test_sentiment_features.py tests/unit/test_finbert_sentiment_runner.py -v --tb=short` passes
- [x] `./.venv/bin/pytest tests/unit/ -v --tb=short` passes
- [x] New public functions have at least one unit test each
- [x] Tests cover: happy path, empty input, missing columns, NaN input
- [x] No live API calls in unit tests — fixtures used from `data/sample/`

### Code quality
- [x] All new public functions have type hints
- [x] All new public functions have a docstring
- [x] Imports ordered: stdlib → third-party → internal
- [x] No unused imports

### Project hygiene
- [x] Branch named `hermes/hermes-93a64003`
- [x] Issue label updated to `review`
- [x] No unrelated files modified
- [ ] `requirements.txt` updated if new packages added (not needed)

## Commands run / results
- `./.venv/bin/pytest tests/unit/test_sentiment_features.py tests/unit/test_finbert_sentiment_runner.py -v --tb=short` ✅
- `./.venv/bin/pytest tests/unit/ -v --tb=short` ✅
- `git diff --check` ✅
- `make lint` ✅ after PATH pointed at the repo venv
- `make typecheck` ⚠️ failed in repo-wide mypy setup before checking touched files: `core/backtesting/engine.py` was reported as a duplicate module (`backtesting.engine` and `core.backtesting.engine`)

## Notes for reviewer
- Direct ticker/entity evidence now drives relevance scoring; contextual news is conservatively weighted, and unset relevance no longer implies a full direct weight.
- No external artifacts were touched; no live provider calls were added.
