### PR TITLE
Add human-readable Layer 1 topic review outputs

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -489,6 +489,11 @@ def run_daily_layer1(
                     date_text: result.topic_feature_key
                     for date_text, result in topic_results.items()
                 },
+                "topic_review_keys": {
+                    date_text: result.topic_review_key
+                    for date_text, result in topic_results.items()
+                    if result.topic_review_key
+                },
                 "sentiment_output_keys": {
                     date_text: result.sentiment_feature_key
                     for date_text, result in sentiment_results.items()

--- a/app/lab/data_pipelines/run_news_preprocessing.py
+++ b/app/lab/data_pipelines/run_news_preprocessing.py
@@ -12,7 +12,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -70,6 +70,9 @@ class NewsPreprocessingPipelineConfig:
     run_id: str
     as_of_date: str
     min_sentence_chars: int = 2
+    target_chunk_chars: int = 240
+    max_chunk_chars: int = 360
+    fallback_chunk_chars: int = 160
 
     def __post_init__(self) -> None:
         """Validate run identity and date settings."""
@@ -81,6 +84,16 @@ class NewsPreprocessingPipelineConfig:
             raise ValueError("as_of_date must be YYYY-MM-DD") from exc
         if self.min_sentence_chars <= 0:
             raise ValueError("min_sentence_chars must be positive")
+        if self.target_chunk_chars <= 0:
+            raise ValueError("target_chunk_chars must be positive")
+        if self.max_chunk_chars <= 0:
+            raise ValueError("max_chunk_chars must be positive")
+        if self.fallback_chunk_chars <= 0:
+            raise ValueError("fallback_chunk_chars must be positive")
+        if self.target_chunk_chars > self.max_chunk_chars:
+            raise ValueError("target_chunk_chars must be <= max_chunk_chars")
+        if self.fallback_chunk_chars > self.target_chunk_chars:
+            raise ValueError("fallback_chunk_chars must be <= target_chunk_chars")
 
 
 @dataclass(frozen=True)
@@ -129,7 +142,12 @@ def run_news_preprocessing(
             articles,
             as_of_date=config.as_of_date,
             point_in_time_tickers=tickers,
-            config=NewsPreprocessingConfig(min_sentence_chars=config.min_sentence_chars),
+            config=NewsPreprocessingConfig(
+                min_sentence_chars=config.min_sentence_chars,
+                target_chunk_chars=config.target_chunk_chars,
+                max_chunk_chars=config.max_chunk_chars,
+                fallback_chunk_chars=config.fallback_chunk_chars,
+            ),
         )
         active_writer.put_object(output_key, _records_to_parquet_bytes(records))
         metadata.update({"article_rows": len(articles), "sentence_rows": len(records)})
@@ -180,6 +198,18 @@ def load_modal_runtime_config(path: Path = MODAL_CONFIG_PATH) -> ModalRuntimeCon
         python_version=str(payload.get("python_version", "3.11")),
         requirements_path=str(payload.get("requirements_path", "requirements/modal.txt")),
     )
+
+
+def _load_news_preprocessing_settings(path: Path = MODAL_CONFIG_PATH) -> dict[str, int]:
+    """Load sentence/chunk defaults for Layer 1 news preprocessing."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    settings = payload.get("news_preprocessing", {})
+    return {
+        "min_sentence_chars": int(settings.get("min_sentence_chars", 2)),
+        "target_chunk_chars": int(settings.get("target_chunk_chars", 240)),
+        "max_chunk_chars": int(settings.get("max_chunk_chars", 360)),
+        "fallback_chunk_chars": int(settings.get("fallback_chunk_chars", 160)),
+    }
 
 
 def _load_raw_news_articles(writer: ObjectStore, as_of_date: str) -> list[dict[str, object]]:
@@ -272,10 +302,14 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def _config_from_args(args: argparse.Namespace) -> NewsPreprocessingPipelineConfig:
     """Build a validated pipeline config from CLI arguments."""
+    defaults = _load_news_preprocessing_settings()
     return NewsPreprocessingPipelineConfig(
         run_id=args.run_id,
         as_of_date=args.as_of_date,
         min_sentence_chars=args.min_sentence_chars,
+        target_chunk_chars=defaults["target_chunk_chars"],
+        max_chunk_chars=defaults["max_chunk_chars"],
+        fallback_chunk_chars=defaults["fallback_chunk_chars"],
     )
 
 
@@ -301,11 +335,15 @@ def _modal_run_news_preprocessing_entry(
     min_sentence_chars: int = 2,
 ) -> dict[str, object]:
     """Run Layer 1 news preprocessing on Modal."""
+    defaults = _load_news_preprocessing_settings()
     result = run_news_preprocessing(
         NewsPreprocessingPipelineConfig(
             run_id=run_id,
             as_of_date=as_of_date,
             min_sentence_chars=min_sentence_chars,
+            target_chunk_chars=defaults["target_chunk_chars"],
+            max_chunk_chars=defaults["max_chunk_chars"],
+            fallback_chunk_chars=defaults["fallback_chunk_chars"],
         )
     )
     return {
@@ -345,7 +383,7 @@ def _define_modal_app() -> object | None:
     return app
 
 
-def _build_modal_image(modal_module: object, runtime: ModalRuntimeConfig):
+def _build_modal_image(modal_module: Any, runtime: ModalRuntimeConfig):
     """Build the Modal image while preserving local `-r base.txt` includes."""
     requirements_path = Path(runtime.requirements_path)
     requirements_dir = requirements_path.parent

--- a/app/lab/data_pipelines/run_text_topics.py
+++ b/app/lab/data_pipelines/run_text_topics.py
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol
+from typing import Any, Protocol
 
 from loguru import logger
 
@@ -47,6 +47,7 @@ from services.r2.paths import (  # noqa: E402
     layer1_text_embedding_path,
     layer1_topic_feature_path,
     layer1_topic_label_path,
+    layer1_topic_review_path,
     pipeline_manifest_path,
 )
 from services.r2.writer import R2Writer  # noqa: E402
@@ -132,11 +133,12 @@ class TextTopicPipelineResult:
     embedding_key: str
     topic_label_key: str
     topic_feature_key: str
-    manifest_key: str
-    sentence_rows: int
-    embedding_rows: int
-    topic_label_rows: int
-    topic_feature_rows: int
+    topic_review_key: str = ""
+    manifest_key: str = ""
+    sentence_rows: int = 0
+    embedding_rows: int = 0
+    topic_label_rows: int = 0
+    topic_feature_rows: int = 0
 
 
 def run_text_topics(
@@ -158,12 +160,14 @@ def run_text_topics(
     topic_label_key = layer1_topic_label_path(config.as_of_date, config.run_id)
     topic_feature_key = layer1_topic_feature_path(config.as_of_date, config.run_id)
     manifest_key = pipeline_manifest_path(TEXT_TOPICS_STAGE, config.run_id)
+    topic_review_key = layer1_topic_review_path(config.as_of_date, config.run_id)
     metadata: dict[str, object] = {
         "as_of_date": config.as_of_date,
         "preprocessed_news_key": config.preprocessed_news_key,
         "embedding_key": embedding_key,
         "topic_label_key": topic_label_key,
         "topic_feature_key": topic_feature_key,
+        "topic_review_key": topic_review_key,
         "embedding_model": runtime.embedding_config.model_name,
         "embedding_revision": runtime.embedding_config.model_revision,
         "topic_model": runtime.topic_config.model_name,
@@ -191,12 +195,25 @@ def run_text_topics(
             topic_feature_key,
             _frame_to_parquet_bytes(feature_records_to_frame(result.feature_records)),
         )
+        active_writer.put_object(
+            topic_review_key,
+            json.dumps(result.topic_review, indent=2, sort_keys=True),
+        )
         metadata.update(
             {
                 "sentence_rows": len(records),
                 "embedding_rows": len(result.embeddings),
                 "topic_label_rows": len(result.topic_labels),
                 "topic_feature_rows": len(result.feature_records),
+                "topic_review_status": str(result.topic_review.get("status", "warn")),
+                "topic_review_diversity_status": str(
+                    result.topic_review.get("diversity_status", "insufficient_diversity")
+                ),
+                "topic_review_topic_count": int(result.topic_review.get("topic_count", 0)),
+                "topic_review_dominant_topic_id": result.topic_review.get("dominant_topic_id"),
+                "topic_review_dominant_topic_share": result.topic_review.get(
+                    "dominant_topic_share"
+                ),
             }
         )
         _write_manifest(
@@ -214,6 +231,7 @@ def run_text_topics(
             embedding_key=embedding_key,
             topic_label_key=topic_label_key,
             topic_feature_key=topic_feature_key,
+            topic_review_key=topic_review_key,
             manifest_key=manifest_key,
             sentence_rows=len(records),
             embedding_rows=len(result.embeddings),
@@ -279,6 +297,14 @@ class BERTopicLabeler:
             embeddings=np.asarray(embeddings),
         )
         return list(topics), _topic_probabilities(topics, probabilities)
+
+    def get_topic(self, topic_id: int) -> Any:
+        """Return BERTopic keywords for one topic id."""
+        return self._model.get_topic(topic_id)
+
+    def get_topic_info(self) -> Any:
+        """Return the BERTopic topic-info frame."""
+        return self._model.get_topic_info()
 
 
 def load_text_model_runtime_config(path: Path = TEXT_MODEL_CONFIG_PATH) -> TextModelRuntimeConfig:
@@ -440,6 +466,7 @@ def _modal_run_text_topics_entry(
         "embedding_key": result.embedding_key,
         "topic_label_key": result.topic_label_key,
         "topic_feature_key": result.topic_feature_key,
+        "topic_review_key": result.topic_review_key,
         "manifest_key": result.manifest_key,
         "sentence_rows": result.sentence_rows,
         "embedding_rows": result.embedding_rows,

--- a/app/lab/feature_audit_dashboard.py
+++ b/app/lab/feature_audit_dashboard.py
@@ -624,6 +624,68 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       color: var(--muted);
       font-size: 0.92rem;
     }}
+    .supporting-audit-panel, .audit-only-control {{
+      display: none;
+    }}
+    .decision-grid {{
+      display: grid;
+      gap: 16px;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    }}
+    .decision-card {{
+      padding: 20px;
+      border-radius: 18px;
+      border: 1px solid var(--line);
+      background: rgba(255, 255, 255, 0.78);
+    }}
+    .check-list {{
+      display: grid;
+      gap: 10px;
+      margin-top: 12px;
+    }}
+    .check-list div {{
+      display: flex;
+      gap: 10px;
+      align-items: flex-start;
+      color: var(--muted);
+      line-height: 1.45;
+    }}
+    .prob-bars {{
+      display: grid;
+      gap: 8px;
+      margin-top: 12px;
+    }}
+    .prob-row {{
+      display: grid;
+      grid-template-columns: 82px 1fr 64px;
+      gap: 10px;
+      align-items: center;
+      color: var(--muted);
+      font-size: 0.9rem;
+    }}
+    .prob-track {{
+      height: 12px;
+      border-radius: 999px;
+      overflow: hidden;
+      background: rgba(36, 62, 56, 0.08);
+    }}
+    .prob-fill {{
+      height: 100%;
+      border-radius: inherit;
+      background: linear-gradient(90deg, #0f766e, #1f8f59);
+    }}
+    .sentiment-line {{
+      stroke: #0f766e;
+    }}
+    .confidence-line {{
+      stroke: #7c3aed;
+    }}
+    .bear-line {{
+      stroke: #bc3f2f;
+    }}
+    .sideways-line {{
+      stroke: #c67b17;
+    }}
     @media (max-width: 760px) {{
       .shell {{ width: min(100vw - 20px, 100%); padding-top: 16px; }}
       .hero {{ padding: 22px; }}
@@ -634,8 +696,8 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
 <body>
   <div class="shell">
     <section class="hero">
-      <span class="eyebrow">Layer 0/1 QA Only</span>
-      <h1>Live Feature Audit Dashboard</h1>
+      <span class="eyebrow">Pilot Window Decision</span>
+      <h1>HMM + FinBERT Pilot Dashboard</h1>
       <p id="readOnlyNotice"></p>
       <div class="notice" id="statusHelp"></div>
     </section>
@@ -646,7 +708,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       <div class="panel-head">
         <div>
           <h2>Selection Controls</h2>
-          <p>Change the audit window and ticker subset, then refine the UI locally by family, feature, and focus date.</p>
+          <p>Select the pilot window and ticker subset. The visible dashboard is intentionally limited to HMM regime evidence and FinBERT sentiment evidence.</p>
         </div>
         <div class="loading" id="loadingState">Waiting for first load.</div>
       </div>
@@ -660,7 +722,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         <label>Ticker subset
           <input type="text" id="tickerInput" placeholder="AAPL,MSFT,SPY" required>
         </label>
-        <label>Feature filter
+        <label class="audit-only-control">Feature filter
           <input type="search" id="featureSearch" placeholder="returns, regime, nlp">
         </label>
         <label>Focus date
@@ -668,11 +730,49 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         </label>
         <button type="submit">Refresh Dashboard</button>
       </form>
-      <div id="familyFilters" class="multi-filter"></div>
+      <div id="familyFilters" class="multi-filter audit-only-control"></div>
       <div class="error-box" id="errorBox"></div>
     </section>
 
     <section class="panel">
+      <div class="panel-head">
+        <div>
+          <h2>Pilot Window Decision Evidence</h2>
+          <p>Use this compact view to decide whether to accept the pilot window before authorizing the broader historical backfill.</p>
+        </div>
+      </div>
+      <div class="decision-grid" id="pilotDecision"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-head">
+        <div>
+          <h2>HMM Regime Graphs and Analysis</h2>
+          <p>Regime label, confidence, and bear/sideways/bull probability movement across the selected pilot window.</p>
+        </div>
+      </div>
+      <div class="chart-card">
+        <div class="chart-frame" id="hmmChart"></div>
+      </div>
+      <div class="prob-bars" id="hmmNarrative"></div>
+      <div class="heatmap-wrap" id="hmmTable" style="margin-top:16px;"></div>
+    </section>
+
+    <section class="panel">
+      <div class="panel-head">
+        <div>
+          <h2>FinBERT Sentiment Graphs and Analysis</h2>
+          <p>Sentiment score, positive/negative/neutral probabilities, relevance, and scored-news coverage for the selected pilot window.</p>
+        </div>
+      </div>
+      <div class="chart-card">
+        <div class="chart-frame" id="finbertChart"></div>
+      </div>
+      <div class="prob-bars" id="finbertNarrative"></div>
+      <div class="heatmap-wrap" id="finbertTable" style="margin-top:16px;"></div>
+    </section>
+
+    <section class="panel supporting-audit-panel">
       <div class="panel-head">
         <div>
           <h2>Feature-Family Status</h2>
@@ -687,7 +787,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       <div class="family-grid" id="familyGrid"></div>
     </section>
 
-    <section class="panel">
+    <section class="panel supporting-audit-panel">
       <div class="panel-head">
         <div>
           <h2>Completeness Heatmap</h2>
@@ -697,7 +797,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       <div class="heatmap-wrap" id="heatmapWrap"></div>
     </section>
 
-    <section class="panel">
+    <section class="panel supporting-audit-panel">
       <div class="panel-head">
         <div>
           <h2>Null-Rate Bars</h2>
@@ -716,7 +816,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       </div>
     </section>
 
-    <section class="panel">
+    <section class="panel supporting-audit-panel">
       <div class="panel-head">
         <div>
           <h2>Raw vs Computed Spot Checks</h2>
@@ -736,7 +836,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       </div>
     </section>
 
-    <section class="panel">
+    <section class="panel supporting-audit-panel">
       <div class="panel-head">
         <div>
           <h2>Formula Audit Cards</h2>
@@ -746,7 +846,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       <div class="cards" id="formulaCards"></div>
     </section>
 
-    <section class="panel">
+    <section class="panel supporting-audit-panel">
       <div class="panel-head">
         <div>
           <h2>Outlier Scatter and Table</h2>
@@ -916,6 +1016,10 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       }}
       renderMeta();
       renderSummary();
+      renderPilotDecision();
+      renderPilotEvidence();
+      renderHmmAnalysis();
+      renderFinbertAnalysis();
       renderFamilyPanels();
       renderHeatmap();
       renderNullRates();
@@ -938,33 +1042,210 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
 
     function renderSummary() {{
       const report = state.payload.report;
-      const summary = report.summary || {{}};
+      const analysis = state.payload.pilot_window_analysis || {{}};
+      const recommendation = analysis.recommendation || {{ status: "warn", label: "Review", message: "Pilot evidence is unavailable." }};
       const warnings = report.load_warnings || [];
       document.getElementById("summaryGrid").innerHTML = `
         <article class="stat-card">
-          <small>Run ID</small>
-          <strong class="mono">${{escapeHtml(report.run_id)}}</strong>
+          <small>Pilot Recommendation</small>
+          <strong><span class="badge ${{statusClass(recommendation.status)}}">${{escapeHtml(recommendation.label)}}</span></strong>
+        </article>
+        <article class="stat-card">
+          <small>HMM Status</small>
+          <strong><span class="badge ${{statusClass(analysis.hmm?.status)}}">${{upper(analysis.hmm?.status)}}</span></strong>
+        </article>
+        <article class="stat-card">
+          <small>FinBERT Status</small>
+          <strong><span class="badge ${{statusClass(analysis.finbert?.status)}}">${{upper(analysis.finbert?.status)}}</span></strong>
         </article>
         <article class="stat-card">
           <small>Rows Loaded</small>
           <strong>${{report.rows_loaded}}</strong>
         </article>
         <article class="stat-card">
-          <small>Family FAIL</small>
-          <strong>${{summary.family_fail_count || 0}}</strong>
-        </article>
-        <article class="stat-card">
-          <small>Spot Check FAIL</small>
-          <strong>${{summary.spot_check_fail_count || 0}}</strong>
-        </article>
-        <article class="stat-card">
-          <small>Outliers</small>
-          <strong>${{summary.outlier_count || 0}}</strong>
+          <small>Window</small>
+          <strong class="mono">${{escapeHtml(report.from_date)}} → ${{escapeHtml(report.to_date)}}</strong>
         </article>
         <article class="stat-card">
           <small>Load Warnings</small>
           <strong>${{warnings.length}}</strong>
         </article>
+      `;
+    }}
+
+    function renderPilotDecision() {{
+      const analysis = state.payload.pilot_window_analysis || {{}};
+      const recommendation = analysis.recommendation || {{ status: "warn", label: "Review", message: "Pilot evidence is unavailable." }};
+      document.getElementById("pilotDecision").innerHTML = `
+        <article class="decision-card">
+          <span class="badge ${{statusClass(recommendation.status)}}">${{escapeHtml(recommendation.label)}}</span>
+          <h3>Decision prompt</h3>
+          <p>${{escapeHtml(recommendation.message)}}</p>
+          <p class="mono">Accept only if both HMM regime quality and FinBERT sentiment evidence are acceptable for this pilot window.</p>
+        </article>
+        ${{decisionCard("HMM", analysis.hmm)}}
+        ${{decisionCard("FinBERT", analysis.finbert)}}
+      `;
+    }}
+
+    function decisionCard(title, section) {{
+      const checks = section?.checks || [];
+      const blockers = section?.blockers || [];
+      return `
+        <article class="decision-card">
+          <span class="badge ${{statusClass(section?.status)}}">${{upper(section?.status)}}</span>
+          <h3>${{escapeHtml(title)}}</h3>
+          <p>${{escapeHtml(section?.description || "")}}</p>
+          <div class="check-list">
+            ${{checks.map((check) => `
+              <div><span class="badge ${{statusClass(check.status)}}">${{upper(check.status)}}</span><span>${{escapeHtml(check.message)}}</span></div>
+            `).join("")}}
+          </div>
+          ${{blockers.length ? `
+            <h4 style="margin:16px 0 8px;">Blocked by missing artifacts</h4>
+            <div class="check-list">
+              ${{blockers.map((blocker) => `
+                <div>
+                  <span class="badge warn">WARN</span>
+                  <span class="mono">${{escapeHtml(blocker.artifact_key || "(missing key)")}}</span>
+                  <span>${{escapeHtml(blocker.reason || "Artifact unavailable.")}}</span>
+                </div>
+              `).join("")}}
+            </div>
+          ` : ""}}
+        </article>
+      `;
+    }}
+
+    function probabilityBars(values) {{
+      return Object.entries(values).map(([label, value]) => `
+        <div class="prob-row">
+          <span>${{escapeHtml(label)}}</span>
+          <span class="prob-track"><span class="prob-fill" style="width:${{clampPercent(value)}}%"></span></span>
+          <span class="mono">${{formatNumber(value)}}</span>
+        </div>
+      `).join("");
+    }}
+
+    function renderHmmAnalysis() {{
+      const section = state.payload.pilot_window_analysis?.hmm || {{ rows: [], checks: [] }};
+      const focusDate = selectedFocusDate();
+      const rows = (section.rows || []).filter((row) => !focusDate || row.date === focusDate);
+      document.getElementById("hmmChart").innerHTML = hmmChartMarkup(rows);
+      document.getElementById("hmmNarrative").innerHTML = section.checks.map((check) => `
+        <div><span class="badge ${{statusClass(check.status)}}">${{upper(check.status)}}</span> ${{escapeHtml(check.message)}}</div>
+      `).join("");
+      document.getElementById("hmmTable").innerHTML = tableMarkup(
+        ["Date", "Ticker", "Regime", "Confidence", "Bear", "Sideways", "Bull", "Status"],
+        rows.map((row) => [
+          row.date,
+          row.ticker,
+          row.regime_label || "n/a",
+          formatNumber(row.regime_confidence),
+          formatNumber(row.regime_prob_bear),
+          formatNumber(row.regime_prob_sideways),
+          formatNumber(row.regime_prob_bull),
+          `<span class="badge ${{statusClass(row.status)}}">${{upper(row.status)}}</span>`,
+        ]),
+      );
+    }}
+
+    function renderFinbertAnalysis() {{
+      const section = state.payload.pilot_window_analysis?.finbert || {{ rows: [], checks: [] }};
+      const focusDate = selectedFocusDate();
+      const rows = (section.rows || []).filter((row) => !focusDate || row.date === focusDate);
+      document.getElementById("finbertChart").innerHTML = finbertChartMarkup(rows);
+      document.getElementById("finbertNarrative").innerHTML = section.checks.map((check) => `
+        <div><span class="badge ${{statusClass(check.status)}}">${{upper(check.status)}}</span> ${{escapeHtml(check.message)}}</div>
+      `).join("");
+      document.getElementById("finbertTable").innerHTML = tableMarkup(
+        ["Date", "Ticker", "Score", "Positive", "Negative", "Neutral", "Articles", "Status"],
+        rows.map((row) => [
+          row.date,
+          row.ticker,
+          formatNumber(row.sentiment_score),
+          formatNumber(row.sentiment_positive),
+          formatNumber(row.sentiment_negative),
+          formatNumber(row.sentiment_neutral),
+          formatNumber(row.article_count),
+          `<span class="badge ${{statusClass(row.status)}}">${{upper(row.status)}}</span>`,
+        ]),
+      );
+    }}
+
+    function tableMarkup(headers, rows) {{
+      if (!rows.length) {{
+        return `<div class="loading">No rows match the selected focus date.</div>`;
+      }}
+      return `
+        <table>
+          <thead><tr>${{headers.map((header) => `<th>${{escapeHtml(header)}}</th>`).join("")}}</tr></thead>
+          <tbody>
+            ${{rows.map((row) => `<tr>${{row.map((cell) => `<td class="mono">${{String(cell).startsWith("<span") ? cell : escapeHtml(cell)}}</td>`).join("")}}</tr>`).join("")}}
+          </tbody>
+        </table>
+      `;
+    }}
+
+    function hmmChartMarkup(rows) {{
+      if (!rows.length) {{
+        return `<div class="loading">No HMM rows for the selected filters.</div>`;
+      }}
+      return multiLineChartMarkup(rows, [
+        ["regime_confidence", "confidence-line", "confidence"],
+        ["regime_prob_bear", "bear-line", "bear"],
+        ["regime_prob_sideways", "sideways-line", "sideways"],
+        ["regime_prob_bull", "sentiment-line", "bull"],
+      ], "HMM regime confidence and probabilities");
+    }}
+
+    function finbertChartMarkup(rows) {{
+      if (!rows.length) {{
+        return `<div class="loading">No FinBERT rows for the selected filters.</div>`;
+      }}
+      return multiLineChartMarkup(rows, [
+        ["sentiment_score", "sentiment-line", "score"],
+        ["sentiment_positive", "confidence-line", "positive"],
+        ["sentiment_negative", "bear-line", "negative"],
+        ["sentiment_neutral", "sideways-line", "neutral"],
+      ], "FinBERT sentiment score and class probabilities");
+    }}
+
+    function multiLineChartMarkup(rows, series, label) {{
+      const values = rows
+        .flatMap((row) => series.map(([key]) => toFiniteNumber(row[key])))
+        .filter((value) => value !== null);
+      if (!values.length) {{
+        return `<div class="loading">Selected rows do not contain numeric chart values.</div>`;
+      }}
+      const min = Math.min(...values, 0);
+      const max = Math.max(...values, 1);
+      const spread = Math.max(max - min, 1e-9);
+      const x = (index) => 40 + (index / Math.max(rows.length - 1, 1)) * 720;
+      const y = (value) => 230 - ((value - min) / spread) * 180;
+      const paths = series.map(([key, className, name]) => {{
+        const path = linePath(rows, key, x, y);
+        return `<path d="${{path}}" fill="none" class="${{className}}" stroke-width="3" stroke-linejoin="round"><title>${{escapeHtml(name)}}</title></path>`;
+      }}).join("");
+      const dots = rows.map((row, index) => series.map(([key, className, name]) => {{
+        const numeric = toFiniteNumber(row[key]);
+        return numeric === null ? "" : `<circle cx="${{x(index)}}" cy="${{y(numeric)}}" r="4" class="${{className}}" fill="currentColor"><title>${{escapeHtml(row.date)}} ${{escapeHtml(row.ticker)}} ${{escapeHtml(name)}}=${{formatNumber(numeric)}}</title></circle>`;
+      }}).join("")).join("");
+      const labels = rows.map((row, index) => `
+        <text x="${{x(index)}}" y="252" text-anchor="middle" font-size="11" fill="#556867">${{escapeHtml(row.date.slice(5))}}</text>
+      `).join("");
+      const legend = series.map(([, className, name]) => `<span class="mono"><svg width="12" height="8"><line x1="0" y1="4" x2="12" y2="4" class="${{className}}" stroke-width="3" /></svg> ${{escapeHtml(name)}}</span>`).join(" · ");
+      return `
+        <div class="legend" style="margin-bottom:8px;">${{legend}}</div>
+        <svg viewBox="0 0 800 260" role="img" aria-label="${{escapeAttr(label)}}">
+          <line x1="40" y1="230" x2="760" y2="230" stroke="rgba(36,62,56,0.18)" />
+          <line x1="40" y1="36" x2="40" y2="230" stroke="rgba(36,62,56,0.18)" />
+          ${{paths}}
+          ${{dots}}
+          ${{labels}}
+          <text x="40" y="24" font-size="12" fill="#556867">max ${{formatNumber(max)}}</text>
+          <text x="40" y="244" font-size="12" fill="#556867">min ${{formatNumber(min)}}</text>
+        </svg>
       `;
     }}
 

--- a/config/news_preprocessing.json
+++ b/config/news_preprocessing.json
@@ -1,5 +1,11 @@
 {
   "app_name": "ai-stock-trader-news-preprocessing",
   "r2_secret_name": "ai-stock-trader-r2",
-  "timeout_seconds": 1800
+  "timeout_seconds": 1800,
+  "news_preprocessing": {
+    "min_sentence_chars": 2,
+    "target_chunk_chars": 240,
+    "max_chunk_chars": 360,
+    "fallback_chunk_chars": 160
+  }
 }

--- a/core/features/dashboard_backend.py
+++ b/core/features/dashboard_backend.py
@@ -1,6 +1,7 @@
 """Read-only Layer 1 audit dashboard backend and local report helpers."""
 from __future__ import annotations
 
+import io
 import json
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
@@ -25,7 +26,10 @@ from core.features.market_spotchecks import (
     build_market_feature_spot_checks,
     summarize_market_feature_spot_checks,
 )
-from services.r2.paths import layer1_ticker_history_path
+from services.r2.paths import (
+    layer1_regime_path,
+    layer1_ticker_history_path,
+)
 from services.r2.writer import R2Writer
 
 DashboardStatus = Literal["pass", "warn", "fail"]
@@ -213,6 +217,7 @@ class Layer1AuditDashboardReport:
     outlier_records: list[dict[str, object]]
     spot_check_records: list[dict[str, object]]
     formula_audit_cards: list[dict[str, object]]
+    pilot_window_evidence: dict[str, object]
     summary: dict[str, int]
 
     def to_dict(self) -> dict[str, object]:
@@ -324,6 +329,12 @@ def build_layer1_audit_dashboard_report(
         records=sorted_rows,
         writer=active_writer,
     )
+    pilot_window_evidence = _build_pilot_window_evidence(
+        selection_rows=selection_rows,
+        requested_dates=(start_text, end_text),
+        requested_tickers=normalized_tickers,
+        writer=active_writer,
+    )
     summary = _build_dashboard_summary(
         selection_rows=selection_rows,
         coverage_by_date=coverage_by_date,
@@ -361,6 +372,7 @@ def build_layer1_audit_dashboard_report(
         outlier_records=[record.to_dict() for record in outlier_records],
         spot_check_records=[record.to_dict() for record in spot_check_records],
         formula_audit_cards=[card.to_dict() for card in formula_audit_cards],
+        pilot_window_evidence=pilot_window_evidence,
         summary=summary,
     )
 
@@ -478,6 +490,695 @@ def render_layer1_audit_dashboard_summary(report: Layer1AuditDashboardReport) ->
                 f"expected={item['expected_value']}"
             )
     return "\n".join(lines) + "\n"
+
+
+def _build_pilot_window_evidence(
+    *,
+    selection_rows: Sequence[DashboardSelectionRow],
+    requested_dates: Sequence[str],
+    requested_tickers: Sequence[str],
+    writer: R2Writer,
+) -> dict[str, object]:
+    """Load sentence/topic/regime evidence linked to the selected pilot window."""
+    selected_dates = _normalize_date_hints(requested_dates) or tuple(
+        sorted({row.date for row in selection_rows})
+    )
+    selected_tickers = _normalize_ticker_hints(requested_tickers) or tuple(
+        sorted({row.ticker for row in selection_rows})
+    )
+    return {
+        "selection": {
+            "dates": list(selected_dates),
+            "tickers": list(selected_tickers),
+        },
+        "sentiment": _build_sentiment_evidence(
+            writer=writer,
+            selected_dates=selected_dates,
+            selected_tickers=selected_tickers,
+        ),
+        "topics": _build_topic_evidence(
+            writer=writer,
+            selected_dates=selected_dates,
+            selected_tickers=selected_tickers,
+        ),
+        "regime": _build_regime_evidence(
+            writer=writer,
+            selected_dates=selected_dates,
+        ),
+    }
+
+
+def _build_sentiment_evidence(
+    *,
+    writer: R2Writer,
+    selected_dates: Sequence[str],
+    selected_tickers: Sequence[str],
+) -> dict[str, object]:
+    manifests = _stage_manifests(writer, "layer1_finbert_sentiment", selected_dates)
+    if not manifests:
+        return _missing_stage_evidence(
+            section="sentiment",
+            stage="layer1_finbert_sentiment",
+            selected_dates=selected_dates,
+            rows_key="rows",
+        )
+    rows: list[dict[str, object]] = []
+    blockers: list[dict[str, object]] = []
+    for manifest in manifests:
+        metadata_obj = manifest.get("metadata")
+        metadata = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+        scored_key = str(metadata.get("scored_news_key") or manifest.get("output_path") or "")
+        if not scored_key:
+            blockers.append(
+                {
+                    "section": "sentiment",
+                    "manifest_key": str(manifest.get("manifest_key", "")),
+                    "run_id": str(manifest.get("run_id", "")),
+                    "artifact_key": "",
+                    "reason": "Layer 1 FinBERT sentiment manifest does not reference a scored-news artifact.",
+                }
+            )
+            continue
+        if not writer.exists(scored_key):
+            blockers.append(
+                {
+                    "section": "sentiment",
+                    "manifest_key": str(manifest.get("manifest_key", "")),
+                    "run_id": str(manifest.get("run_id", "")),
+                    "artifact_key": scored_key,
+                    "reason": "Layer 1 FinBERT scored-news artifact is missing.",
+                }
+            )
+            continue
+        try:
+            frame = _read_parquet_frame(writer, scored_key)
+        except FileNotFoundError:
+            blockers.append(
+                {
+                    "section": "sentiment",
+                    "manifest_key": str(manifest.get("manifest_key", "")),
+                    "run_id": str(manifest.get("run_id", "")),
+                    "artifact_key": scored_key,
+                    "reason": "Layer 1 FinBERT scored-news artifact could not be read.",
+                }
+            )
+            continue
+        for record in _frame_records(frame):
+            if record.get("date") not in selected_dates or record.get("ticker") not in selected_tickers:
+                continue
+            rows.append(
+                {
+                    "manifest_key": manifest.get("manifest_key", ""),
+                    "run_id": str(manifest.get("run_id", "")),
+                    "scored_news_key": scored_key,
+                    "date": str(record.get("date", "")),
+                    "ticker": str(record.get("ticker", "")),
+                    "article_id": _optional_text(record.get("article_id")),
+                    "sentence_index": _optional_int(record.get("sentence_index")),
+                    "headline": _optional_text(record.get("headline")),
+                    "text": _optional_text(record.get("text")),
+                    "source": _optional_text(record.get("source")),
+                    "published_at": _optional_text(record.get("published_at")),
+                    "sentiment_positive": _optional_float(record.get("sentiment_positive")),
+                    "sentiment_negative": _optional_float(record.get("sentiment_negative")),
+                    "sentiment_neutral": _optional_float(record.get("sentiment_neutral")),
+                    "sentiment_score": _optional_float(record.get("sentiment_score")),
+                    "relevance_score": _optional_float(record.get("relevance_score")),
+                }
+            )
+    rows.sort(key=_topic_row_sort_key)
+    return {
+        "status": "pass" if rows else "warn",
+        "row_count": len(rows),
+        "manifest_count": len(manifests),
+        "manifest_keys": [str(item.get("manifest_key", "")) for item in manifests],
+        "blockers": blockers,
+        "missing_artifact_keys": [str(item.get("artifact_key", "")) for item in blockers if item.get("artifact_key")],
+        "rows": rows,
+    }
+
+
+def _build_topic_evidence(
+    *,
+    writer: R2Writer,
+    selected_dates: Sequence[str],
+    selected_tickers: Sequence[str],
+) -> dict[str, object]:
+    manifests = _stage_manifests(writer, "layer1_text_topics", selected_dates)
+    if not manifests:
+        return _missing_stage_topic_evidence(
+            stage="layer1_text_topics",
+            selected_dates=selected_dates,
+        )
+
+    label_rows: list[dict[str, object]] = []
+    feature_rows: list[dict[str, object]] = []
+    review_topics: list[dict[str, object]] = []
+    review_rows: list[dict[str, object]] = []
+    blockers: list[dict[str, object]] = []
+    review_statuses: list[str] = []
+
+    for manifest in manifests:
+        metadata_obj = manifest.get("metadata")
+        metadata = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+        label_key = str(metadata.get("topic_label_key") or manifest.get("output_path") or "")
+        feature_key = str(metadata.get("topic_feature_key") or "")
+        review_key = str(metadata.get("topic_review_key") or "")
+        loaded_review = False
+
+        if review_key:
+            if not writer.exists(review_key):
+                blockers.append(
+                    {
+                        "section": "topics",
+                        "manifest_key": str(manifest.get("manifest_key", "")),
+                        "run_id": str(manifest.get("run_id", "")),
+                        "artifact_key": review_key,
+                        "reason": "Layer 1 BERTopic review artifact is missing.",
+                    }
+                )
+            else:
+                try:
+                    review_payload = json.loads(writer.get_object(review_key).decode("utf-8"))
+                except FileNotFoundError:
+                    blockers.append(
+                        {
+                            "section": "topics",
+                            "manifest_key": str(manifest.get("manifest_key", "")),
+                            "run_id": str(manifest.get("run_id", "")),
+                            "artifact_key": review_key,
+                            "reason": "Layer 1 BERTopic review artifact could not be read.",
+                        }
+                    )
+                else:
+                    review_statuses.append(
+                        str(
+                            review_payload.get("diversity_status")
+                            or review_payload.get("status")
+                            or "warn"
+                        )
+                    )
+                    for topic in review_payload.get("topics", []):
+                        if isinstance(topic, Mapping):
+                            review_topics.append(dict(topic))
+                    for row in review_payload.get("rows", []):
+                        if not isinstance(row, Mapping):
+                            continue
+                        row_date = str(row.get("date", ""))
+                        row_ticker = str(row.get("ticker", ""))
+                        if row_date not in selected_dates or row_ticker not in selected_tickers:
+                            continue
+                        review_rows.append(dict(row))
+                    loaded_review = True
+
+        if not loaded_review and label_key:
+            if not writer.exists(label_key):
+                blockers.append(
+                    {
+                        "section": "topics",
+                        "manifest_key": str(manifest.get("manifest_key", "")),
+                        "run_id": str(manifest.get("run_id", "")),
+                        "artifact_key": label_key,
+                        "reason": "Layer 1 BERTopic label artifact is missing.",
+                    }
+                )
+            else:
+                try:
+                    frame = _read_parquet_frame(writer, label_key)
+                except FileNotFoundError:
+                    blockers.append(
+                        {
+                            "section": "topics",
+                            "manifest_key": str(manifest.get("manifest_key", "")),
+                            "run_id": str(manifest.get("run_id", "")),
+                            "artifact_key": label_key,
+                            "reason": "Layer 1 BERTopic label artifact could not be read.",
+                        }
+                    )
+                else:
+                    for record in _frame_records(frame):
+                        if record.get("date") not in selected_dates or record.get("ticker") not in selected_tickers:
+                            continue
+                        label_rows.append(
+                            {
+                                "manifest_key": manifest.get("manifest_key", ""),
+                                "run_id": str(manifest.get("run_id", "")),
+                                "topic_label_key": label_key,
+                                "date": str(record.get("date", "")),
+                                "ticker": str(record.get("ticker", "")),
+                                "article_id": _optional_text(record.get("article_id")),
+                                "sentence_index": _optional_int(record.get("sentence_index")),
+                                "text": _optional_text(record.get("text")),
+                                "embedding_cache_key": _optional_text(record.get("embedding_cache_key")),
+                                "topic_model": _optional_text(record.get("topic_model")),
+                                "topic_model_version": _optional_text(record.get("topic_model_version")),
+                                "topic_id": _optional_int(record.get("topic_id")),
+                                "topic_probability": _optional_float(record.get("topic_probability")),
+                            }
+                        )
+
+        if feature_key:
+            if not writer.exists(feature_key):
+                blockers.append(
+                    {
+                        "section": "topics",
+                        "manifest_key": str(manifest.get("manifest_key", "")),
+                        "run_id": str(manifest.get("run_id", "")),
+                        "artifact_key": feature_key,
+                        "reason": "Layer 1 BERTopic feature artifact is missing.",
+                    }
+                )
+                continue
+            try:
+                feature_frame = _read_parquet_frame(writer, feature_key)
+            except FileNotFoundError:
+                blockers.append(
+                    {
+                        "section": "topics",
+                        "manifest_key": str(manifest.get("manifest_key", "")),
+                        "run_id": str(manifest.get("run_id", "")),
+                        "artifact_key": feature_key,
+                        "reason": "Layer 1 BERTopic feature artifact could not be read.",
+                    }
+                )
+                continue
+            for record in _frame_records(feature_frame):
+                if record.get("date") not in selected_dates or record.get("ticker") not in selected_tickers:
+                    continue
+                features_obj = record.get("features")
+                features = features_obj if isinstance(features_obj, Mapping) else {}
+                feature_rows.append(
+                    {
+                        "manifest_key": manifest.get("manifest_key", ""),
+                        "run_id": str(manifest.get("run_id", "")),
+                        "topic_feature_key": feature_key,
+                        "date": str(record.get("date", "")),
+                        "ticker": str(record.get("ticker", "")),
+                        "nlp_sentence_count": _optional_int(features.get("nlp_sentence_count")),
+                        "nlp_topic_count": _optional_int(features.get("nlp_topic_count")),
+                        "nlp_dominant_topic_id": _optional_int(features.get("nlp_dominant_topic_id")),
+                        "nlp_dominant_topic_probability": _optional_float(
+                            features.get("nlp_dominant_topic_probability")
+                        ),
+                        "nlp_mean_topic_probability": _optional_float(
+                            features.get("nlp_mean_topic_probability")
+                        ),
+                    }
+                )
+
+    if review_rows:
+        rows = sorted(review_rows, key=_topic_row_sort_key)
+        topics = sorted(review_topics, key=_topic_summary_sort_key)
+        diversity_status = review_statuses[0] if review_statuses else str(
+            review_topics[0].get("diversity_status", "diverse") if review_topics else "warn"
+        )
+        status = "pass" if diversity_status == "diverse" else "warn"
+    else:
+        rows, topics = _topic_rows_from_label_rows(label_rows)
+        if topics:
+            dominant_share = max(
+                _optional_float(item.get("topic_row_share")) or 0.0 for item in topics
+            )
+            diversity_status = (
+                "diverse" if len(topics) > 1 and dominant_share < 0.85 else "insufficient_diversity"
+            )
+        else:
+            diversity_status = "insufficient_diversity"
+        status = "pass" if diversity_status == "diverse" else "warn"
+
+    feature_rows.sort(key=lambda item: (item["date"], item["ticker"]))
+    return {
+        "status": status,
+        "diversity_status": diversity_status,
+        "row_count": len(rows),
+        "feature_row_count": len(feature_rows),
+        "topic_count": len(topics),
+        "manifest_count": len(manifests),
+        "manifest_keys": [str(item.get("manifest_key", "")) for item in manifests],
+        "blockers": blockers,
+        "missing_artifact_keys": [
+            str(item.get("artifact_key", "")) for item in blockers if item.get("artifact_key")
+        ],
+        "rows": rows,
+        "topics": topics,
+        "feature_rows": feature_rows,
+    }
+
+
+def _topic_rows_from_label_rows(label_rows: Sequence[dict[str, object]]) -> tuple[list[dict[str, object]], list[dict[str, object]]]:
+    """Synthesize human-readable topic review payloads from label-only topic rows."""
+    if not label_rows:
+        return [], []
+
+    grouped: dict[int, list[dict[str, object]]] = defaultdict(list)
+    for row in label_rows:
+        grouped[_optional_int(row.get("topic_id")) or -1].append(row)
+
+    total_rows = len(label_rows)
+    summaries = {
+        topic_id: _topic_summary_from_label_group(topic_id, rows, total_rows)
+        for topic_id, rows in grouped.items()
+    }
+    ordered_topics = sorted(
+        summaries.values(),
+        key=lambda item: (-float(item.get("topic_row_share", 0.0)), int(item.get("topic_id", -1))),
+    )
+
+    rows: list[dict[str, object]] = []
+    for row in label_rows:
+        topic_id = _optional_int(row.get("topic_id")) or -1
+        summary = summaries[topic_id]
+        rows.append(
+            {
+                **row,
+                "topic_label": summary["topic_label"],
+                "topic_keywords": summary["topic_keywords"],
+                "topic_keyword_text": summary["topic_keyword_text"],
+                "topic_example_text": summary["topic_example_text"],
+                "topic_row_count": summary["topic_row_count"],
+                "topic_row_share": summary["topic_row_share"],
+            }
+        )
+    rows.sort(key=_topic_row_sort_key)
+    return rows, ordered_topics
+
+
+def _topic_summary_from_label_group(
+    topic_id: int,
+    rows: Sequence[dict[str, object]],
+    total_rows: int,
+) -> dict[str, object]:
+    """Return a fallback topic summary when no review artifact exists."""
+    example_text = next((str(row.get("text", "")).strip() for row in rows if str(row.get("text", "")).strip()), "")
+    row_count = len(rows)
+    row_share = row_count / max(1, total_rows)
+    topic_label = "Outlier / Unassigned" if topic_id < 0 else f"Topic {topic_id}"
+    return {
+        "topic_id": topic_id,
+        "topic_label": topic_label,
+        "topic_keywords": [],
+        "topic_keyword_text": "",
+        "topic_example_text": example_text,
+        "topic_example_texts": [example_text] if example_text else [],
+        "topic_row_count": row_count,
+        "topic_row_share": row_share,
+        "topic_probability_mean": _mean_optional_float(
+            [row.get("topic_probability") for row in rows]
+        ),
+        "topic_probability_max": _max_optional_float(
+            [row.get("topic_probability") for row in rows]
+        ),
+        "diversity_status": "insufficient_diversity" if len(rows) <= 1 else "diverse",
+    }
+
+
+def _mean_optional_float(values: Sequence[object]) -> float | None:
+    """Return the mean of nullable numeric values."""
+    numeric_values = [value for value in (_optional_float(item) for item in values) if value is not None]
+    if not numeric_values:
+        return None
+    return sum(numeric_values) / len(numeric_values)
+
+
+def _max_optional_float(values: Sequence[object]) -> float | None:
+    """Return the max of nullable numeric values."""
+    numeric_values = [value for value in (_optional_float(item) for item in values) if value is not None]
+    if not numeric_values:
+        return None
+    return max(numeric_values)
+
+
+def _topic_row_sort_key(row: Mapping[str, object]) -> tuple[str, str, int]:
+    """Return a stable sort key for topic review rows."""
+    sentence_index = _optional_int(row.get("sentence_index"))
+    return (
+        str(row.get("date", "")),
+        str(row.get("ticker", "")),
+        sentence_index if sentence_index is not None else -1,
+    )
+
+
+def _topic_summary_sort_key(summary: Mapping[str, object]) -> tuple[float, int]:
+    """Return a stable sort key for topic review summaries."""
+    topic_share = _optional_float(summary.get("topic_row_share")) or 0.0
+    topic_id = _optional_int(summary.get("topic_id")) or -1
+    return (-topic_share, topic_id)
+
+
+def _build_regime_evidence(
+    *,
+    writer: R2Writer,
+    selected_dates: Sequence[str],
+) -> dict[str, object]:
+    """Load regime evidence for the selected dates."""
+    manifests = _stage_manifests(writer, "layer1_5_regime", selected_dates)
+    if not manifests:
+        return _missing_stage_evidence(
+            section="regime",
+            stage="layer1_5_regime",
+            selected_dates=selected_dates,
+            rows_key="rows",
+        )
+    rows: list[dict[str, object]] = []
+    blockers: list[dict[str, object]] = []
+    for manifest in manifests:
+        metadata_obj = manifest.get("metadata")
+        metadata = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+        output_key = str(manifest.get("output_path") or metadata.get("output_path") or "")
+        if not output_key:
+            output_key = layer1_regime_path(str(manifest.get("run_id", "")))
+        if not writer.exists(output_key):
+            blockers.append(
+                {
+                    "section": "regime",
+                    "manifest_key": str(manifest.get("manifest_key", "")),
+                    "run_id": str(manifest.get("run_id", "")),
+                    "artifact_key": output_key,
+                    "reason": "Layer 1 regime artifact is missing.",
+                }
+            )
+            continue
+        try:
+            frame = _read_parquet_frame(writer, output_key)
+        except FileNotFoundError:
+            blockers.append(
+                {
+                    "section": "regime",
+                    "manifest_key": str(manifest.get("manifest_key", "")),
+                    "run_id": str(manifest.get("run_id", "")),
+                    "artifact_key": output_key,
+                    "reason": "Layer 1 regime artifact could not be read.",
+                }
+            )
+            continue
+        for record in _frame_records(frame):
+            if record.get("date") not in selected_dates:
+                continue
+            rows.append(
+                {
+                    "manifest_key": manifest.get("manifest_key", ""),
+                    "run_id": str(manifest.get("run_id", "")),
+                    "regime_key": output_key,
+                    "date": str(record.get("date", "")),
+                    "regime_label": _optional_text(record.get("regime_label")),
+                    "regime_confidence": _optional_float(record.get("regime_confidence")),
+                    "regime_prob_bear": _optional_float(record.get("regime_prob_bear")),
+                    "regime_prob_sideways": _optional_float(record.get("regime_prob_sideways")),
+                    "regime_prob_bull": _optional_float(record.get("regime_prob_bull")),
+                    "regime_readiness_status": _optional_text(record.get("regime_readiness_status")),
+                    "regime_readiness_reason": _optional_text(record.get("regime_readiness_reason")),
+                    "regime_probability_sum": _optional_float(record.get("regime_probability_sum")),
+                }
+            )
+    rows.sort(key=lambda item: item["date"])
+    return {
+        "status": "pass" if rows else "warn",
+        "row_count": len(rows),
+        "manifest_count": len(manifests),
+        "manifest_keys": [str(item.get("manifest_key", "")) for item in manifests],
+        "blockers": blockers,
+        "missing_artifact_keys": [str(item.get("artifact_key", "")) for item in blockers if item.get("artifact_key")],
+        "rows": rows,
+    }
+
+
+def _manifest_sort_key(item: Mapping[str, object]) -> tuple[str, str]:
+    metadata_obj = item.get("metadata")
+    metadata = metadata_obj if isinstance(metadata_obj, Mapping) else {}
+    return (str(metadata.get("as_of_date", "")), str(item.get("run_id", "")))
+
+
+def _stage_manifests(
+    writer: R2Writer,
+    stage: str,
+    selected_dates: Sequence[str],
+) -> list[dict[str, object]]:
+    manifest_prefix = f"artifacts/manifests/{stage}/"
+    manifests: list[dict[str, object]] = []
+    for manifest_key in writer.list_keys(manifest_prefix):
+        try:
+            manifest_data = json.loads(writer.get_object(manifest_key).decode("utf-8"))
+        except (FileNotFoundError, UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(manifest_data, dict):
+            continue
+        manifest: dict[str, object] = manifest_data
+        metadata_obj = manifest.get("metadata")
+        manifest_dates = {str(date) for date in selected_dates}
+        manifest_date = ""
+        if isinstance(metadata_obj, Mapping):
+            manifest_date = str(metadata_obj.get("as_of_date", "")).strip()
+            if not manifest_date:
+                inference_dates = metadata_obj.get("inference_dates")
+                if isinstance(inference_dates, Sequence) and inference_dates:
+                    manifest_date = str(inference_dates[0]).strip()
+        if manifest_date and manifest_dates and manifest_date not in manifest_dates:
+            continue
+        manifests.append({**manifest, "manifest_key": manifest_key})
+    manifests.sort(key=_manifest_sort_key)
+    return manifests
+
+
+def _missing_stage_evidence(
+    *,
+    section: str,
+    stage: str,
+    selected_dates: Sequence[str],
+    rows_key: str,
+) -> dict[str, object]:
+    date_text = ", ".join(selected_dates) if selected_dates else "the selected window"
+    stage_label = _stage_label(stage)
+    artifact_key = (
+        f"artifacts/manifests/{stage}/<as_of_date={selected_dates[0] if selected_dates else 'unknown'}>"
+    )
+    return {
+        "status": "warn",
+        "row_count": 0,
+        "manifest_count": 0,
+        "manifest_keys": [],
+        "blockers": [
+            {
+                "section": section,
+                "manifest_key": f"artifacts/manifests/{stage}/",
+                "run_id": "",
+                "artifact_key": artifact_key,
+                "reason": f"No {stage_label} manifest was published for {date_text}.",
+            }
+        ],
+        "missing_artifact_keys": [artifact_key],
+        rows_key: [],
+    }
+
+
+def _missing_stage_topic_evidence(
+    *,
+    stage: str,
+    selected_dates: Sequence[str],
+) -> dict[str, object]:
+    base = _missing_stage_evidence(
+        section="topics",
+        stage=stage,
+        selected_dates=selected_dates,
+        rows_key="rows",
+    )
+    base["feature_row_count"] = 0
+    base["feature_rows"] = []
+    return base
+
+
+def _stage_label(stage: str) -> str:
+    labels = {
+        "layer1_finbert_sentiment": "Layer 1 FinBERT sentiment",
+        "layer1_text_topics": "Layer 1 BERTopic",
+        "layer1_5_regime": "Layer 1 regime",
+    }
+    return labels.get(stage, stage)
+
+
+def _normalize_date_hints(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                _coerce_iso_date(str(value).strip())
+                for value in values
+                if str(value).strip()
+            }
+        )
+    )
+
+
+def _normalize_ticker_hints(values: Sequence[str]) -> tuple[str, ...]:
+    return tuple(
+        sorted(
+            {
+                str(value).strip().upper()
+                for value in values
+                if str(value).strip()
+            }
+        )
+    )
+
+
+def _read_parquet_frame(writer: R2Writer, key: str):
+    """Load a Parquet frame from object storage."""
+    pd = _require_pandas()
+    return pd.read_parquet(io.BytesIO(writer.get_object(key)))
+
+
+def _frame_records(frame) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for row in frame.to_dict(orient="records"):
+        records.append({name: _json_safe(value) for name, value in row.items()})
+    return records
+
+
+def _json_safe(value: object) -> object:
+    if value is None or isinstance(value, (str, bool)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, list):
+        return [_json_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if hasattr(value, "item"):
+        try:
+            value = getattr(value, "item")()
+        except Exception:
+            return str(value)
+        return _json_safe(value)
+    if isinstance(value, float):
+        if value != value or value in {float("inf"), float("-inf")}:  # NaN/inf
+            return None
+        return value
+    return value
+
+
+def _optional_int(value: object) -> int | None:
+    numeric = _optional_float(value)
+    if numeric is None:
+        return None
+    return int(numeric)
+
+
+def _optional_float(value: object) -> float | None:
+    return to_float_or_none(value)
+
+
+def _optional_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text if text else None
+
+
+def _require_pandas():
+    """Import pandas lazily when evidence loading needs Parquet access."""
+    try:
+        import pandas as pd
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError("pandas is required for pilot window evidence loading.") from exc
+    return pd
 
 
 def _build_heatmap_cells(

--- a/core/features/dashboard_ui.py
+++ b/core/features/dashboard_ui.py
@@ -5,6 +5,24 @@ import math
 from collections import defaultdict
 from collections.abc import Iterable, Mapping, Sequence
 
+HMM_FEATURE_NAMES = (
+    "regime_label",
+    "regime_confidence",
+    "regime_prob_bear",
+    "regime_prob_sideways",
+    "regime_prob_bull",
+)
+FINBERT_FEATURE_NAMES = (
+    "nlp_sentiment_score",
+    "nlp_sentiment_positive",
+    "nlp_sentiment_negative",
+    "nlp_sentiment_neutral",
+    "nlp_sentiment_strength",
+    "nlp_article_count",
+    "nlp_sentence_count",
+    "nlp_relevance_score",
+)
+
 
 def build_layer1_audit_dashboard_ui_payload(report: object) -> dict[str, object]:
     """Return a UI-oriented JSON payload derived from the backend dashboard report."""
@@ -16,6 +34,7 @@ def build_layer1_audit_dashboard_ui_payload(report: object) -> dict[str, object]
     outlier_records = _list_of_dicts(report_dict.get("outlier_records"))
     spot_check_records = _list_of_dicts(report_dict.get("spot_check_records"))
     formula_cards = _list_of_dicts(report_dict.get("formula_audit_cards"))
+    pilot_window_evidence = _pilot_window_evidence_payload(report_dict.get("pilot_window_evidence"))
     family_definitions = _list_of_dicts(report_dict.get("family_definitions"))
 
     family_order = {
@@ -238,6 +257,10 @@ def build_layer1_audit_dashboard_ui_payload(report: object) -> dict[str, object]
     ]
 
     date_index = {date_value: index for index, date_value in enumerate(dates)}
+    pilot_window_analysis = _build_pilot_window_analysis(
+        selection_rows=selection_rows,
+        heatmap_cells=heatmap_cells,
+    )
     outlier_points = [
         {
             "row_key": str(item.get("row_key", "")),
@@ -327,6 +350,7 @@ def build_layer1_audit_dashboard_ui_payload(report: object) -> dict[str, object]
             "default_outlier_feature": outlier_features[0] if outlier_features else "",
         },
         "family_panels": family_panels,
+        "pilot_window_analysis": pilot_window_analysis,
         "heatmap": {
             "columns": heatmap_columns,
             "rows": heatmap_rows,
@@ -340,10 +364,272 @@ def build_layer1_audit_dashboard_ui_payload(report: object) -> dict[str, object]
             "series": spot_check_series,
         },
         "formula_cards": normalized_formula_cards,
+        "pilot_window_evidence": pilot_window_evidence,
         "outliers": {
             "points": outlier_points,
         },
     }
+
+
+def _build_pilot_window_analysis(
+    *,
+    selection_rows: Sequence[Mapping[str, object]],
+    heatmap_cells: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    values_by_row: dict[str, dict[str, Mapping[str, object]]] = defaultdict(dict)
+    for cell in heatmap_cells:
+        row_key = str(cell.get("row_key", ""))
+        feature_name = str(cell.get("feature_name", ""))
+        if row_key and feature_name:
+            values_by_row[row_key][feature_name] = cell
+
+    hmm_rows: list[dict[str, object]] = []
+    finbert_rows: list[dict[str, object]] = []
+    for row in selection_rows:
+        row_key = str(row.get("row_key", ""))
+        date = str(row.get("date", ""))
+        ticker = str(row.get("ticker", ""))
+        features = values_by_row.get(row_key, {})
+        hmm_rows.append(_hmm_row_payload(row_key=row_key, date=date, ticker=ticker, features=features))
+        finbert_rows.append(
+            _finbert_row_payload(row_key=row_key, date=date, ticker=ticker, features=features)
+        )
+
+    hmm_status, hmm_checks = _hmm_status_and_checks(hmm_rows)
+    finbert_status, finbert_checks = _finbert_status_and_checks(finbert_rows)
+    recommendation = _pilot_recommendation(
+        hmm_status=hmm_status,
+        finbert_status=finbert_status,
+    )
+    return {
+        "recommendation": recommendation,
+        "hmm": {
+            "status": hmm_status,
+            "title": "HMM regime analysis",
+            "description": (
+                "Regime labels, confidence, and bear/sideways/bull probabilities from the "
+                "Layer 1.5 HMM output embedded in the selected Layer 1 histories."
+            ),
+            "checks": hmm_checks,
+            "rows": hmm_rows,
+        },
+        "finbert": {
+            "status": finbert_status,
+            "title": "FinBERT sentiment analysis",
+            "description": (
+                "Ticker-day sentiment score/probability evidence from the FinBERT Layer 1 "
+                "sentiment features for the selected pilot window."
+            ),
+            "checks": finbert_checks,
+            "rows": finbert_rows,
+        },
+    }
+
+
+def _hmm_row_payload(
+    *,
+    row_key: str,
+    date: str,
+    ticker: str,
+    features: Mapping[str, Mapping[str, object]],
+) -> dict[str, object]:
+    label = _feature_value(features, "regime_label")
+    probabilities = {
+        "bear": _feature_float(features, "regime_prob_bear"),
+        "sideways": _feature_float(features, "regime_prob_sideways"),
+        "bull": _feature_float(features, "regime_prob_bull"),
+    }
+    row_status = _worst_feature_status(features, HMM_FEATURE_NAMES)
+    probability_sum = sum(value for value in probabilities.values() if value is not None)
+    if row_status == "pass" and abs(probability_sum - 1.0) > 0.05:
+        row_status = "warn"
+    return {
+        "row_key": row_key,
+        "date": date,
+        "ticker": ticker,
+        "status": row_status,
+        "regime_label": str(label) if label is not None else None,
+        "regime_confidence": _feature_float(features, "regime_confidence"),
+        "regime_prob_bear": probabilities["bear"],
+        "regime_prob_sideways": probabilities["sideways"],
+        "regime_prob_bull": probabilities["bull"],
+        "probability_sum": probability_sum,
+    }
+
+
+def _finbert_row_payload(
+    *,
+    row_key: str,
+    date: str,
+    ticker: str,
+    features: Mapping[str, Mapping[str, object]],
+) -> dict[str, object]:
+    row_status = _worst_feature_status(features, FINBERT_FEATURE_NAMES)
+    article_count = _feature_float(features, "nlp_article_count")
+    sentence_count = _feature_float(features, "nlp_sentence_count")
+    if row_status == "pass" and not (article_count or sentence_count):
+        row_status = "warn"
+    return {
+        "row_key": row_key,
+        "date": date,
+        "ticker": ticker,
+        "status": row_status,
+        "sentiment_score": _feature_float(features, "nlp_sentiment_score"),
+        "sentiment_positive": _feature_float(features, "nlp_sentiment_positive"),
+        "sentiment_negative": _feature_float(features, "nlp_sentiment_negative"),
+        "sentiment_neutral": _feature_float(features, "nlp_sentiment_neutral"),
+        "sentiment_strength": _feature_float(features, "nlp_sentiment_strength"),
+        "article_count": article_count,
+        "sentence_count": sentence_count,
+        "relevance_score": _feature_float(features, "nlp_relevance_score"),
+    }
+
+
+def _hmm_status_and_checks(rows: Sequence[Mapping[str, object]]) -> tuple[str, list[dict[str, object]]]:
+    if not rows:
+        return "fail", [{"status": "fail", "message": "No Layer 1 rows were loaded for HMM analysis."}]
+    failed_rows = [row for row in rows if row.get("status") == "fail"]
+    confidence_values = [_optional_float(row.get("regime_confidence")) for row in rows]
+    confidence_values = [value for value in confidence_values if value is not None]
+    low_confidence_rows = [
+        row for row in rows if (_optional_float(row.get("regime_confidence")) or 0.0) < 0.5
+    ]
+    probability_drift_rows = [
+        row
+        for row in rows
+        if abs((_optional_float(row.get("probability_sum")) or 0.0) - 1.0) > 0.05
+    ]
+    checks = [
+        _check_payload(
+            failed_rows,
+            fail_message=f"{len(failed_rows)} rows have missing or invalid HMM regime fields.",
+            pass_message="All selected rows contain valid HMM regime labels and probabilities.",
+        ),
+        _check_payload(
+            low_confidence_rows,
+            fail_message=f"{len(low_confidence_rows)} rows have HMM confidence below 0.50.",
+            pass_message=(
+                f"Average HMM confidence is {_average(confidence_values):.3f}."
+                if confidence_values
+                else "HMM confidence values are not available."
+            ),
+            warning=True,
+        ),
+        _check_payload(
+            probability_drift_rows,
+            fail_message=f"{len(probability_drift_rows)} rows have HMM probabilities that do not sum near 1.0.",
+            pass_message="HMM probability triplets sum near 1.0 for the selected rows.",
+            warning=True,
+        ),
+    ]
+    return _status_from_checks(checks), checks
+
+
+def _finbert_status_and_checks(rows: Sequence[Mapping[str, object]]) -> tuple[str, list[dict[str, object]]]:
+    if not rows:
+        return "fail", [{"status": "fail", "message": "No Layer 1 rows were loaded for FinBERT analysis."}]
+    failed_rows = [row for row in rows if row.get("status") == "fail"]
+    sentiment_values = [_optional_float(row.get("sentiment_score")) for row in rows]
+    sentiment_values = [value for value in sentiment_values if value is not None]
+    scored_rows = [
+        row
+        for row in rows
+        if (_optional_float(row.get("article_count")) or 0.0) > 0
+        or (_optional_float(row.get("sentence_count")) or 0.0) > 0
+    ]
+    missing_sentiment_rows = [row for row in rows if _optional_float(row.get("sentiment_score")) is None]
+    checks = [
+        _check_payload(
+            failed_rows,
+            fail_message=f"{len(failed_rows)} rows have invalid FinBERT sentiment fields.",
+            pass_message="FinBERT sentiment probabilities and scores are within expected ranges.",
+        ),
+        _check_payload(
+            [row for row in rows if row not in scored_rows],
+            fail_message=f"{len(rows) - len(scored_rows)} rows have no scored FinBERT article/sentence evidence.",
+            pass_message=f"{len(scored_rows)} rows include scored FinBERT article or sentence evidence.",
+            warning=True,
+        ),
+        _check_payload(
+            missing_sentiment_rows,
+            fail_message=f"{len(missing_sentiment_rows)} rows are missing FinBERT sentiment_score.",
+            pass_message=(
+                f"Average FinBERT sentiment score is {_average(sentiment_values):.3f}."
+                if sentiment_values
+                else "FinBERT sentiment scores are not available."
+            ),
+            warning=True,
+        ),
+    ]
+    return _status_from_checks(checks), checks
+
+
+def _feature_value(features: Mapping[str, Mapping[str, object]], feature_name: str) -> object:
+    cell = features.get(feature_name)
+    if not cell:
+        return None
+    return cell.get("value")
+
+
+def _feature_float(features: Mapping[str, Mapping[str, object]], feature_name: str) -> float | None:
+    return _optional_float(_feature_value(features, feature_name))
+
+
+def _worst_feature_status(
+    features: Mapping[str, Mapping[str, object]],
+    feature_names: Sequence[str],
+) -> str:
+    statuses = [str(features.get(name, {}).get("status", "warn")) for name in feature_names]
+    if "fail" in statuses:
+        return "fail"
+    if "warn" in statuses:
+        return "warn"
+    return "pass"
+
+
+def _check_payload(
+    offenders: Sequence[Mapping[str, object]],
+    *,
+    fail_message: str,
+    pass_message: str,
+    warning: bool = False,
+) -> dict[str, object]:
+    if offenders:
+        return {"status": "warn" if warning else "fail", "message": fail_message}
+    return {"status": "pass", "message": pass_message}
+
+
+def _status_from_checks(checks: Sequence[Mapping[str, object]]) -> str:
+    statuses = [str(check.get("status", "warn")) for check in checks]
+    if "fail" in statuses:
+        return "fail"
+    if "warn" in statuses:
+        return "warn"
+    return "pass"
+
+
+def _pilot_recommendation(*, hmm_status: str, finbert_status: str) -> dict[str, str]:
+    if "fail" in {hmm_status, finbert_status}:
+        return {
+            "status": "fail",
+            "label": "Do not accept yet",
+            "message": "Rerun or repair the pilot window before starting the broad backfill.",
+        }
+    if "warn" in {hmm_status, finbert_status}:
+        return {
+            "status": "warn",
+            "label": "Human review needed",
+            "message": "Use the HMM and FinBERT evidence below to decide whether this pilot window is acceptable.",
+        }
+    return {
+        "status": "pass",
+        "label": "Pilot window looks acceptable",
+        "message": "HMM and FinBERT evidence is complete enough to accept the selected pilot window.",
+    }
+
+
+def _average(values: Sequence[float]) -> float:
+    return sum(values) / len(values) if values else 0.0
 
 
 def _coerce_report_dict(report: object) -> dict[str, object]:
@@ -387,12 +673,121 @@ def _heatmap_cell_payload(cell: Mapping[str, object]) -> dict[str, object]:
     }
 
 
+def _pilot_window_evidence_payload(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        return {
+            "selection": {"dates": [], "tickers": []},
+            "sentiment": {
+                "status": "warn",
+                "row_count": 0,
+                "manifest_count": 0,
+                "manifest_keys": [],
+                "rows": [],
+                "blockers": [],
+                "missing_artifact_keys": [],
+            },
+            "topics": {
+                "status": "warn",
+                "row_count": 0,
+                "feature_row_count": 0,
+                "manifest_count": 0,
+                "manifest_keys": [],
+                "rows": [],
+                "feature_rows": [],
+                "blockers": [],
+                "missing_artifact_keys": [],
+            },
+            "regime": {
+                "status": "warn",
+                "row_count": 0,
+                "manifest_count": 0,
+                "manifest_keys": [],
+                "rows": [],
+                "blockers": [],
+                "missing_artifact_keys": [],
+            },
+        }
+    selection = value.get("selection")
+    if isinstance(selection, Mapping):
+        selection_dates = _string_list(selection.get("dates"))
+        selection_tickers = _string_list(selection.get("tickers"))
+    else:
+        selection_dates = []
+        selection_tickers = []
+    return {
+        "selection": {"dates": selection_dates, "tickers": selection_tickers},
+        "sentiment": _normalize_evidence_section(value.get("sentiment")),
+        "topics": _normalize_topic_evidence_section(value.get("topics")),
+        "regime": _normalize_evidence_section(value.get("regime")),
+    }
+
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes)):
+        return []
+    return [str(item) for item in value if str(item)]
+
+
+def _normalize_evidence_section(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        return {
+            "status": "warn",
+            "row_count": 0,
+            "manifest_count": 0,
+            "manifest_keys": [],
+            "blockers": [],
+            "missing_artifact_keys": [],
+            "rows": [],
+        }
+    return {
+        "status": str(value.get("status", "warn")),
+        "row_count": int(value.get("row_count", 0)),
+        "manifest_count": int(value.get("manifest_count", 0)),
+        "manifest_keys": _string_list(value.get("manifest_keys")),
+        "blockers": _list_of_dicts(value.get("blockers")),
+        "missing_artifact_keys": _string_list(value.get("missing_artifact_keys")),
+        "rows": _list_of_dicts(value.get("rows")),
+    }
+
+
+def _normalize_topic_evidence_section(value: object) -> dict[str, object]:
+    if not isinstance(value, Mapping):
+        return {
+            "status": "warn",
+            "row_count": 0,
+            "feature_row_count": 0,
+            "manifest_count": 0,
+            "manifest_keys": [],
+            "blockers": [],
+            "missing_artifact_keys": [],
+            "rows": [],
+            "feature_rows": [],
+        }
+    return {
+        "status": str(value.get("status", "warn")),
+        "row_count": _safe_int(value.get("row_count", 0)),
+        "feature_row_count": _safe_int(value.get("feature_row_count", 0)),
+        "manifest_count": _safe_int(value.get("manifest_count", 0)),
+        "manifest_keys": _string_list(value.get("manifest_keys")),
+        "blockers": _list_of_dicts(value.get("blockers")),
+        "missing_artifact_keys": _string_list(value.get("missing_artifact_keys")),
+        "rows": _list_of_dicts(value.get("rows")),
+        "feature_rows": _list_of_dicts(value.get("feature_rows")),
+    }
+
+
+def _safe_int(value: object) -> int:
+    numeric = _optional_float(value)
+    return 0 if numeric is None else int(numeric)
+
+
 def _default_spot_check_feature(*, feature_options: Sequence[Mapping[str, object]]) -> str:
     for item in feature_options:
-        if int(item.get("fail_count", 0)) > 0:
+        if _safe_int(item.get("fail_count", 0)) > 0:
             return str(item.get("feature_name", ""))
     for item in feature_options:
-        if int(item.get("warn_count", 0)) > 0:
+        if _safe_int(item.get("warn_count", 0)) > 0:
             return str(item.get("feature_name", ""))
     return str(feature_options[0].get("feature_name", "")) if feature_options else ""
 

--- a/core/features/news_preprocessing.py
+++ b/core/features/news_preprocessing.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import html
 import math
 import re
 from collections.abc import Iterable, Mapping, Sequence
@@ -15,6 +16,26 @@ from services.wikipedia.sp500_universe import canonicalize_ticker
 
 _SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[\"'A-Z0-9])")
 _WHITESPACE = re.compile(r"\s+")
+_HTML_BLOCK_BREAK = re.compile(
+    r"(?is)</?(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|br|hr)[^>]*>"
+)
+_HTML_NOISE_BLOCKS = (
+    re.compile(r"(?is)<script\b[^>]*>.*?</script>"),
+    re.compile(r"(?is)<style\b[^>]*>.*?</style>"),
+    re.compile(r"(?is)<noscript\b[^>]*>.*?</noscript>"),
+    re.compile(r"(?is)<iframe\b[^>]*>.*?</iframe>"),
+    re.compile(
+        r"(?is)<blockquote\b[^>]*class=[\"'][^\"']*"
+        r"(?:twitter-tweet|instagram-media|tiktok-embed|reddit-embed|embed|widget)"
+        r"[^\"']*[\"'][^>]*>.*?</blockquote>"
+    ),
+    re.compile(
+        r"(?is)<div\b[^>]*class=[\"'][^\"']*"
+        r"(?:widget|embed|promo|related|newsletter|ad|advert|sponsored|social-embed)"
+        r"[^\"']*[\"'][^>]*>.*?</div>"
+    ),
+)
+_HTML_TAG = re.compile(r"<[^>]+>")
 
 
 @dataclass(frozen=True)
@@ -59,7 +80,7 @@ def preprocess_news_articles(
             continue
 
         article_id = _article_id(article)
-        headline = _optional_text(article.get("headline"))
+        headline = _clean_article_text(article.get("headline"))
         source = _optional_text(article.get("source") or article.get("author"))
         url = _optional_text(article.get("url"))
         published_at = _published_at(article)
@@ -203,7 +224,7 @@ def _normalize_allowed_tickers(tickers: Iterable[str] | None) -> set[str] | None
 
 def _sentences_from_text(value: Any, *, settings: NewsPreprocessingConfig) -> list[str]:
     """Split and normalize one raw text field into sentence strings."""
-    text = _optional_text(value)
+    text = _clean_article_text(value)
     if text is None:
         return []
     normalized = _WHITESPACE.sub(" ", text).strip()
@@ -259,6 +280,21 @@ def _optional_text(value: Any) -> str | None:
     text = str(value).strip()
     return text or None
 
+
+def _clean_article_text(value: Any) -> str | None:
+    """Return readable plain text from raw provider HTML or text content."""
+    text = _optional_text(value)
+    if text is None:
+        return None
+    cleaned = html.unescape(text)
+    for pattern in _HTML_NOISE_BLOCKS:
+        cleaned = pattern.sub(" ", cleaned)
+    cleaned = _HTML_BLOCK_BREAK.sub(" ", cleaned)
+    cleaned = _HTML_TAG.sub(" ", cleaned)
+    cleaned = cleaned.replace("\xa0", " ")
+    cleaned = _WHITESPACE.sub(" ", cleaned).strip()
+    cleaned = re.sub(r"\s+([,.;:!?])", r"\1", cleaned)
+    return cleaned or None
 
 def _optional_datetime(value: Any) -> datetime | None:
     """Return an ISO timestamp parsed by Pydantic, or None when missing."""

--- a/core/features/news_preprocessing.py
+++ b/core/features/news_preprocessing.py
@@ -11,14 +11,18 @@ from datetime import date as Date
 from datetime import datetime
 from typing import Any
 
+from pydantic import TypeAdapter
+
 from core.contracts.schemas import NewsSentimentRecord
 from services.wikipedia.sp500_universe import canonicalize_ticker
 
-_SENTENCE_BOUNDARY = re.compile(r"(?<=[.!?])\s+(?=[\"'A-Z0-9])")
-_WHITESPACE = re.compile(r"\s+")
-_HTML_BLOCK_BREAK = re.compile(
-    r"(?is)</?(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|br|hr)[^>]*>"
+_HTML_BLOCK_BREAK_START = re.compile(
+    r"(?is)<\s*(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|ul|ol)\b[^>]*>"
 )
+_HTML_BLOCK_BREAK_END = re.compile(
+    r"(?is)</\s*(?:p|div|li|tr|td|th|h[1-6]|section|article|header|footer|blockquote|ul|ol)\b[^>]*>"
+)
+_HTML_LINE_BREAK = re.compile(r"(?is)<\s*(?:br|hr)\b[^>]*>")
 _HTML_NOISE_BLOCKS = (
     re.compile(r"(?is)<script\b[^>]*>.*?</script>"),
     re.compile(r"(?is)<style\b[^>]*>.*?</style>"),
@@ -36,13 +40,43 @@ _HTML_NOISE_BLOCKS = (
     ),
 )
 _HTML_TAG = re.compile(r"<[^>]+>")
+_INLINE_WHITESPACE = re.compile(r"[ \t\f\v]+")
+_PARAGRAPH_BREAK = re.compile(r"\n+")
+_SENTENCE_BOUNDARY = re.compile(r'([.!?]+(?:["\')\]]+)?)\s+')
+_ABBREVIATION_TOKENS = {
+    "a.m",
+    "co",
+    "corp",
+    "dr",
+    "e.u",
+    "fig",
+    "inc",
+    "jr",
+    "ltd",
+    "mr",
+    "mrs",
+    "ms",
+    "mt",
+    "no",
+    "p.m",
+    "prof",
+    "sr",
+    "st",
+    "u.k",
+    "u.s",
+    "vs",
+}
+_DATETIME_ADAPTER = TypeAdapter(datetime)
 
 
 @dataclass(frozen=True)
 class NewsPreprocessingConfig:
-    """Text and filtering settings for sentence-level news preprocessing."""
+    """Text splitting and filtering settings for sentence-level news preprocessing."""
 
     min_sentence_chars: int = 2
+    target_chunk_chars: int = 240
+    max_chunk_chars: int = 360
+    fallback_chunk_chars: int = 160
     include_headline: bool = True
     include_summary: bool = True
     include_content: bool = True
@@ -51,6 +85,16 @@ class NewsPreprocessingConfig:
         """Validate text preprocessing settings."""
         if self.min_sentence_chars <= 0:
             raise ValueError("min_sentence_chars must be positive")
+        if self.target_chunk_chars <= 0:
+            raise ValueError("target_chunk_chars must be positive")
+        if self.max_chunk_chars <= 0:
+            raise ValueError("max_chunk_chars must be positive")
+        if self.fallback_chunk_chars <= 0:
+            raise ValueError("fallback_chunk_chars must be positive")
+        if self.target_chunk_chars > self.max_chunk_chars:
+            raise ValueError("target_chunk_chars must be <= max_chunk_chars")
+        if self.fallback_chunk_chars > self.target_chunk_chars:
+            raise ValueError("fallback_chunk_chars must be <= target_chunk_chars")
         if not (self.include_headline or self.include_summary or self.include_content):
             raise ValueError("At least one text field must be included")
 
@@ -62,7 +106,7 @@ def preprocess_news_articles(
     point_in_time_tickers: Iterable[str] | None,
     config: NewsPreprocessingConfig | None = None,
 ) -> list[NewsSentimentRecord]:
-    """Convert raw Layer 0 news articles into sentence-level sentiment records."""
+    """Convert raw Layer 0 news articles into sentence/chunk sentiment records."""
     normalized_date = _validate_date(as_of_date)
     settings = config or NewsPreprocessingConfig()
     allowed_tickers = _normalize_allowed_tickers(point_in_time_tickers)
@@ -75,8 +119,8 @@ def preprocess_news_articles(
         if not article_tickers:
             continue
 
-        sentences = split_article_sentences(article, config=settings)
-        if not sentences:
+        chunks = split_article_sentences(article, config=settings)
+        if not chunks:
             continue
 
         article_id = _article_id(article)
@@ -85,14 +129,14 @@ def preprocess_news_articles(
         url = _optional_text(article.get("url"))
         published_at = _published_at(article)
 
-        for sentence_index, sentence in enumerate(sentences):
+        for sentence_index, chunk in enumerate(chunks):
             for ticker in article_tickers:
                 records.append(
                     NewsSentimentRecord(
                         date=normalized_date,
                         ticker=ticker,
                         headline=headline,
-                        text=sentence,
+                        text=chunk,
                         article_id=article_id,
                         sentence_index=sentence_index,
                         source=source,
@@ -117,7 +161,7 @@ def split_article_sentences(
     *,
     config: NewsPreprocessingConfig | None = None,
 ) -> list[str]:
-    """Return normalized article sentences from configured raw text fields."""
+    """Return normalized article sentences/chunks from configured raw text fields."""
     settings = config or NewsPreprocessingConfig()
     chunks: list[str] = []
     if settings.include_headline:
@@ -223,17 +267,127 @@ def _normalize_allowed_tickers(tickers: Iterable[str] | None) -> set[str] | None
 
 
 def _sentences_from_text(value: Any, *, settings: NewsPreprocessingConfig) -> list[str]:
-    """Split and normalize one raw text field into sentence strings."""
+    """Split and normalize one raw text field into bounded sentence/chunk strings."""
     text = _clean_article_text(value)
     if text is None:
         return []
-    normalized = _WHITESPACE.sub(" ", text).strip()
-    sentences = [
-        sentence.strip(" \t\r\n")
-        for sentence in _SENTENCE_BOUNDARY.split(normalized)
-        if len(sentence.strip(" \t\r\n")) >= settings.min_sentence_chars
-    ]
-    return sentences
+
+    chunks: list[str] = []
+    for block in _split_text_blocks(text):
+        block_chunks = _split_block_into_chunks(block, settings=settings)
+        chunks.extend(block_chunks)
+    return chunks
+
+
+def _split_text_blocks(text: str) -> list[str]:
+    """Return paragraph- and list-level blocks from cleaned article text."""
+    blocks: list[str] = []
+    for raw_block in _PARAGRAPH_BREAK.split(text):
+        block = _INLINE_WHITESPACE.sub(" ", raw_block).strip()
+        if block:
+            blocks.append(block)
+    return blocks
+
+
+def _split_block_into_chunks(
+    block: str,
+    *,
+    settings: NewsPreprocessingConfig,
+) -> list[str]:
+    """Split one paragraph-like block into bounded chunks."""
+    sentence_like = _split_sentence_candidates(block, settings=settings)
+    chunks: list[str] = []
+    for sentence in sentence_like:
+        if len(sentence) > settings.max_chunk_chars:
+            chunks.extend(_split_oversized_text(sentence, settings=settings))
+        else:
+            chunks.append(sentence)
+    return chunks
+
+
+def _split_sentence_candidates(
+    text: str,
+    *,
+    settings: NewsPreprocessingConfig,
+) -> list[str]:
+    """Split a cleaned block into sentence-like units while honoring abbreviations."""
+    sentences: list[str] = []
+    start = 0
+    for match in _SENTENCE_BOUNDARY.finditer(text):
+        boundary_end = match.end(1)
+        candidate = text[start:boundary_end].strip()
+        remainder = text[match.end():]
+        if not candidate:
+            start = match.end()
+            continue
+        if _should_split_sentence(candidate, remainder):
+            sentences.append(candidate)
+            start = match.end()
+    tail = text[start:].strip()
+    if tail:
+        sentences.append(tail)
+    return [sentence for sentence in sentences if len(sentence) >= settings.min_sentence_chars]
+
+
+def _should_split_sentence(candidate: str, remainder: str) -> bool:
+    """Return True when a punctuation boundary should end the current sentence."""
+    if not remainder.strip():
+        return True
+    return not _looks_like_abbreviation(candidate)
+
+
+def _looks_like_abbreviation(text: str) -> bool:
+    """Return True when trailing punctuation belongs to a known abbreviation."""
+    stripped = text.rstrip('"\'”’)]}')
+    if not stripped.endswith((".", "!", "?")):
+        return False
+    last_token = stripped.split()[-1]
+    normalized = re.sub(r"[^A-Za-z0-9]", "", last_token).lower()
+    if normalized in _ABBREVIATION_TOKENS:
+        return True
+    if re.fullmatch(r"(?:[A-Za-z]\.){2,}", last_token):
+        return True
+    return False
+
+
+def _split_oversized_text(text: str, *, settings: NewsPreprocessingConfig) -> list[str]:
+    """Split an oversized sentence into readable fallback chunks."""
+    if len(text) <= settings.max_chunk_chars:
+        return [text]
+
+    words = text.split()
+    if len(words) <= 1:
+        return _split_single_token(text, limit=settings.fallback_chunk_chars)
+
+    chunks: list[str] = []
+    current_words: list[str] = []
+    current_length = 0
+    for word in words:
+        candidate_length = len(word) if not current_words else current_length + 1 + len(word)
+        if current_words and candidate_length > settings.target_chunk_chars:
+            chunks.append(" ".join(current_words))
+            current_words = [word]
+            current_length = len(word)
+            continue
+        current_words.append(word)
+        current_length = candidate_length
+
+    if current_words:
+        chunks.append(" ".join(current_words))
+
+    if all(len(chunk) <= settings.max_chunk_chars for chunk in chunks):
+        return chunks
+    return [chunk for piece in chunks for chunk in _split_single_token(piece, limit=settings.fallback_chunk_chars)]
+
+
+def _split_single_token(text: str, *, limit: int) -> list[str]:
+    """Split a long token into fixed-size pieces without dropping text."""
+    if len(text) <= limit:
+        return [text]
+    pieces: list[str] = []
+    for start in range(0, len(text), limit):
+        pieces.append(text[start : start + limit])
+    return pieces
 
 
 def _dedupe_preserving_order(values: Sequence[str]) -> list[str]:
@@ -286,22 +440,30 @@ def _clean_article_text(value: Any) -> str | None:
     text = _optional_text(value)
     if text is None:
         return None
+
     cleaned = html.unescape(text)
     for pattern in _HTML_NOISE_BLOCKS:
         cleaned = pattern.sub(" ", cleaned)
-    cleaned = _HTML_BLOCK_BREAK.sub(" ", cleaned)
+    cleaned = _HTML_LINE_BREAK.sub("\n", cleaned)
+    cleaned = _HTML_BLOCK_BREAK_START.sub("\n", cleaned)
+    cleaned = _HTML_BLOCK_BREAK_END.sub("\n", cleaned)
     cleaned = _HTML_TAG.sub(" ", cleaned)
     cleaned = cleaned.replace("\xa0", " ")
-    cleaned = _WHITESPACE.sub(" ", cleaned).strip()
+    cleaned = re.sub(r"[ \t\f\v]*\n[ \t\f\v]*", "\n", cleaned)
+    cleaned = re.sub(r"\n{3,}", "\n\n", cleaned)
+    cleaned = _INLINE_WHITESPACE.sub(" ", cleaned)
+    cleaned = re.sub(r" *\n *", "\n", cleaned)
     cleaned = re.sub(r"\s+([,.;:!?])", r"\1", cleaned)
+    cleaned = cleaned.strip(" \n\t\r")
     return cleaned or None
+
 
 def _optional_datetime(value: Any) -> datetime | None:
     """Return an ISO timestamp parsed by Pydantic, or None when missing."""
     text = _optional_text(value)
     if text is None:
         return None
-    return NewsSentimentRecord(date="2000-01-01", ticker="SPY", published_at=text).published_at
+    return _DATETIME_ADAPTER.validate_python(text)
 
 
 def _optional_float(value: Any) -> float | None:

--- a/core/features/text_topics.py
+++ b/core/features/text_topics.py
@@ -5,6 +5,8 @@ import hashlib
 import importlib
 import json
 import math
+import re
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -42,6 +44,44 @@ TOPIC_FEATURE_COLUMNS: tuple[str, ...] = (
     "nlp_dominant_topic_probability",
     "nlp_mean_topic_probability",
 )
+
+_TOPIC_FALLBACK_STOPWORDS = {
+    "about",
+    "after",
+    "also",
+    "amid",
+    "analyst",
+    "analysts",
+    "and",
+    "are",
+    "beats",
+    "because",
+    "before",
+    "company",
+    "companies",
+    "days",
+    "earnings",
+    "from",
+    "guidance",
+    "higher",
+    "improved",
+    "into",
+    "lower",
+    "management",
+    "market",
+    "moves",
+    "news",
+    "quarter",
+    "results",
+    "sales",
+    "shares",
+    "stocks",
+    "strong",
+    "the",
+    "this",
+    "with",
+    "year",
+}
 
 
 class SentenceEmbedder(Protocol):
@@ -102,6 +142,7 @@ class TextTopicResult:
     embeddings: Any
     topic_labels: Any
     feature_records: list[FeatureRecord]
+    topic_review: dict[str, object]
 
 
 def compute_text_topics(
@@ -135,6 +176,7 @@ def compute_text_topics(
         embeddings=embeddings,
         topic_labels=topic_labels,
         feature_records=topic_labels_to_feature_records(topic_labels),
+        topic_review=build_topic_review_payload(topic_labels, topic_labeler=topic_labeler),
     )
 
 
@@ -318,6 +360,97 @@ def topic_labels_to_feature_records(topic_labels: Any) -> list[FeatureRecord]:
     return records
 
 
+def build_topic_review_payload(topic_labels: Any, *, topic_labeler: Any | None = None) -> dict[str, object]:
+    """Build a human-readable topic review payload from topic label rows."""
+    if len(topic_labels) == 0:
+        return {
+            "status": "warn",
+            "diversity_status": "insufficient_diversity",
+            "diversity_reason": "No topic rows were produced.",
+            "row_count": 0,
+            "topic_count": 0,
+            "dominant_topic_id": None,
+            "dominant_topic_share": None,
+            "topics": [],
+            "rows": [],
+        }
+
+    _require_columns(topic_labels, TOPIC_LABEL_COLUMNS)
+    frame = topic_labels.copy()
+    frame["topic_id"] = frame["topic_id"].map(int)
+    frame["topic_probability"] = frame["topic_probability"].map(float)
+
+    topic_info = _topic_info_lookup(topic_labeler)
+    topic_summaries: list[dict[str, object]] = []
+    row_payloads: list[dict[str, object]] = []
+    valid_rows = frame[frame["topic_id"] >= 0].copy()
+    invalid_rows = frame[frame["topic_id"] < 0].copy()
+    topic_count = int(valid_rows["topic_id"].nunique()) if len(valid_rows) else 0
+
+    for topic_id, group in valid_rows.groupby("topic_id", sort=True):
+        summary = _summarize_topic_group(
+            group,
+            topic_id=int(topic_id),
+            topic_info=topic_info,
+            topic_labeler=topic_labeler,
+            total_rows=len(frame),
+        )
+        topic_summaries.append(summary)
+        row_payloads.extend(_topic_rows_with_summary(group, summary))
+
+    if len(invalid_rows):
+        invalid_summary = _summarize_topic_group(
+            invalid_rows,
+            topic_id=-1,
+            topic_info=topic_info,
+            topic_labeler=topic_labeler,
+            total_rows=len(frame),
+        )
+        invalid_summary["topic_label"] = "Outlier / Unassigned"
+        invalid_summary["topic_keywords"] = []
+        row_payloads.extend(_topic_rows_with_summary(invalid_rows, invalid_summary))
+
+    dominant_topic_id: int | None = None
+    dominant_topic_share: float | None = None
+    diversity_reason = "No non-outlier topics were detected."
+    diversity_status = "insufficient_diversity"
+    if topic_summaries:
+        dominant = max(topic_summaries, key=lambda item: float(item["topic_row_share"]))
+        dominant_topic_id = int(dominant["topic_id"])
+        dominant_topic_share = float(dominant["topic_row_share"])
+        if len(topic_summaries) == 1:
+            diversity_reason = (
+                f"Only one topic was detected across {len(valid_rows)} rows."
+            )
+            diversity_status = "insufficient_diversity"
+        elif dominant_topic_share >= 0.85:
+            diversity_reason = (
+                f"One topic covers {dominant_topic_share:.0%} of rows, so the corpus is too "
+                "concentrated for a varied review sample."
+            )
+            diversity_status = "concentrated"
+        else:
+            diversity_reason = (
+                f"Detected {len(topic_summaries)} topics across {len(valid_rows)} rows."
+            )
+            diversity_status = "diverse"
+
+    status = "pass" if diversity_status == "diverse" else "warn"
+    row_payloads.sort(key=_topic_row_sort_key)
+    topic_summaries.sort(key=_topic_summary_sort_key)
+    return {
+        "status": status,
+        "diversity_status": diversity_status,
+        "diversity_reason": diversity_reason,
+        "row_count": int(len(frame)),
+        "topic_count": topic_count,
+        "dominant_topic_id": dominant_topic_id,
+        "dominant_topic_share": dominant_topic_share,
+        "topics": topic_summaries,
+        "rows": row_payloads,
+    }
+
+
 def feature_records_to_frame(records: Sequence[FeatureRecord]) -> Any:
     """Serialize FeatureRecord rows into a Parquet-ready DataFrame."""
     pd = _require_pandas()
@@ -491,6 +624,276 @@ def _require_columns(frame: Any, columns: Sequence[str]) -> None:
     missing = sorted(set(columns) - set(frame.columns))
     if missing:
         raise ValueError(f"Topic label frame missing required columns: {missing}")
+
+
+def _topic_info_lookup(topic_labeler: Any | None) -> dict[int, str]:
+    """Return optional BERTopic topic names keyed by topic id."""
+    if topic_labeler is None or not hasattr(topic_labeler, "get_topic_info"):
+        return {}
+
+    try:
+        topic_info = topic_labeler.get_topic_info()
+    except Exception:  # pragma: no cover - defensive against optional BERTopic APIs
+        return {}
+
+    pd = _require_pandas()
+    if not isinstance(topic_info, pd.DataFrame) or "Topic" not in topic_info.columns:
+        return {}
+
+    name_column = None
+    for candidate in ("Name", "Representation", "TopicName"):
+        if candidate in topic_info.columns:
+            name_column = candidate
+            break
+    if name_column is None:
+        return {}
+
+    names: dict[int, str] = {}
+    for _, row in topic_info.iterrows():
+        topic_value = row.get("Topic")
+        if topic_value is None:
+            continue
+        try:
+            topic_id = int(topic_value)
+        except (TypeError, ValueError):
+            continue
+        name = str(row.get(name_column, "")).strip()
+        if name:
+            names[topic_id] = name
+    return names
+
+
+def _summarize_topic_group(
+    group: Any,
+    *,
+    topic_id: int,
+    topic_info: dict[int, str],
+    topic_labeler: Any | None,
+    total_rows: int,
+) -> dict[str, object]:
+    """Summarize one topic group for review output."""
+    texts = [str(text or "") for text in group["text"].tolist() if str(text or "").strip()]
+    keywords = _topic_keywords_for_group(
+        topic_id=topic_id,
+        texts=texts,
+        topic_labeler=topic_labeler,
+        topic_name=topic_info.get(topic_id),
+    )
+    representative_row = group.copy()
+    representative_row["_sort_text_length"] = representative_row["text"].map(
+        lambda value: len(str(value or ""))
+    )
+    representative_row = representative_row.sort_values(
+        by=["topic_probability", "_sort_text_length", "sentence_index", "article_id"],
+        ascending=[False, False, True, True],
+        kind="mergesort",
+    )
+    primary_text = str(representative_row.iloc[0]["text"] or "") if len(representative_row) else ""
+    example_texts = _representative_texts(group)
+    row_count = int(len(group))
+    return {
+        "topic_id": topic_id,
+        "topic_label": _format_topic_label(topic_id=topic_id, keywords=keywords, topic_name=topic_info.get(topic_id)),
+        "topic_keywords": keywords,
+        "topic_keyword_text": ", ".join(keywords),
+        "topic_example_text": primary_text,
+        "topic_example_texts": example_texts,
+        "topic_row_count": row_count,
+        "topic_row_share": row_count / max(1, total_rows),
+        "topic_probability_mean": float(group["topic_probability"].mean()),
+        "topic_probability_max": float(group["topic_probability"].max()),
+    }
+
+
+def _topic_rows_with_summary(
+    group: Any,
+    summary: dict[str, object],
+) -> list[dict[str, object]]:
+    """Return row-level review payloads decorated with topic summary fields."""
+    rows: list[dict[str, object]] = []
+    keywords = list(summary.get("topic_keywords", []))
+    example_text = summary.get("topic_example_text")
+    for record in group.to_dict(orient="records"):
+        rows.append(
+            {
+                "date": str(record.get("date", "")),
+                "ticker": str(record.get("ticker", "")),
+                "article_id": _optional_text(record.get("article_id")),
+                "sentence_index": _optional_int(record.get("sentence_index")),
+                "text": _optional_text(record.get("text")),
+                "topic_id": _optional_int(record.get("topic_id")),
+                "topic_probability": _optional_float(record.get("topic_probability")),
+                "topic_label": str(summary.get("topic_label", "")),
+                "topic_keywords": keywords,
+                "topic_keyword_text": str(summary.get("topic_keyword_text", "")),
+                "topic_example_text": _optional_text(example_text),
+                "topic_row_count": _optional_int(summary.get("topic_row_count")),
+                "topic_row_share": _optional_float(summary.get("topic_row_share")),
+            }
+        )
+    return rows
+
+
+def _topic_keywords_for_group(
+    *,
+    topic_id: int,
+    texts: Sequence[str],
+    topic_labeler: Any | None,
+    topic_name: str | None,
+) -> list[str]:
+    """Return up to five human-readable keywords for one topic group."""
+    keywords = _extract_topic_keywords(topic_labeler, topic_id)
+    if not keywords and topic_name:
+        keywords = _keywords_from_topic_name(topic_name)
+    if not keywords:
+        keywords = _keywords_from_texts(texts)
+    return keywords[:5]
+
+
+def _extract_topic_keywords(topic_labeler: Any | None, topic_id: int) -> list[str]:
+    """Extract keywords from an optional BERTopic model wrapper."""
+    if topic_labeler is None:
+        return []
+    topic_getter = getattr(topic_labeler, "get_topic", None)
+    if topic_getter is None:
+        return []
+    try:
+        topic_data = topic_getter(topic_id)
+    except Exception:  # pragma: no cover - optional BERTopic API fallback
+        return []
+    if not topic_data:
+        return []
+
+    keywords: list[str] = []
+    for item in topic_data:
+        if isinstance(item, tuple) and item:
+            keyword = str(item[0]).strip()
+        else:
+            keyword = str(item).strip()
+        if keyword:
+            keywords.append(keyword)
+    return keywords
+
+
+def _keywords_from_topic_name(topic_name: str) -> list[str]:
+    """Derive readable keywords from a BERTopic topic name."""
+    cleaned = re.sub(r"^\d+[_\-\s]*", "", topic_name)
+    cleaned = cleaned.replace("/", " ").replace("_", " ").replace("-", " ")
+    tokens = [token for token in cleaned.split() if token]
+    return [token.lower() for token in tokens if token.lower() not in _TOPIC_FALLBACK_STOPWORDS]
+
+
+def _keywords_from_texts(texts: Sequence[str]) -> list[str]:
+    """Derive fallback keywords from the topic's representative texts."""
+    tokens: list[str] = []
+    for text in texts:
+        tokens.extend(
+            token.lower()
+            for token in re.findall(r"[A-Za-z][A-Za-z0-9'\-]+", text)
+            if token.lower() not in _TOPIC_FALLBACK_STOPWORDS and len(token) > 2
+        )
+    counts = Counter(tokens)
+    return [word for word, _ in counts.most_common(5)]
+
+
+def _format_topic_label(
+    *,
+    topic_id: int,
+    keywords: Sequence[str],
+    topic_name: str | None,
+) -> str:
+    """Return a human-readable label for one topic."""
+    if topic_name:
+        label = re.sub(r"^\d+[_\-\s]*", "", topic_name).replace("_", " ").replace("-", " ")
+        label = " ".join(label.split())
+        if label:
+            return _title_case_phrase(label)
+    if keywords:
+        return " / ".join(_title_case_phrase(keyword) for keyword in keywords[:3])
+    if topic_id < 0:
+        return "Outlier / Unassigned"
+    return f"Topic {topic_id}"
+
+
+def _title_case_phrase(value: str) -> str:
+    """Title-case a phrase while preserving all-caps acronyms."""
+    parts: list[str] = []
+    for token in value.split():
+        if token.isupper() or token.isdigit():
+            parts.append(token)
+        else:
+            parts.append(token[:1].upper() + token[1:].lower())
+    return " ".join(parts)
+
+
+def _representative_texts(group: Any, *, limit: int = 2) -> list[str]:
+    """Return up to `limit` representative texts ordered by confidence."""
+    rows = group.copy()
+    rows["_sort_text_length"] = rows["text"].map(lambda value: len(str(value or "")))
+    rows = rows.sort_values(
+        by=["topic_probability", "_sort_text_length", "sentence_index", "article_id"],
+        ascending=[False, False, True, True],
+        kind="mergesort",
+    )
+    texts: list[str] = []
+    for value in rows["text"].tolist():
+        text = str(value or "").strip()
+        if not text or text in texts:
+            continue
+        texts.append(text)
+        if len(texts) >= limit:
+            break
+    return texts
+
+
+def _optional_text(value: object) -> str | None:
+    """Return a stripped string or None."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_int(value: object) -> int | None:
+    """Return an int or None when the value is null-like."""
+    if value is None:
+        return None
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _optional_float(value: object) -> float | None:
+    """Return a float or None when the value is null-like."""
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(number) or math.isinf(number):
+        return None
+    return number
+
+
+def _topic_row_sort_key(row: dict[str, object]) -> tuple[str, str, int]:
+    """Return a stable sort key for topic review rows."""
+    sentence_index = _optional_int(row.get("sentence_index"))
+    return (
+        str(row.get("date", "")),
+        str(row.get("ticker", "")),
+        sentence_index if sentence_index is not None else -1,
+    )
+
+
+def _topic_summary_sort_key(summary: dict[str, object]) -> tuple[float, int]:
+    """Return a stable sort key for topic review summaries."""
+    topic_share = _optional_float(summary.get("topic_row_share")) or 0.0
+    topic_id = _optional_int(summary.get("topic_id")) or -1
+    return (-topic_share, topic_id)
 
 
 def _require_pandas() -> Any:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -360,9 +360,9 @@ history file is refreshed.
 ```
 RAW ARTICLES (Alpaca news)
   → Step 1: Preprocessing
-      Read raw/news and raw/universe from R2, split into sentences, tag
-      point-in-time tickers, write NewsSentimentRecord rows to
-      features/layer1/news_sentiment/{date}/{run_id}.parquet
+      Read raw/news and raw/universe from R2, clean provider HTML/entities,
+      split into sentences, tag point-in-time tickers, write NewsSentimentRecord rows to
+      features/{date}/news_sentiment/{run_id}.parquet
   → Step 2a: Sentence Transformers (per article)
       Model: all-mpnet-base-v2
       Output: pinned-version sentence embedding cache in R2

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -247,8 +247,8 @@ Use cases:
 
 Input note:
 - generated from Layer 0 raw point-in-time news archives
-- sentence-level preprocessing rows should populate `text`, `article_id`, and
-  `sentence_index`; aggregated ticker-day rows may leave those fields unset
+- sentence-level preprocessing rows should populate `text` with cleaned plain text,
+  `article_id`, and `sentence_index`; aggregated ticker-day rows may leave those fields unset
 - `published_at` must preserve the raw article timestamp exactly for downstream leakage checks
 
 ### FeatureRecord

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -167,6 +167,18 @@ def layer1_topic_feature_path(as_of_date: str | Date | datetime, run_id: str) ->
     )
 
 
+def layer1_topic_review_path(as_of_date: str | Date | datetime, run_id: str) -> str:
+    """Return the canonical Layer 1 topic review payload path."""
+    safe_run_id = _validate_key_part(run_id)
+    return build_r2_key(
+        "features",
+        "layer1",
+        "topic_reviews",
+        _format_date(as_of_date),
+        f"{safe_run_id}.json",
+    )
+
+
 def layer1_sentiment_score_path(as_of_date: str | Date | datetime, run_id: str) -> str:
     """Return the canonical Layer 1 scored FinBERT news path."""
     safe_run_id = _validate_key_part(run_id)

--- a/tests/fixtures/layer1_audit_support.py
+++ b/tests/fixtures/layer1_audit_support.py
@@ -38,6 +38,7 @@ from services.r2.paths import (
     layer1_ticker_history_path,
     layer1_topic_feature_path,
     layer1_topic_label_path,
+    layer1_topic_review_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_macro_path,
@@ -115,6 +116,48 @@ def seed_layer1_audit_fixture(
     _write_parquet(writer, topic_label_key, topic_labels)
     topic_feature_records = topic_labels_to_feature_records(topic_labels)
     writer.put_object(topic_feature_key, feature_records_to_parquet_bytes(topic_feature_records))
+    topic_review_key = layer1_topic_review_path(as_of_date, "audit-topics")
+    topic_review = {
+        "status": "warn",
+        "diversity_status": "insufficient_diversity",
+        "diversity_reason": "Only one topic was detected across one row.",
+        "row_count": 1,
+        "topic_count": 1,
+        "dominant_topic_id": 7,
+        "dominant_topic_share": 1.0,
+        "topics": [
+            {
+                "topic_id": 7,
+                "topic_label": "Apple Results",
+                "topic_keywords": ["apple", "results", "margins"],
+                "topic_keyword_text": "apple, results, margins",
+                "topic_example_text": str(preprocessed_records[0].text),
+                "topic_example_texts": [str(preprocessed_records[0].text)],
+                "topic_row_count": 1,
+                "topic_row_share": 1.0,
+                "topic_probability_mean": 0.9,
+                "topic_probability_max": 0.9,
+            }
+        ],
+        "rows": [
+            {
+                "date": as_of_date,
+                "ticker": ticker,
+                "article_id": str(preprocessed_records[0].article_id),
+                "sentence_index": int(preprocessed_records[0].sentence_index or 0),
+                "text": str(preprocessed_records[0].text),
+                "topic_id": 7,
+                "topic_probability": 0.9,
+                "topic_label": "Apple Results",
+                "topic_keywords": ["apple", "results", "margins"],
+                "topic_keyword_text": "apple, results, margins",
+                "topic_example_text": str(preprocessed_records[0].text),
+                "topic_row_count": 1,
+                "topic_row_share": 1.0,
+            }
+        ],
+    }
+    writer.put_object(topic_review_key, json.dumps(topic_review, sort_keys=True))
     _write_manifest(
         writer,
         stage="layer1_text_topics",
@@ -124,6 +167,9 @@ def seed_layer1_audit_fixture(
             "as_of_date": as_of_date,
             "topic_label_key": topic_label_key,
             "topic_feature_key": topic_feature_key,
+            "topic_review_key": topic_review_key,
+            "topic_review_status": topic_review["status"],
+            "topic_review_diversity_status": topic_review["diversity_status"],
         },
     )
 
@@ -162,6 +208,7 @@ def seed_layer1_audit_fixture(
             "sentiment_feature_key": sentiment_feature_key,
         },
     )
+
 
     regime_key = layer1_regime_path("audit-regime")
     regime_output = pd.DataFrame(

--- a/tests/fixtures/layer1_dashboard_support.py
+++ b/tests/fixtures/layer1_dashboard_support.py
@@ -15,6 +15,18 @@ def seed_layer1_dashboard_fixture(writer: R2Writer) -> dict[str, object]:
     """Seed multi-row Layer 1 histories for dashboard backend tests."""
     audit_fixture = seed_layer1_audit_fixture(writer, as_of_date="2024-05-08")
     base_features = dict(audit_fixture["history_record"].features)
+    base_features.update(
+        {
+            "nlp_sentiment_positive": 0.8,
+            "nlp_sentiment_negative": 0.1,
+            "nlp_sentiment_neutral": 0.1,
+            "nlp_sentiment_score": 0.7,
+            "nlp_sentiment_strength": 0.8,
+            "nlp_article_count": 1,
+            "nlp_sentence_count": 1,
+            "nlp_relevance_score": 1.0,
+        }
+    )
     aapl_market_by_date = _market_features_by_date("AAPL", writer)
 
     aapl_records = [

--- a/tests/fixtures/layer1_support.py
+++ b/tests/fixtures/layer1_support.py
@@ -46,6 +46,7 @@ from services.r2.paths import (
     layer1_regime_path,
     layer1_sentiment_feature_path,
     layer1_topic_feature_path,
+    layer1_topic_review_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_macro_path,
@@ -148,6 +149,7 @@ def fake_topic_runner(writer: R2Writer, tickers: Sequence[str]):
 
     def _runner(config: TextTopicPipelineConfig, *, writer: R2Writer):
         output_key = layer1_topic_feature_path(config.as_of_date, config.run_id)
+        review_key = layer1_topic_review_path(config.as_of_date, config.run_id)
         records = [
             FeatureRecord(
                 date=config.as_of_date,
@@ -155,12 +157,54 @@ def fake_topic_runner(writer: R2Writer, tickers: Sequence[str]):
                 features={"nlp_topic_count": 1, "nlp_sentence_count": 1},
             )
         ]
+        review_payload = {
+            "status": "warn",
+            "diversity_status": "insufficient_diversity",
+            "diversity_reason": "Only one topic was detected across one row.",
+            "row_count": 1,
+            "topic_count": 1,
+            "dominant_topic_id": 0,
+            "dominant_topic_share": 1.0,
+            "topics": [
+                {
+                    "topic_id": 0,
+                    "topic_label": "Topic 0",
+                    "topic_keywords": ["market", "update", "stocks"],
+                    "topic_keyword_text": "market, update, stocks",
+                    "topic_example_text": "Stocks moved higher.",
+                    "topic_example_texts": ["Stocks moved higher."],
+                    "topic_row_count": 1,
+                    "topic_row_share": 1.0,
+                    "topic_probability_mean": 0.75,
+                    "topic_probability_max": 0.75,
+                }
+            ],
+            "rows": [
+                {
+                    "date": config.as_of_date,
+                    "ticker": tickers[0],
+                    "article_id": f"article-{config.as_of_date}",
+                    "sentence_index": 0,
+                    "text": "Stocks moved higher.",
+                    "topic_id": 0,
+                    "topic_probability": 0.75,
+                    "topic_label": "Topic 0",
+                    "topic_keywords": ["market", "update", "stocks"],
+                    "topic_keyword_text": "market, update, stocks",
+                    "topic_example_text": "Stocks moved higher.",
+                    "topic_row_count": 1,
+                    "topic_row_share": 1.0,
+                }
+            ],
+        }
         writer.put_object(output_key, feature_records_to_parquet_bytes(records))
+        writer.put_object(review_key, json.dumps(review_payload, sort_keys=True))
         return TextTopicPipelineResult(
             run_id=config.run_id,
             embedding_key="unused",
             topic_label_key="unused",
             topic_feature_key=output_key,
+            topic_review_key=review_key,
             manifest_key=pipeline_manifest_path("layer1_text_topics", config.run_id),
             sentence_rows=1,
             embedding_rows=1,

--- a/tests/unit/test_feature_audit_dashboard_ui.py
+++ b/tests/unit/test_feature_audit_dashboard_ui.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import math
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 
 from app.lab.feature_audit_dashboard import _DashboardDefaults, _render_dashboard_html
 from core.features.dashboard_backend import build_layer1_audit_dashboard_report
 from core.features.dashboard_ui import build_layer1_audit_dashboard_ui_payload
+from services.r2.paths import layer1_regime_path
 from tests.fixtures.layer1_audit_support import local_writer
 from tests.fixtures.layer1_dashboard_support import seed_layer1_dashboard_fixture
 
@@ -23,7 +25,7 @@ def test_build_layer1_audit_dashboard_ui_payload_groups_backend_data_for_the_web
         run_id="dashboard-ui",
         from_date=str(fixture["from_date"]),
         to_date=str(fixture["to_date"]),
-        tickers=list(fixture["tickers"]),
+        tickers=cast(list[str], fixture["tickers"]),
         writer=writer,
     )
 
@@ -34,6 +36,27 @@ def test_build_layer1_audit_dashboard_ui_payload_groups_backend_data_for_the_web
     assert payload["controls"]["available_tickers"] == ["AAPL", "MSFT"]
     assert payload["controls"]["default_focus_date"] == "2024-05-08"
     assert payload["controls"]["default_spot_check_feature"] == "returns_1d"
+
+    pilot_analysis = cast(dict[str, Any], payload["pilot_window_analysis"])
+    recommendation = cast(dict[str, Any], pilot_analysis["recommendation"])
+    hmm_analysis = cast(dict[str, Any], pilot_analysis["hmm"])
+    finbert_analysis = cast(dict[str, Any], pilot_analysis["finbert"])
+    hmm_rows = cast(list[dict[str, Any]], hmm_analysis["rows"])
+    finbert_rows = cast(list[dict[str, Any]], finbert_analysis["rows"])
+    pilot_evidence = cast(dict[str, Any], payload["pilot_window_evidence"])
+    sentiment_rows = cast(list[dict[str, Any]], pilot_evidence["sentiment"]["rows"])
+    topic_rows = cast(list[dict[str, Any]], pilot_evidence["topics"]["rows"])
+    regime_rows = cast(list[dict[str, Any]], pilot_evidence["regime"]["rows"])
+    assert recommendation["status"] == "warn"
+    assert hmm_analysis["status"] == "pass"
+    assert finbert_analysis["status"] == "warn"
+    assert hmm_rows[0]["regime_label"] == "bull"
+    assert hmm_rows[0]["regime_confidence"] == 0.8
+    assert finbert_rows[0]["sentiment_score"] == 0.7
+    assert finbert_rows[0]["article_count"] == 1.0
+    assert sentiment_rows[0]["article_id"].startswith("article-")
+    assert topic_rows[0]["text"].startswith("AAPL beats")
+    assert regime_rows[0]["regime_label"] == "bull"
 
     heatmap_rows = {
         item["feature_name"]: item
@@ -62,6 +85,31 @@ def test_build_layer1_audit_dashboard_ui_payload_groups_backend_data_for_the_web
     assert any(item["rule_type"] == "distribution_outlier" for item in outlier_points)
 
 
+def test_build_layer1_audit_dashboard_ui_payload_preserves_evidence_blockers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Evidence blockers should flow from the backend into the UI payload."""
+    writer = local_writer(tmp_path, monkeypatch)
+    fixture = seed_layer1_dashboard_fixture(writer)
+    writer.delete_object(layer1_regime_path("audit-regime"))
+    report = build_layer1_audit_dashboard_report(
+        run_id="dashboard-ui-blockers",
+        from_date=str(fixture["from_date"]),
+        to_date=str(fixture["to_date"]),
+        tickers=cast(list[str], fixture["tickers"]),
+        writer=writer,
+    )
+
+    payload = build_layer1_audit_dashboard_ui_payload(report)
+    pilot_evidence = cast(dict[str, Any], payload["pilot_window_evidence"])
+    regime_evidence = cast(dict[str, Any], pilot_evidence["regime"])
+    blockers = cast(list[dict[str, Any]], regime_evidence["blockers"])
+
+    assert regime_evidence["status"] == "warn"
+    assert regime_evidence["missing_artifact_keys"] == [layer1_regime_path("audit-regime")]
+    assert blockers[0]["artifact_key"] == layer1_regime_path("audit-regime")
+
 def test_build_layer1_audit_dashboard_ui_payload_accepts_mapping_reports(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -73,7 +121,7 @@ def test_build_layer1_audit_dashboard_ui_payload_accepts_mapping_reports(
         run_id="dashboard-ui-mapping",
         from_date=str(fixture["from_date"]),
         to_date=str(fixture["to_date"]),
-        tickers=list(fixture["tickers"]),
+        tickers=cast(list[str], fixture["tickers"]),
         writer=writer,
     )
 
@@ -246,5 +294,10 @@ def test_render_dashboard_html_keeps_original_point_indexes_in_line_paths() -> N
     assert "function linePath(points, valueKey, x, y)" in html
     assert 'const storedPath = linePath(points, "stored_value", x, y);' in html
     assert 'const expectedPath = linePath(points, "expected_value", x, y);' in html
+    assert "HMM + FinBERT Pilot Dashboard" in html
+    assert "Pilot Window Decision Evidence" in html
+    assert "HMM Regime Graphs and Analysis" in html
+    assert "FinBERT Sentiment Graphs and Analysis" in html
+    assert "supporting-audit-panel" in html
     assert "${y(point.expected_value)})" not in html
     assert "const escapeHtml = (value) => String(value ?? \"\")" in html

--- a/tests/unit/test_feature_dashboard_backend.py
+++ b/tests/unit/test_feature_dashboard_backend.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import cast
 
 import pytest
 
@@ -10,7 +11,7 @@ from core.features.dashboard_backend import (
     write_layer1_audit_dashboard_report,
 )
 from core.features.io import feature_records_to_parquet_bytes, read_feature_records
-from services.r2.paths import layer1_ticker_history_path
+from services.r2.paths import layer1_regime_path, layer1_ticker_history_path
 from tests.fixtures.layer1_audit_support import local_writer
 from tests.fixtures.layer1_dashboard_support import seed_layer1_dashboard_fixture
 
@@ -27,7 +28,7 @@ def test_build_layer1_audit_dashboard_report_builds_visualization_inputs(
         run_id="dashboard-unit",
         from_date=str(fixture["from_date"]),
         to_date=str(fixture["to_date"]),
-        tickers=list(fixture["tickers"]),
+        tickers=cast(list[str], fixture["tickers"]),
         writer=writer,
     )
 
@@ -99,6 +100,35 @@ def test_build_layer1_audit_dashboard_report_builds_visualization_inputs(
         formula_cards[("MSFT", "2024-05-06", "returns_1d")]["status"] == "warn"
     )
 
+    pilot_evidence = report.pilot_window_evidence
+    sentiment_evidence = cast(dict[str, object], pilot_evidence["sentiment"])
+    topic_evidence = cast(dict[str, object], pilot_evidence["topics"])
+    regime_evidence = cast(dict[str, object], pilot_evidence["regime"])
+    selection = cast(dict[str, object], pilot_evidence["selection"])
+    assert cast(list[str], selection["tickers"]) == ["AAPL", "MSFT"]
+    assert sentiment_evidence["status"] == "pass"
+    assert sentiment_evidence["row_count"] == 1
+    sentiment_rows = cast(list[dict[str, object]], sentiment_evidence["rows"])
+    article_id = cast(str, sentiment_rows[0]["article_id"])
+    assert article_id.startswith("article-")
+    assert sentiment_evidence["rows"][0]["sentiment_score"] == 0.7
+    assert sentiment_evidence["missing_artifact_keys"] == []
+    assert topic_evidence["status"] == "warn"
+    assert topic_evidence["diversity_status"] == "insufficient_diversity"
+    assert topic_evidence["row_count"] == 1
+    topic_rows = cast(list[dict[str, object]], topic_evidence["rows"])
+    topic_topics = cast(list[dict[str, object]], topic_evidence["topics"])
+    assert topic_rows[0]["topic_label"] == "Apple Results"
+    assert cast(list[str], topic_topics[0]["topic_keywords"]) == ["apple", "results", "margins"]
+    assert cast(list[str], topic_topics[0]["topic_example_texts"])[0].startswith("AAPL beats")
+    assert topic_evidence["rows"][0]["topic_probability"] == 0.9
+    assert topic_evidence["missing_artifact_keys"] == []
+    assert regime_evidence["status"] == "pass"
+    assert regime_evidence["row_count"] == 1
+    assert regime_evidence["rows"][0]["regime_label"] == "bull"
+    assert regime_evidence["rows"][0]["regime_probability_sum"] == 1.0
+    assert regime_evidence["missing_artifact_keys"] == []
+
 
 def test_write_layer1_audit_dashboard_report_writes_json_and_summary(
     tmp_path: Path,
@@ -111,7 +141,7 @@ def test_write_layer1_audit_dashboard_report_writes_json_and_summary(
         run_id="dashboard-write",
         from_date=str(fixture["from_date"]),
         to_date=str(fixture["to_date"]),
-        tickers=list(fixture["tickers"]),
+        tickers=cast(list[str], fixture["tickers"]),
         writer=writer,
     )
 
@@ -124,6 +154,75 @@ def test_write_layer1_audit_dashboard_report_writes_json_and_summary(
     assert "Layer 1 Audit Dashboard Backend" in summary
     assert "Family Status" in output_paths.summary_path.read_text(encoding="utf-8")
     assert "Market spot checks" in summary
+
+
+def test_build_layer1_audit_dashboard_report_handles_missing_regime_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing regime artifacts should degrade to blockers instead of aborting the report."""
+    writer = local_writer(tmp_path, monkeypatch)
+    fixture = seed_layer1_dashboard_fixture(writer)
+    writer.delete_object(layer1_regime_path("audit-regime"))
+
+    report = build_layer1_audit_dashboard_report(
+        run_id="dashboard-missing-regime",
+        from_date=str(fixture["from_date"]),
+        to_date=str(fixture["to_date"]),
+        tickers=cast(list[str], fixture["tickers"]),
+        writer=writer,
+    )
+
+    pilot_evidence = cast(dict[str, dict[str, object]], report.pilot_window_evidence)
+    regime_evidence = pilot_evidence["regime"]
+    sentiment_evidence = pilot_evidence["sentiment"]
+    topic_evidence = pilot_evidence["topics"]
+
+    assert regime_evidence["status"] == "warn"
+    assert regime_evidence["row_count"] == 0
+    assert regime_evidence["rows"] == []
+    blockers = cast(list[dict[str, object]], regime_evidence["blockers"])
+    assert regime_evidence["missing_artifact_keys"] == [layer1_regime_path("audit-regime")]
+    assert blockers[0]["artifact_key"] == layer1_regime_path("audit-regime")
+    assert sentiment_evidence["status"] == "pass"
+    assert topic_evidence["status"] == "warn"
+    assert topic_evidence["diversity_status"] == "insufficient_diversity"
+    assert report.rows_loaded == 6
+
+
+def test_build_layer1_audit_dashboard_report_surfaces_missing_semantic_manifests(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A date window with no semantic manifests should return blockers quickly."""
+    writer = local_writer(tmp_path, monkeypatch)
+    seed_layer1_dashboard_fixture(writer)
+
+    report = build_layer1_audit_dashboard_report(
+        run_id="dashboard-missing-manifests",
+        from_date="2099-01-01",
+        to_date="2099-01-01",
+        tickers=["AAPL"],
+        writer=writer,
+    )
+
+    pilot_evidence = cast(dict[str, dict[str, object]], report.pilot_window_evidence)
+    sentiment_evidence = cast(dict[str, object], pilot_evidence["sentiment"])
+    topic_evidence = cast(dict[str, object], pilot_evidence["topics"])
+    regime_evidence = cast(dict[str, object], pilot_evidence["regime"])
+
+    assert report.rows_loaded == 0
+    assert sentiment_evidence["status"] == "warn"
+    assert topic_evidence["status"] == "warn"
+    assert regime_evidence["status"] == "warn"
+    assert sentiment_evidence["row_count"] == 0
+    assert topic_evidence["row_count"] == 0
+    assert regime_evidence["row_count"] == 0
+    assert sentiment_evidence["blockers"][0]["reason"].startswith(
+        "No Layer 1 FinBERT sentiment manifest"
+    )
+    assert topic_evidence["blockers"][0]["reason"].startswith("No Layer 1 BERTopic manifest")
+    assert regime_evidence["blockers"][0]["reason"].startswith("No Layer 1 regime manifest")
 
 
 def test_build_layer1_audit_dashboard_report_surfaces_partial_coverage(
@@ -143,7 +242,7 @@ def test_build_layer1_audit_dashboard_report_surfaces_partial_coverage(
         run_id="dashboard-partial-coverage",
         from_date=str(fixture["from_date"]),
         to_date=str(fixture["to_date"]),
-        tickers=list(fixture["tickers"]),
+        tickers=cast(list[str], fixture["tickers"]),
         writer=writer,
     )
     summary = render_layer1_audit_dashboard_summary(report)

--- a/tests/unit/test_news_preprocessing.py
+++ b/tests/unit/test_news_preprocessing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import io
+import re
 from datetime import UTC
 
 import pandas as pd
@@ -94,6 +95,34 @@ def test_split_article_sentences_cleans_provider_html_and_preserves_meaningful_t
     assert all("&nbsp;" not in sentence for sentence in sentences)
 
 
+def test_split_article_sentences_preserves_headings_lists_and_quote_punctuation() -> None:
+    """Headings, list items, abbreviations, and quoted sentences stay readable."""
+    article = {
+        "headline": '<h1><a href="https://example.test/aapl">AAPL</a> gains on AI rollout.</h1>',
+        "summary": '<p>Analyst says, "Buy now." Revenue may accelerate.</p>',
+        "content": (
+            "<h2>Key points</h2>"
+            "<p>U.S. regulators review the deal.</p>"
+            "<ul><li>Revenue beat expectations.</li><li>Margins improved.</li></ul>"
+        ),
+        "symbols": ["AAPL"],
+    }
+
+    sentences = split_article_sentences(article)
+
+    assert sentences == [
+        "AAPL gains on AI rollout.",
+        'Analyst says, "Buy now."',
+        "Revenue may accelerate.",
+        "Key points",
+        "U.S. regulators review the deal.",
+        "Revenue beat expectations.",
+        "Margins improved.",
+    ]
+    assert all("<" not in sentence and ">" not in sentence for sentence in sentences)
+    assert all("aapl" not in sentence.lower() or sentence == "AAPL gains on AI rollout." for sentence in sentences)
+
+
 def test_split_article_sentences_handles_abbreviations_and_deduplicates() -> None:
     """Sentence splitting avoids common abbreviation splits and removes duplicate text."""
     article = {
@@ -109,6 +138,41 @@ def test_split_article_sentences_handles_abbreviations_and_deduplicates() -> Non
         "Apple Inc. reported earnings.",
         "Shares rose!",
     ]
+
+
+def test_preprocess_news_articles_chunks_oversized_paragraphs_without_truncation() -> None:
+    """Oversized blocks are split into bounded chunks without dropping content."""
+    paragraph = " ".join(
+        [
+            "Alpha beta gamma delta epsilon zeta eta theta iota kappa lambda mu",
+            "nu xi omicron pi rho sigma tau upsilon phi chi psi omega",
+        ]
+        * 6
+    )
+    article = {
+        "id": "chunk-limit",
+        "content": f"<p>{paragraph}</p>",
+        "symbols": ["AAPL"],
+    }
+    config = NewsPreprocessingConfig(
+        target_chunk_chars=80,
+        max_chunk_chars=120,
+        fallback_chunk_chars=60,
+    )
+
+    records = preprocess_news_articles(
+        [article],
+        as_of_date="2024-01-02",
+        point_in_time_tickers=["AAPL"],
+        config=config,
+    )
+
+    assert len(records) > 1
+    assert all(len(record.text or "") <= 120 for record in records)
+    reconstructed = re.sub(r"\s+", " ", " ".join(record.text or "" for record in records)).strip()
+    expected = re.sub(r"\s+", " ", paragraph).strip()
+    assert reconstructed == expected
+    assert [record.sentence_index for record in records] == list(range(len(records)))
 
 
 def test_preprocess_news_articles_filters_empty_text_and_missing_universe_symbols() -> None:

--- a/tests/unit/test_news_preprocessing.py
+++ b/tests/unit/test_news_preprocessing.py
@@ -54,6 +54,46 @@ def test_preprocess_news_articles_emits_sentence_records_for_multiple_alias_tick
     assert records[0].published_at.isoformat() == "2024-01-02T12:00:00+00:00"
 
 
+def test_split_article_sentences_cleans_provider_html_and_preserves_meaningful_text() -> None:
+    """Provider HTML is stripped before splitting without losing useful article text."""
+    article = {
+        "headline": (
+            '<div><a href="https://example.test/apple">Apple</a> shares rise &nbsp; '
+            "on <strong>AI</strong> push.</div>"
+        ),
+        "summary": (
+            '<p>Analyst calls it a "strong quarter" &#8212; target rises to $210.</p>'
+            '<blockquote class="twitter-tweet"><p>Ignore this tweet embed.</p></blockquote>'
+        ),
+        "content": (
+            '<div><p>AAPL traded at <span>$189.20</span>.</p>'
+            '<script>window.widget = true;</script>'
+            '<div class="widget">widget boilerplate</div>'
+            '<p>Source: Benzinga</p></div>'
+        ),
+        "symbols": ["AAPL"],
+    }
+
+    sentences = split_article_sentences(article)
+    records = preprocess_news_articles(
+        [article],
+        as_of_date="2024-01-02",
+        point_in_time_tickers=["AAPL"],
+    )
+
+    assert sentences == [
+        "Apple shares rise on AI push.",
+        'Analyst calls it a "strong quarter" — target rises to $210.',
+        "AAPL traded at $189.20.",
+        "Source: Benzinga",
+    ]
+    assert [record.text for record in records] == sentences
+    assert all("<" not in sentence and ">" not in sentence for sentence in sentences)
+    assert all("twitter" not in sentence.lower() for sentence in sentences)
+    assert all("widget" not in sentence.lower() for sentence in sentences)
+    assert all("&nbsp;" not in sentence for sentence in sentences)
+
+
 def test_split_article_sentences_handles_abbreviations_and_deduplicates() -> None:
     """Sentence splitting avoids common abbreviation splits and removes duplicate text."""
     article = {

--- a/tests/unit/test_news_preprocessing_runner.py
+++ b/tests/unit/test_news_preprocessing_runner.py
@@ -37,8 +37,16 @@ def test_run_news_preprocessing_reads_r2_and_writes_outputs(
         [
             {
                 "id": 1001,
-                "headline": "Apple reports earnings.",
-                "summary": "Shares rose.",
+                "headline": "<div>Apple <a href='https://example.test/apple'>reports</a> earnings today.</div>",
+                "summary": (
+                    '<p>Revenue rose 10% to $100.2B.</p>'
+                    '<blockquote class="twitter-tweet"><p>Tweet boilerplate.</p></blockquote>'
+                ),
+                "content": (
+                    '<div><p>Gross margin improved to 45% &#8212; per the company.</p>'
+                    '<script>window.widget = true;</script>'
+                    '<p>Source: Benzinga</p></div>'
+                ),
                 "created_at": "2024-01-02T12:00:00+00:00",
                 "source": "benzinga",
                 "symbols": ["AAPL", "MSFT"],
@@ -70,10 +78,18 @@ def test_run_news_preprocessing_reads_r2_and_writes_outputs(
     assert result.output_key == news_preprocessing_output_path("nlp-test-run", "2024-01-02")
     assert result.manifest_key == pipeline_manifest_path(NLP_PREPROCESSING_STAGE, "nlp-test-run")
     assert output["ticker"].unique().tolist() == ["AAPL"]
-    assert output["text"].tolist() == ["Apple reports earnings.", "Shares rose."]
+    assert output["text"].tolist() == [
+        "Apple reports earnings today.",
+        "Revenue rose 10% to $100.2B.",
+        "Gross margin improved to 45% — per the company.",
+        "Source: Benzinga",
+    ]
+    assert all("<" not in text and ">" not in text for text in output["text"].tolist())
+    assert all("twitter" not in text.lower() for text in output["text"].tolist())
+    assert all("widget" not in text.lower() for text in output["text"].tolist())
     assert manifest["status"] == RunStatus.COMPLETED
     assert manifest["metadata"]["article_rows"] == 1
-    assert manifest["metadata"]["sentence_rows"] == 2
+    assert manifest["metadata"]["sentence_rows"] == 4
 
 
 def test_run_news_preprocessing_writes_failure_manifest(

--- a/tests/unit/test_text_topics.py
+++ b/tests/unit/test_text_topics.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from collections.abc import Sequence
+from typing import cast
 
 import pandas as pd
 import pytest
@@ -33,12 +34,31 @@ class _NaNEmbedder:
 
 
 class _FakeTopicLabeler:
+    def __init__(self) -> None:
+        self._topics = {
+            0: [("earnings", 0.5), ("guidance", 0.3), ("revenue", 0.2)],
+            1: [("cloud", 0.5), ("ai", 0.3), ("demand", 0.2)],
+        }
+
     def fit_transform(
         self,
         documents: Sequence[str],
         embeddings: Sequence[Sequence[float]],
     ) -> tuple[Sequence[int], Sequence[float]]:
-        return [index % 2 for index, _ in enumerate(documents)], [0.8, 0.6][: len(documents)]
+        topics = [index % 2 for index, _ in enumerate(documents)]
+        probabilities = [0.8 - (index * 0.05) for index, _ in enumerate(documents)]
+        return topics, probabilities
+
+    def get_topic(self, topic_id: int) -> Sequence[tuple[str, float]]:
+        return self._topics.get(topic_id, [])
+
+    def get_topic_info(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {"Topic": 0, "Name": "earnings_guidance_revenue"},
+                {"Topic": 1, "Name": "cloud_ai_demand"},
+            ]
+        )
 
 
 class _RecordingEmbedder:
@@ -92,7 +112,65 @@ def test_compute_text_topics_caches_unique_sentence_embeddings_and_topic_feature
     assert aapl.features["nlp_topic_count"] == 2
 
 
-def test_embedding_cache_key_changes_with_model_revision() -> None:
+
+
+def test_compute_text_topics_builds_human_readable_topic_review() -> None:
+    """Topic review output should carry labels, keywords, and representative examples."""
+    result = compute_text_topics(
+        [
+            _record(text="Apple raised guidance on iPhone demand.", sentence_index=0),
+            _record(text="Apple posted strong margins and services revenue.", sentence_index=1),
+            _record(
+                ticker="MSFT",
+                text="Microsoft cloud revenue accelerated on AI demand.",
+                sentence_index=0,
+            ),
+        ],
+        embedder=_FakeEmbedder(),
+        topic_labeler=_FakeTopicLabeler(),
+        embedding_config=_embedding_config(),
+        topic_config=_topic_config(),
+    )
+
+    review = cast(dict[str, object], result.topic_review)
+    topics = cast(list[dict[str, object]], review["topics"])
+    rows = cast(list[dict[str, object]], review["rows"])
+
+    assert review["status"] == "pass"
+    assert review["diversity_status"] == "diverse"
+    assert review["topic_count"] == 2
+    assert len(topics) == 2
+    first_topic = topics[0]
+    assert "Earnings" in str(first_topic["topic_label"])
+    assert cast(list[str], first_topic["topic_keywords"] )[:3] == ["earnings", "guidance", "revenue"]
+    assert first_topic["topic_example_text"]
+    assert len(cast(list[str], first_topic["topic_example_texts"])) >= 1
+    assert all("topic_label" in row for row in rows)
+
+
+def test_compute_text_topics_marks_insufficient_diversity_for_single_topic() -> None:
+    """A single-topic corpus should be called out explicitly in the review payload."""
+    result = compute_text_topics(
+        [
+            _record(text="Apple released results.", sentence_index=0),
+            _record(text="Margins improved.", sentence_index=1),
+        ],
+        embedder=_FakeEmbedder(),
+        topic_labeler=_ResettingTopicLabeler(),
+        embedding_config=_embedding_config(),
+        topic_config=_topic_config(),
+    )
+
+    review = cast(dict[str, object], result.topic_review)
+    topics = cast(list[dict[str, object]], review["topics"])
+
+    assert review["status"] == "warn"
+    assert review["diversity_status"] == "insufficient_diversity"
+    assert review["topic_count"] == 1
+    assert topics[0]["topic_label"]
+    assert topics[0]["topic_example_text"]
+
+
     """Embedding cache keys include the pinned model revision."""
     record = _record()
     first = embedding_cache_key(record, config=_embedding_config(model_revision="rev-a"))

--- a/tests/unit/test_text_topics_runner.py
+++ b/tests/unit/test_text_topics_runner.py
@@ -28,6 +28,7 @@ from services.r2.paths import (
     layer1_text_embedding_path,
     layer1_topic_feature_path,
     layer1_topic_label_path,
+    layer1_topic_review_path,
     pipeline_manifest_path,
 )
 from services.r2.writer import R2Writer
@@ -39,12 +40,29 @@ class _FakeEmbedder:
 
 
 class _FakeTopicLabeler:
+    def __init__(self) -> None:
+        self._topics = {
+            0: [("earnings", 0.5), ("guidance", 0.3), ("revenue", 0.2)],
+            1: [("cloud", 0.5), ("ai", 0.3), ("demand", 0.2)],
+        }
+
     def fit_transform(
         self,
         documents: Sequence[str],
         embeddings: Sequence[Sequence[float]],
     ) -> tuple[Sequence[int], Sequence[float]]:
         return [index for index, _ in enumerate(documents)], [0.75 for _ in documents]
+
+    def get_topic(self, topic_id: int) -> Sequence[tuple[str, float]]:
+        return self._topics.get(topic_id, [])
+
+    def get_topic_info(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [
+                {"Topic": 0, "Name": "earnings_guidance_revenue"},
+                {"Topic": 1, "Name": "cloud_ai_demand"},
+            ]
+        )
 
 
 def test_run_text_topics_reads_preprocessed_news_and_writes_outputs(
@@ -71,18 +89,25 @@ def test_run_text_topics_reads_preprocessed_news_and_writes_outputs(
     embeddings = pd.read_parquet(io.BytesIO(writer.get_object(result.embedding_key)))
     labels = pd.read_parquet(io.BytesIO(writer.get_object(result.topic_label_key)))
     features = pd.read_parquet(io.BytesIO(writer.get_object(result.topic_feature_key)))
+    review = json.loads(writer.get_object(result.topic_review_key))
     manifest = json.loads(writer.get_object(result.manifest_key))
 
     assert result.embedding_key == layer1_text_embedding_path("2024-01-02", "text-topics-run")
     assert result.topic_label_key == layer1_topic_label_path("2024-01-02", "text-topics-run")
     assert result.topic_feature_key == layer1_topic_feature_path("2024-01-02", "text-topics-run")
+    assert result.topic_review_key == layer1_topic_review_path("2024-01-02", "text-topics-run")
     assert result.manifest_key == pipeline_manifest_path(TEXT_TOPICS_STAGE, "text-topics-run")
     assert len(embeddings) == 2
     assert len(labels) == 3
     assert set(features["ticker"]) == {"AAPL", "MSFT"}
+    assert review["status"] == "pass"
+    assert review["topic_count"] == 2
+    assert review["topics"][0]["topic_label"]
     assert manifest["status"] == RunStatus.COMPLETED
     assert manifest["metadata"]["embedding_rows"] == 2
     assert manifest["metadata"]["topic_label_rows"] == 3
+    assert manifest["metadata"]["topic_review_key"] == result.topic_review_key
+    assert manifest["metadata"]["topic_review_status"] == "pass"
 
 
 def test_run_text_topics_writes_failure_manifest(


### PR DESCRIPTION
Closes #261

Summary:
- Adds human-readable topic labels, keywords, representative examples, and topic review payload wiring for Layer 1 text topics.
- Wires the review artifact into the daily Layer 1 flow and dashboard evidence paths.
- Updates fixtures and unit tests to cover the new review payload semantics and insufficient-diversity fallback.

Verification:
- ./.venv/bin/pytest tests/unit/test_text_topics.py tests/unit/test_text_topics_runner.py tests/unit/test_feature_dashboard_backend.py -v --tb=short
- ./.venv/bin/pytest tests/unit -v --tb=short
- git diff --check
- ./.venv/bin/ruff check .

Owner: code-monkey