### PR TITLE
feat: Layer 1 topic review payloads

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -2270,6 +2270,7 @@ def _existing_text_topic_runner(
             run_id=config.run_id,
             embedding_key="",
             topic_label_key="",
+            topic_review_key="",
             topic_feature_key=output_key,
             manifest_key=manifest_key,
             sentence_rows=0,

--- a/app/lab/data_pipelines/run_text_topics.py
+++ b/app/lab/data_pipelines/run_text_topics.py
@@ -47,6 +47,7 @@ from services.r2.paths import (  # noqa: E402
     layer1_text_embedding_path,
     layer1_topic_feature_path,
     layer1_topic_label_path,
+    layer1_topic_review_path,
     pipeline_manifest_path,
 )
 from services.r2.writer import R2Writer  # noqa: E402
@@ -135,6 +136,7 @@ class TextTopicPipelineResult:
     run_id: str
     embedding_key: str
     topic_label_key: str
+    topic_review_key: str
     topic_feature_key: str
     manifest_key: str
     sentence_rows: int
@@ -161,6 +163,7 @@ def run_text_topics(
 
     embedding_key = layer1_text_embedding_path(config.as_of_date, config.run_id)
     topic_label_key = layer1_topic_label_path(config.as_of_date, config.run_id)
+    topic_review_key = layer1_topic_review_path(config.as_of_date, config.run_id)
     topic_feature_key = layer1_topic_feature_path(config.as_of_date, config.run_id)
     manifest_key = pipeline_manifest_path(TEXT_TOPICS_STAGE, config.run_id)
     metadata: dict[str, object] = {
@@ -169,6 +172,7 @@ def run_text_topics(
         "requested_tickers": list(config.tickers),
         "embedding_key": embedding_key,
         "topic_label_key": topic_label_key,
+        "topic_review_key": topic_review_key,
         "topic_feature_key": topic_feature_key,
         "embedding_model": runtime.embedding_config.model_name,
         "embedding_revision": runtime.embedding_config.model_revision,
@@ -196,6 +200,7 @@ def run_text_topics(
         )
         active_writer.put_object(embedding_key, _frame_to_parquet_bytes(result.embeddings))
         active_writer.put_object(topic_label_key, _frame_to_parquet_bytes(result.topic_labels))
+        active_writer.put_object(topic_review_key, json.dumps(result.topic_review, sort_keys=True))
         active_writer.put_object(
             topic_feature_key,
             _frame_to_parquet_bytes(feature_records_to_frame(result.feature_records)),
@@ -207,6 +212,7 @@ def run_text_topics(
                 "article_rows": len(result.embeddings),
                 "embedding_rows": len(result.embeddings),
                 "topic_label_rows": len(result.topic_labels),
+                "topic_review": result.topic_review,
                 "topic_feature_rows": len(result.feature_records),
             }
         )
@@ -224,6 +230,7 @@ def run_text_topics(
             run_id=config.run_id,
             embedding_key=embedding_key,
             topic_label_key=topic_label_key,
+            topic_review_key=topic_review_key,
             topic_feature_key=topic_feature_key,
             manifest_key=manifest_key,
             sentence_rows=len(records),

--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -1437,6 +1437,89 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
         </details>`;
     }}
 
+    function topicReviewText(value, fallback = 'n/a') {{
+      if (Array.isArray(value)) {{
+        const items = value.map((item) => String(item ?? '').trim()).filter(Boolean);
+        return items.length ? items.join(', ') : fallback;
+      }}
+      const text = String(value ?? '').trim();
+      return text || fallback;
+    }}
+
+    function topicReviewList(value, fallback = 'n/a') {{
+      if (!Array.isArray(value)) return fallback;
+      const items = value.map((item) => String(item ?? '').trim()).filter(Boolean);
+      return items.length ? items.join(' | ') : fallback;
+    }}
+
+    function renderTopicReviewCard(topic) {{
+      const topicLabel = topic.topic_label || 'Topic';
+      const topicKeywords = topicReviewText(topic.topic_keywords, topic.topic_keyword_text || 'n/a');
+      const topicExamples = Array.isArray(topic.topic_example_texts) ? topic.topic_example_texts : [];
+      const topicExampleText = topic.topic_example_text || topicExamples[0] || 'n/a';
+      const topicRowCount = Number(topic.topic_row_count || 0);
+      const topicRowShare = Number(topic.topic_row_share || 0);
+      const topicProbabilityMean = Number(topic.topic_probability_mean);
+      const topicProbabilityMax = Number(topic.topic_probability_max);
+      return `
+        <details class="row-item">
+          <summary>
+            <span class="article-title">${{escapeHtml(topicLabel)}}</span>
+            <span class="badge">rows: ${{topicRowCount}}</span>
+            <span class="badge">share: ${{formatNumber(topicRowShare * 100, 1)}}%</span>
+            ${{Number.isFinite(topicProbabilityMean) ? `<span class="badge">mean prob: ${{formatNumber(topicProbabilityMean, 3)}}</span>` : ''}}
+            ${{Number.isFinite(topicProbabilityMax) ? `<span class="badge">max prob: ${{formatNumber(topicProbabilityMax, 3)}}</span>` : ''}}
+          </summary>
+          <div class="body">
+            <p class="article-copy">What am I looking at? A human-readable BERTopic summary. Why does it matter? Reviewers should see the topic label, keywords, and representative examples before accepting the corpus. What would make this good or bad? Good: the topic label and examples match the article set. Bad: empty keywords, no example text, or a single catch-all topic.</p>
+            <div class="compact-grid">
+              <div class="compact"><div class="k">Topic label</div><div class="v">${{escapeHtml(topicLabel)}}</div><div class="k">raw: topic_label</div></div>
+              <div class="compact"><div class="k">Topic keywords</div><div class="v">${{escapeHtml(topicKeywords)}}</div><div class="k">raw: topic_keywords / topic_keyword_text</div></div>
+              <div class="compact"><div class="k">Example text</div><div class="v">${{escapeHtml(topicExampleText)}}</div><div class="k">raw: topic_example_text</div></div>
+              <div class="compact"><div class="k">Example texts</div><div class="v">${{escapeHtml(topicReviewList(topicExamples))}}</div><div class="k">raw: topic_example_texts</div></div>
+              <div class="compact"><div class="k">Row count</div><div class="v">${{topicRowCount}}</div><div class="k">raw: topic_row_count</div></div>
+              <div class="compact"><div class="k">Row share</div><div class="v">${{formatNumber(topicRowShare * 100, 1)}}%</div><div class="k">raw: topic_row_share</div></div>
+              ${{Number.isFinite(topicProbabilityMean) ? `<div class="compact"><div class="k">Mean probability</div><div class="v">${{formatNumber(topicProbabilityMean, 3)}}</div><div class="k">raw: topic_probability_mean</div></div>` : ''}}
+              ${{Number.isFinite(topicProbabilityMax) ? `<div class="compact"><div class="k">Max probability</div><div class="v">${{formatNumber(topicProbabilityMax, 3)}}</div><div class="k">raw: topic_probability_max</div></div>` : ''}}
+            </div>
+          </div>
+        </details>`;
+    }}
+
+    function renderTopicReviewRow(row) {{
+      const topicLabel = row.topic_label || 'Topic';
+      const topicKeywords = topicReviewText(row.topic_keywords, row.topic_keyword_text || 'n/a');
+      const topicExamples = Array.isArray(row.topic_example_texts) ? row.topic_example_texts : [];
+      const topicExampleText = row.topic_example_text || topicExamples[0] || 'n/a';
+      const topicRowCount = Number(row.topic_row_count || 0);
+      const topicRowShare = Number(row.topic_row_share || 0);
+      const topicProbability = Number(row.topic_probability);
+      const topicProbabilityMean = Number(row.topic_probability_mean);
+      const topicProbabilityMax = Number(row.topic_probability_max);
+      return `
+        <details class="row-item">
+          <summary>
+            <span class="article-title">${{escapeHtml(row.date || 'n/a')}} · ${{escapeHtml(row.ticker || 'n/a')}}</span>
+            <span class="badge">${{escapeHtml(topicLabel)}}</span>
+            <span class="badge">prob: ${{formatNumber(topicProbability, 3)}}</span>
+            <span class="badge">rows: ${{topicRowCount}}</span>
+          </summary>
+          <div class="body">
+            <div class="compact-grid">
+              <div class="compact"><div class="k">Topic label</div><div class="v">${{escapeHtml(topicLabel)}}</div><div class="k">raw: topic_label</div></div>
+              <div class="compact"><div class="k">Topic keywords</div><div class="v">${{escapeHtml(topicKeywords)}}</div><div class="k">raw: topic_keywords / topic_keyword_text</div></div>
+              <div class="compact"><div class="k">Example text</div><div class="v">${{escapeHtml(topicExampleText)}}</div><div class="k">raw: topic_example_text</div></div>
+              <div class="compact"><div class="k">Row count</div><div class="v">${{topicRowCount}}</div><div class="k">raw: topic_row_count</div></div>
+              <div class="compact"><div class="k">Row share</div><div class="v">${{formatNumber(topicRowShare * 100, 1)}}%</div><div class="k">raw: topic_row_share</div></div>
+              <div class="compact"><div class="k">Probability</div><div class="v">${{formatNumber(topicProbability, 3)}}</div><div class="k">raw: topic_probability</div></div>
+              ${{Number.isFinite(topicProbabilityMean) ? `<div class="compact"><div class="k">Mean probability</div><div class="v">${{formatNumber(topicProbabilityMean, 3)}}</div><div class="k">raw: topic_probability_mean</div></div>` : ''}}
+              ${{Number.isFinite(topicProbabilityMax) ? `<div class="compact"><div class="k">Max probability</div><div class="v">${{formatNumber(topicProbabilityMax, 3)}}</div><div class="k">raw: topic_probability_max</div></div>` : ''}}
+            </div>
+            <p class="article-copy">${{escapeHtml(topicExamples.length ? topicReviewList(topicExamples) : topicExampleText)}}</p>
+          </div>
+        </details>`;
+    }}
+
     function renderTopicRelevanceReview(payload) {{
       const review = payload.topic_relevance_review || {{}};
       const summary = review.summary || {{}};
@@ -1461,7 +1544,28 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
           ${{metricCard('Missing/default', summary.missing_or_default_count ?? 0, 'topic_relevance_review.summary.missing_or_default_count', 'Rows missing required topic, embedding, or relevance support.')}}
         </div>
         ${{topicReviewWarning ? `<div class="chart-blocker"><h3>Topic review diversity warning</h3><p>${{escapeHtml(topicReviewWarning)}}</p><p class="section-note">Layer 1 topic review should surface readable labels, keywords, and examples. This warning means the corpus is too concentrated or collapsed into a single catch-all topic, so the review evidence is not yet diverse.</p><p class="muted">Review rows: ${{Number(topicReviewRows.length || 0)}} · Topics: ${{Number(topicReviewCards.length || 0)}}</p></div>` : ''}}
-        ''
+        ${{reviewable ? '' : `<div class="chart-blocker"><h3>Topic / relevance is not reviewable yet</h3><p>${{escapeHtml(summary.review_explanation || 'Missing topic, embedding, or relevance-gate evidence.')}}</p><p class="section-note">Missing embedding, topic, or relevance-gate evidence still blocks human acceptance.</p>${{blockerPreview.length ? `<div class="row-list">${{blockerPreview.map((blocker) => `
+          <div class="compact-grid" style="margin-bottom: 12px;">
+            <div class="compact"><div class="k">Article</div><div class="v">${{escapeHtml(blocker.article_id || 'n/a')}}</div><div class="k">raw: article_id</div></div>
+            <div class="compact"><div class="k">Status</div><div class="v">${{escapeHtml(blocker.evidence_status || 'n/a')}}</div><div class="k">raw: evidence_status</div></div>
+            <div class="compact"><div class="k">Interpretation</div><div class="v">${{escapeHtml(blocker.relevance_score_interpretation || 'n/a')}}</div><div class="k">raw: relevance_score_interpretation</div></div>
+            <div class="compact"><div class="k">Missing evidence flags</div><div class="v">${{escapeHtml(topicReviewList(blocker.missing_evidence_flags || []))}}</div><div class="k">raw: missing_evidence_flags</div></div>
+          </div>
+        `).join('')}}</div>` : ''}}</div>` : ''}}
+        <div class="panel">
+          <h3>Topic review cards</h3>
+          <p class="section-note">Layer 1 topic review should surface readable labels, keywords, examples, row counts, and probability summaries before the review is accepted.</p>
+          <div class="row-list">
+            ${{topicReviewCards.length ? topicReviewCards.map(renderTopicReviewCard).join('') : '<p class="muted">No topic review cards were loaded for this run.</p>'}}
+          </div>
+        </div>
+        <div class="panel">
+          <h3>Topic review rows</h3>
+          <p class="section-note">These rows keep the underlying article-level topic evidence visible and separate from the summary cards.</p>
+          <div class="row-list">
+            ${{topicReviewRows.length ? topicReviewRows.map(renderTopicReviewRow).join('') : '<p class="muted">No topic review rows were loaded for this run.</p>'}}
+          </div>
+        </div>
         <div class="date-grid">
           ${{dateGroups.length ? dateGroups.map((group) => `
             <details class="date-card">

--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -1444,6 +1444,12 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       const blockers = Array.isArray(review.missing_evidence_blockers) ? review.missing_evidence_blockers : [];
       const blockerPreview = blockers.slice(0, 12);
       const reviewable = summary.reviewable === true;
+      const topicReview = payload.topic_review || {{}};
+      const topicReviewSummary = topicReview.summary || {{}};
+      const topicReviewTopics = Array.isArray(topicReview.topics) ? topicReview.topics : [];
+      const topicReviewRows = Array.isArray(topicReview.rows) ? topicReview.rows : [];
+      const topicReviewCards = topicReviewTopics.slice(0, 6);
+      const topicReviewWarning = topicReviewSummary.warning || summary.topic_review_warning || '';
       topicRelevanceReviewEl.innerHTML = `
         <div class="hero-grid">
           ${{metricCard('Articles', summary.article_count ?? 0, 'topic_relevance_review.summary.article_count', 'Article-level topic/relevance evidence rows.')}}
@@ -1454,7 +1460,8 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
           ${{metricCard('Rejected', summary.rejected_count ?? 0, 'topic_relevance_review.summary.rejected_count', 'Rows rejected by the relevance gate.')}}
           ${{metricCard('Missing/default', summary.missing_or_default_count ?? 0, 'topic_relevance_review.summary.missing_or_default_count', 'Rows missing required topic, embedding, or relevance support.')}}
         </div>
-        ${{!reviewable ? `<div class="chart-blocker"><h3>Topic / relevance is not reviewable yet</h3><p>${{escapeHtml(summary.review_explanation || 'Required topic/relevance evidence is missing.')}}</p><details><summary>Show sample affected articles (${{blockers.length}} total)</summary><div class="body"><ul>${{blockerPreview.map((item) => `<li>${{escapeHtml(item.date || 'n/a')}} · ${{escapeHtml(item.article_id || 'n/a')}} · ${{escapeHtml((item.missing_evidence_flags || []).join(', '))}}</li>`).join('')}}</ul></div></details></div>` : ''}}
+        ${{topicReviewWarning ? `<div class="chart-blocker"><h3>Topic review diversity warning</h3><p>${{escapeHtml(topicReviewWarning)}}</p><p class="section-note">Layer 1 topic review should surface readable labels, keywords, and examples. This warning means the corpus is too concentrated or collapsed into a single catch-all topic, so the review evidence is not yet diverse.</p><p class="muted">Review rows: ${{Number(topicReviewRows.length || 0)}} · Topics: ${{Number(topicReviewCards.length || 0)}}</p></div>` : ''}}
+        ''
         <div class="date-grid">
           ${{dateGroups.length ? dateGroups.map((group) => `
             <details class="date-card">

--- a/core/features/aapl_evidence.py
+++ b/core/features/aapl_evidence.py
@@ -17,6 +17,7 @@ import pandas as pd
 
 from core.common.trading_calendar import skipped_non_trading_dates, trading_dates
 from core.features.regime_training import HMM_TRAINING_FEATURE_COLUMNS
+from core.features.text_topics import build_topic_review_payload
 from services.r2.paths import (
     layer1_feature_path,
     layer1_news_preprocessing_path,
@@ -213,6 +214,7 @@ class Layer1SemanticReviewReport:
     preprocessing_rows: list[dict[str, object]]
     embedding_rows: list[dict[str, object]]
     topic_label_rows: list[dict[str, object]]
+    topic_review: dict[str, object]
     relevance_gate_rows: list[dict[str, object]]
     semantic_aggregate_rows: list[dict[str, object]]
     regime_rows: list[dict[str, object]]
@@ -442,7 +444,12 @@ def build_layer1_aapl_evidence_report(
 
     preprocessing_rows = _preprocessing_rows(preprocessing_frame, requested_ticker=requested_ticker)
     embedding_rows = _embedding_rows(embedding_frame)
-    topic_label_rows = _topic_label_rows(topic_label_frame, requested_ticker=requested_ticker)
+    topic_review = build_topic_review_payload(topic_label_frame)
+    topic_label_rows = _topic_label_rows(
+        topic_label_frame,
+        requested_ticker=requested_ticker,
+        topic_review=topic_review,
+    )
     relevance_gate_rows = _relevance_gate_rows(relevance_gate_frame, requested_ticker=requested_ticker)
     semantic_aggregate_rows = _semantic_aggregate_rows(
         semantic_aggregate_frame,
@@ -531,6 +538,7 @@ def build_layer1_aapl_evidence_report(
         preprocessing_rows=preprocessing_rows,
         embedding_rows=embedding_rows,
         topic_label_rows=topic_label_rows,
+        topic_review=topic_review,
         relevance_gate_rows=relevance_gate_rows,
         semantic_aggregate_rows=semantic_aggregate_rows,
         regime_rows=[item.to_dict() for item in _regime_rows_from_map(regime_by_date)],
@@ -1467,22 +1475,31 @@ def _topic_label_rows(
     frame: pd.DataFrame,
     *,
     requested_ticker: str,
+    topic_review: Mapping[str, object] | None = None,
 ) -> list[dict[str, object]]:
     """Return normalized topic-label evidence rows for dashboard review."""
     if frame.empty:
         return []
     normalized = frame.copy()
     normalized.columns = [str(column) for column in normalized.columns]
+    review_rows_by_article_id: dict[str, dict[str, object]] = {}
+    if topic_review:
+        for review_row in _json_list(topic_review.get("rows")):
+            article_id = _optional_str(review_row.get("article_id"))
+            if article_id:
+                review_rows_by_article_id[article_id] = review_row
     rows: list[dict[str, object]] = []
     for _, row in normalized.iterrows():
         ticker = (_optional_str(row.get("ticker")) or "").upper()
         if ticker and ticker != requested_ticker:
             continue
+        article_id = _optional_str(row.get("article_id"))
+        review_row = review_rows_by_article_id.get(article_id or "")
         rows.append(
             {
                 "date": _optional_str(row.get("date")),
                 "ticker": ticker or requested_ticker,
-                "article_id": _optional_str(row.get("article_id")),
+                "article_id": article_id,
                 "normalized_headline": _optional_str(row.get("normalized_headline")),
                 "article_sentence_count": _maybe_int(row.get("article_sentence_count")),
                 "embedding_cache_key": _optional_str(row.get("embedding_cache_key")),
@@ -1490,8 +1507,29 @@ def _topic_label_rows(
                 "topic_model_version": _optional_str(row.get("topic_model_version")),
                 "topic_id": _maybe_int(row.get("topic_id")),
                 "topic_probability": _maybe_float(row.get("topic_probability")),
-                "topic_label": _optional_str(row.get("topic_label")),
-                "topic_keywords": _json_string_list(row.get("topic_keywords")),
+                "topic_label": _optional_str(review_row.get("topic_label"))
+                if review_row
+                else _optional_str(row.get("topic_label")),
+                "topic_keywords": _json_string_list(
+                    review_row.get("topic_keywords") if review_row else row.get("topic_keywords")
+                ),
+                "topic_keyword_text": _optional_str(review_row.get("topic_keyword_text"))
+                if review_row
+                else _optional_str(row.get("topic_keyword_text")),
+                "topic_example_text": _optional_str(review_row.get("topic_example_text"))
+                if review_row
+                else _optional_str(row.get("topic_example_text")),
+                "topic_example_texts": _json_string_list(
+                    review_row.get("topic_example_texts") if review_row else row.get("topic_example_texts")
+                ),
+                "topic_row_count": _maybe_int(review_row.get("topic_row_count")) if review_row else None,
+                "topic_row_share": _maybe_float(review_row.get("topic_row_share")) if review_row else None,
+                "topic_diversity_status": _optional_str(topic_review.get("diversity_status"))
+                if topic_review
+                else None,
+                "topic_diversity_reason": _optional_str(topic_review.get("diversity_reason"))
+                if topic_review
+                else None,
                 "artifact_key": _optional_str(row.get("_artifact_key")),
                 "stage": "article_topic_labels",
             }
@@ -2040,11 +2078,13 @@ def _build_payload_from_report(report: Layer1SemanticReviewReport | Mapping[str,
         "accepted_articles": accepted_articles,
         "flagged_articles": flagged_articles,
         "article_review": _build_article_review_payload(date_groups=date_groups),
+        "topic_review": _json_mapping(report_dict.get("topic_review")),
         "pipeline_sections": {
             "raw_preprocessing_rows": list(report_dict.get("preprocessing_rows", [])),
             "article_embedding_rows": list(report_dict.get("embedding_rows", [])),
             "topic_label_rows": list(report_dict.get("topic_label_rows", [])),
             "relevance_gate_rows": list(report_dict.get("relevance_gate_rows", [])),
+            "topic_review": _json_mapping(report_dict.get("topic_review")),
             "finbert_sentence_rows": [
                 row
                 for article in article_groups

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -119,6 +119,7 @@ def build_layer1_topic_relevance_review(
         for item in _json_list(payload.get("article_groups"))
         if isinstance(item, Mapping)
     ]
+    topic_review = _json_mapping(payload.get("topic_review"))
     preprocessing_by_article = _rows_by_article(sections.get("raw_preprocessing_rows"))
     embedding_by_article = _rows_by_article(sections.get("article_embedding_rows"))
     topic_by_article = _rows_by_article(sections.get("topic_label_rows"))
@@ -127,6 +128,15 @@ def build_layer1_topic_relevance_review(
     embedding_rows = _json_list(sections.get("article_embedding_rows"))
     topic_rows = _json_list(sections.get("topic_label_rows"))
     relevance_rows = _json_list(sections.get("relevance_gate_rows"))
+    diversity_status = str(topic_review.get("diversity_status") or "unknown")
+    diversity_reason = _optional_str(topic_review.get("diversity_reason"))
+    topic_review_topics = _json_list(topic_review.get("topics"))
+    topic_review_rows = _json_list(topic_review.get("rows"))
+    topic_review_warning = (
+        None
+        if diversity_status == "diverse"
+        else diversity_reason or "Topic diversity is insufficient for a varied review sample."
+    )
 
     rows = [
         _topic_relevance_article_row(
@@ -185,6 +195,10 @@ def build_layer1_topic_relevance_review(
             "topic_label_row_count": len(topic_rows),
             "relevance_gate_row_count": len(relevance_rows),
             "relevance_gate_available": bool(relevance_rows),
+            "topic_review_row_count": len(topic_review_rows),
+            "topic_review_topic_count": len(topic_review_topics),
+            "topic_review_diversity_status": diversity_status,
+            "topic_review_warning": topic_review_warning,
             "accepted_count": sum(
                 1 for row in rows if row.get("evidence_status") == "accepted"
             ),
@@ -222,8 +236,22 @@ def build_layer1_topic_relevance_review(
         },
         "date_groups": date_groups,
         "articles": rows,
+        "topic_review": {
+            "summary": {
+                "row_count": len(topic_review_rows),
+                "topic_count": len(topic_review_topics),
+                "diversity_status": diversity_status,
+                "diversity_reason": diversity_reason,
+                "warning": topic_review_warning,
+                "dominant_topic_id": topic_review.get("dominant_topic_id"),
+                "dominant_topic_share": topic_review.get("dominant_topic_share"),
+            },
+            "topics": topic_review_topics,
+            "rows": topic_review_rows,
+        },
         "missing_evidence_blockers": missing_blockers,
     }
+
 
 
 def build_layer1_semantic_aggregate_review(
@@ -883,6 +911,14 @@ def _json_string_list(value: Any) -> list[str]:
     if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
         return [str(item) for item in value if str(item)]
     return []
+
+
+def _optional_str(value: Any) -> str | None:
+    """Return a stripped string when a value is present."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
 
 
 def _dedupe_preserve_order(items: Sequence[str]) -> list[str]:

--- a/core/features/text_topics.py
+++ b/core/features/text_topics.py
@@ -5,6 +5,8 @@ import hashlib
 import importlib
 import json
 import math
+import re
+from collections import Counter
 from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Any, Protocol
@@ -98,6 +100,103 @@ class TopicModelConfig:
             raise ValueError("model_version cannot be empty")
 
 
+_TOPIC_FALLBACK_STOPWORDS = {
+    "a",
+    "about",
+    "after",
+    "all",
+    "also",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "before",
+    "by",
+    "for",
+    "from",
+    "has",
+    "have",
+    "in",
+    "into",
+    "is",
+    "it",
+    "its",
+    "new",
+    "of",
+    "on",
+    "or",
+    "said",
+    "shares",
+    "the",
+    "their",
+    "this",
+    "to",
+    "with",
+    "via",
+    "over",
+    "up",
+}
+
+
+def _optional_int(value: object) -> int | None:
+    """Return an int if the value is numeric, otherwise None."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return None if math.isnan(value) else int(value)
+    try:
+        parsed = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(parsed) else int(parsed)
+
+
+def _optional_float(value: object) -> float | None:
+    """Return a float if the value is numeric, otherwise None."""
+    if value is None or isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return None if isinstance(value, float) and math.isnan(value) else float(value)
+    try:
+        parsed = float(str(value))
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(parsed) else parsed
+
+
+def _optional_str(value: object) -> str | None:
+    """Return a stripped string if present, otherwise None."""
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _coerce_string_list(value: object) -> list[str]:
+    """Return a normalized list of human-readable strings from JSON-ish values."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            return [text]
+        if isinstance(parsed, list):
+            return [str(item).strip() for item in parsed if str(item).strip()]
+        return [str(parsed).strip()]
+    if isinstance(value, Sequence) and not isinstance(value, (bytes, bytearray, str)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    text = str(value).strip()
+    return [text] if text else []
+
+
 @dataclass(frozen=True)
 class TextTopicResult:
     """Computed article embedding cache, topic labels, and ticker-day topic features."""
@@ -105,6 +204,7 @@ class TextTopicResult:
     embeddings: Any
     topic_labels: Any
     feature_records: list[FeatureRecord]
+    topic_review: dict[str, object]
 
 
 @dataclass(frozen=True)
@@ -151,7 +251,100 @@ def compute_text_topics(
         embeddings=embeddings,
         topic_labels=topic_labels,
         feature_records=topic_labels_to_feature_records(topic_labels),
+        topic_review=build_topic_review_payload(topic_labels, topic_labeler=topic_labeler),
     )
+
+
+def build_topic_review_payload(
+    topic_labels: Any,
+    *,
+    topic_labeler: Any | None = None,
+) -> dict[str, object]:
+    """Build a human-readable topic review payload from topic label rows."""
+    if len(topic_labels) == 0:
+        return {
+            "status": "warn",
+            "diversity_status": "insufficient_diversity",
+            "diversity_reason": "No topic rows were produced.",
+            "row_count": 0,
+            "topic_count": 0,
+            "dominant_topic_id": None,
+            "dominant_topic_share": None,
+            "topics": [],
+            "rows": [],
+        }
+
+    _require_columns(topic_labels, TOPIC_LABEL_COLUMNS)
+    frame = topic_labels.copy()
+    frame.columns = [str(column) for column in frame.columns]
+    frame["topic_id"] = frame["topic_id"].map(int)
+    frame["topic_probability"] = frame["topic_probability"].map(float)
+
+    topic_info = _topic_info_lookup(topic_labeler)
+    topic_summaries: list[dict[str, object]] = []
+    row_payloads: list[dict[str, object]] = []
+    valid_rows = frame[frame["topic_id"] >= 0].copy()
+    invalid_rows = frame[frame["topic_id"] < 0].copy()
+    topic_count = int(valid_rows["topic_id"].nunique()) if len(valid_rows) else 0
+
+    for topic_id, group in valid_rows.groupby("topic_id", sort=True):
+        summary = _summarize_topic_group(
+            group,
+            topic_id=int(topic_id),
+            topic_info=topic_info,
+            topic_labeler=topic_labeler,
+            total_rows=len(frame),
+        )
+        topic_summaries.append(summary)
+        row_payloads.extend(_topic_rows_with_summary(group, summary))
+
+    if len(invalid_rows):
+        invalid_summary = _summarize_topic_group(
+            invalid_rows,
+            topic_id=-1,
+            topic_info=topic_info,
+            topic_labeler=topic_labeler,
+            total_rows=len(frame),
+        )
+        invalid_summary["topic_label"] = "Outlier / Unassigned"
+        invalid_summary["topic_keywords"] = []
+        row_payloads.extend(_topic_rows_with_summary(invalid_rows, invalid_summary))
+
+    dominant_topic_id: int | None = None
+    dominant_topic_share: float | None = None
+    diversity_reason = "No non-outlier topics were detected."
+    diversity_status = "insufficient_diversity"
+    if topic_summaries:
+        dominant = max(topic_summaries, key=lambda item: float(item["topic_row_share"]))
+        dominant_topic_id = int(dominant["topic_id"])
+        dominant_topic_share = float(dominant["topic_row_share"])
+        if len(topic_summaries) == 1:
+            diversity_reason = f"Only one topic was detected across {len(valid_rows)} rows."
+            diversity_status = "insufficient_diversity"
+        elif dominant_topic_share >= 0.85:
+            diversity_reason = (
+                f"One topic covers {dominant_topic_share:.0%} of rows, so the corpus is too "
+                "concentrated for a varied review sample."
+            )
+            diversity_status = "concentrated"
+        else:
+            diversity_reason = f"Detected {len(topic_summaries)} topics across {len(valid_rows)} rows."
+            diversity_status = "diverse"
+
+    status = "pass" if diversity_status == "diverse" else "warn"
+    row_payloads.sort(key=_topic_row_sort_key)
+    topic_summaries.sort(key=_topic_summary_sort_key)
+    return {
+        "status": status,
+        "diversity_status": diversity_status,
+        "diversity_reason": diversity_reason,
+        "row_count": int(len(frame)),
+        "topic_count": topic_count,
+        "dominant_topic_id": dominant_topic_id,
+        "dominant_topic_share": dominant_topic_share,
+        "topics": topic_summaries,
+        "rows": row_payloads,
+    }
 
 
 def compute_sentence_embeddings(
@@ -333,6 +526,251 @@ def topic_labels_to_feature_records(topic_labels: Any) -> list[FeatureRecord]:
             )
         )
     return records
+
+
+def _topic_info_lookup(topic_labeler: Any | None) -> dict[int, str]:
+    """Return optional topic names keyed by topic id."""
+    if topic_labeler is None or not hasattr(topic_labeler, "get_topic_info"):
+        return {}
+
+    try:
+        topic_info = topic_labeler.get_topic_info()
+    except Exception:  # pragma: no cover - defensive against optional BERTopic APIs
+        return {}
+
+    pd = _require_pandas()
+    if not isinstance(topic_info, pd.DataFrame) or "Topic" not in topic_info.columns:
+        return {}
+
+    name_column = None
+    for candidate in ("Name", "Representation", "TopicName"):
+        if candidate in topic_info.columns:
+            name_column = candidate
+            break
+    if name_column is None:
+        return {}
+
+    names: dict[int, str] = {}
+    for _, row in topic_info.iterrows():
+        topic_value = row.get("Topic")
+        if topic_value is None:
+            continue
+        try:
+            topic_id = int(topic_value)
+        except (TypeError, ValueError):
+            continue
+        name = str(row.get(name_column, "")).strip()
+        if name:
+            names[topic_id] = name
+    return names
+
+
+def _summarize_topic_group(
+    group: Any,
+    *,
+    topic_id: int,
+    topic_info: dict[int, str],
+    topic_labeler: Any | None,
+    total_rows: int,
+) -> dict[str, object]:
+    """Summarize one topic group for review output."""
+    texts = [str(text or "") for text in group["text"].tolist() if str(text or "").strip()]
+    first_row = group.iloc[0] if len(group) else None
+    explicit_label = _optional_str(first_row["topic_label"]) if first_row is not None and "topic_label" in group.columns else None
+    explicit_keywords = _coerce_string_list(first_row["topic_keywords"]) if first_row is not None and "topic_keywords" in group.columns else []
+    keywords = explicit_keywords or _topic_keywords_for_group(
+        topic_id=topic_id,
+        texts=texts,
+        topic_labeler=topic_labeler,
+        topic_name=topic_info.get(topic_id),
+    )
+    representative_row = group.copy()
+    representative_row["_sort_text_length"] = representative_row["text"].map(
+        lambda value: len(str(value or ""))
+    )
+    representative_row = representative_row.sort_values(
+        by=["topic_probability", "_sort_text_length", "article_id", "date"],
+        ascending=[False, False, True, True],
+        kind="mergesort",
+    )
+    primary_text = str(representative_row.iloc[0]["text"] or "") if len(representative_row) else ""
+    example_texts = _representative_texts(group)
+    row_count = int(len(group))
+    return {
+        "topic_id": topic_id,
+        "topic_label": explicit_label or _format_topic_label(
+            topic_id=topic_id,
+            keywords=keywords,
+            topic_name=topic_info.get(topic_id),
+        ),
+        "topic_keywords": keywords,
+        "topic_keyword_text": ", ".join(keywords),
+        "topic_example_text": primary_text,
+        "topic_example_texts": example_texts,
+        "topic_row_count": row_count,
+        "topic_row_share": row_count / max(1, total_rows),
+        "topic_probability_mean": float(group["topic_probability"].mean()),
+        "topic_probability_max": float(group["topic_probability"].max()),
+    }
+
+
+def _topic_rows_with_summary(
+    group: Any,
+    summary: dict[str, object],
+) -> list[dict[str, object]]:
+    """Return row-level review payloads decorated with topic summary fields."""
+    rows: list[dict[str, object]] = []
+    keywords = list(summary.get("topic_keywords", []))
+    example_text = summary.get("topic_example_text")
+    for record in group.to_dict(orient="records"):
+        rows.append(
+            {
+                "date": str(record.get("date", "")),
+                "ticker": str(record.get("ticker", "")),
+                "article_id": _optional_str(record.get("article_id")),
+                "normalized_headline": _optional_str(record.get("normalized_headline")),
+                "text": _optional_str(record.get("text")),
+                "article_sentence_count": _optional_int(record.get("article_sentence_count")),
+                "topic_id": _optional_int(record.get("topic_id")),
+                "topic_probability": _optional_float(record.get("topic_probability")),
+                "topic_label": str(summary.get("topic_label", "")),
+                "topic_keywords": keywords,
+                "topic_keyword_text": str(summary.get("topic_keyword_text", "")),
+                "topic_example_text": _optional_str(example_text),
+                "topic_example_texts": list(summary.get("topic_example_texts", [])),
+                "topic_row_count": _optional_int(summary.get("topic_row_count")),
+                "topic_row_share": _optional_float(summary.get("topic_row_share")),
+            }
+        )
+    return rows
+
+
+def _topic_row_sort_key(row: dict[str, object]) -> tuple[str, str, int]:
+    """Return a stable sort key for topic review rows."""
+    return (
+        str(row.get("date", "")),
+        str(row.get("ticker", "")),
+        _optional_int(row.get("article_sentence_count")) or -1,
+    )
+
+
+def _topic_summary_sort_key(summary: dict[str, object]) -> tuple[float, int]:
+    """Return a stable sort key for topic review summaries."""
+    topic_share = _optional_float(summary.get("topic_row_share")) or 0.0
+    topic_id = _optional_int(summary.get("topic_id")) or -1
+    return (-topic_share, topic_id)
+
+
+def _topic_keywords_for_group(
+    *,
+    topic_id: int,
+    texts: Sequence[str],
+    topic_labeler: Any | None,
+    topic_name: str | None,
+) -> list[str]:
+    """Return up to five human-readable keywords for one topic group."""
+    keywords = _extract_topic_keywords(topic_labeler, topic_id)
+    if not keywords and topic_name:
+        keywords = _keywords_from_topic_name(topic_name)
+    if not keywords:
+        keywords = _keywords_from_texts(texts)
+    return keywords[:5]
+
+
+def _extract_topic_keywords(topic_labeler: Any | None, topic_id: int) -> list[str]:
+    """Extract keywords from an optional topic model wrapper."""
+    if topic_labeler is None:
+        return []
+    topic_getter = getattr(topic_labeler, "get_topic", None)
+    if topic_getter is None:
+        return []
+    try:
+        topic_data = topic_getter(topic_id)
+    except Exception:  # pragma: no cover - optional topic API fallback
+        return []
+    if not topic_data:
+        return []
+
+    keywords: list[str] = []
+    for item in topic_data:
+        if isinstance(item, tuple) and item:
+            keyword = str(item[0]).strip()
+        else:
+            keyword = str(item).strip()
+        if keyword:
+            keywords.append(keyword)
+    return keywords
+
+
+def _keywords_from_topic_name(topic_name: str) -> list[str]:
+    """Derive readable keywords from a topic name string."""
+    cleaned = re.sub(r"^\d+[_\-\s]*", "", topic_name)
+    cleaned = cleaned.replace("/", " ").replace("_", " ").replace("-", " ")
+    tokens = [token for token in cleaned.split() if token]
+    return [token.lower() for token in tokens if token.lower() not in _TOPIC_FALLBACK_STOPWORDS]
+
+
+def _keywords_from_texts(texts: Sequence[str]) -> list[str]:
+    """Derive fallback keywords from representative texts."""
+    tokens: list[str] = []
+    for text in texts:
+        tokens.extend(
+            token.lower()
+            for token in re.findall(r"[A-Za-z][A-Za-z0-9'\-]+", text)
+            if token.lower() not in _TOPIC_FALLBACK_STOPWORDS and len(token) > 2
+        )
+    counts = Counter(tokens)
+    return [word for word, _ in counts.most_common(5)]
+
+
+def _representative_texts(group: Any, *, limit: int = 2) -> list[str]:
+    """Return up to `limit` representative texts ordered by confidence."""
+    rows = group.copy()
+    rows["_sort_text_length"] = rows["text"].map(lambda value: len(str(value or "")))
+    rows = rows.sort_values(
+        by=["topic_probability", "_sort_text_length", "article_id", "date"],
+        ascending=[False, False, True, True],
+        kind="mergesort",
+    )
+    texts: list[str] = []
+    for value in rows["text"].tolist():
+        text = str(value or "").strip()
+        if not text or text in texts:
+            continue
+        texts.append(text)
+        if len(texts) >= limit:
+            break
+    return texts
+
+
+def _format_topic_label(
+    *,
+    topic_id: int,
+    keywords: Sequence[str],
+    topic_name: str | None,
+) -> str:
+    """Return a human-readable label for one topic."""
+    if topic_name:
+        label = re.sub(r"^\d+[_\-\s]*", "", topic_name).replace("_", " ").replace("-", " ")
+        label = " ".join(label.split())
+        if label:
+            return _title_case_phrase(label)
+    if keywords:
+        return " / ".join(_title_case_phrase(keyword) for keyword in keywords[:3])
+    if topic_id < 0:
+        return "Outlier / Unassigned"
+    return f"Topic {topic_id}"
+
+
+def _title_case_phrase(value: str) -> str:
+    """Title-case a phrase while preserving all-caps acronyms."""
+    parts: list[str] = []
+    for token in value.split():
+        if token.isupper() or token.isdigit():
+            parts.append(token)
+        else:
+            parts.append(token[:1].upper() + token[1:].lower())
+    return " ".join(parts)
 
 
 def feature_records_to_frame(records: Sequence[FeatureRecord]) -> Any:

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,8 @@ The system is designed around four deployment surfaces:
 2. **Cloud (heavy compute) — Modal**
    Used for:
    - daily Layer 1 feature generation after the Pi finishes Layer 0
+   - Layer 1 topic-review artifacts that pair topic labels with human-readable labels,
+     keywords, examples, and diversity warnings for review dashboards
    - FinBERT inference on news text
    - offline FinBERT evaluation and optional fine-tuning from archived news plus
      return-derived labels

--- a/docs/data_contracts.md
+++ b/docs/data_contracts.md
@@ -674,7 +674,8 @@ Never:
 - Layer 0 output → `UniverseRecord`, `OHLCVRecord`
 - Layer 0 raw archives → Alpaca news, SimFin fundamentals/earnings, FRED macro/rates
   (R2 artifacts, not separate Pydantic inter-layer contracts)
-- Layer 1 output → `NewsSentimentRecord`, `FeatureRecord`
+- Layer 1 output → `NewsSentimentRecord`, `FeatureRecord` (plus Layer 1 topic-review
+  JSON artifacts used by review dashboards; not separate Pydantic contracts)
 - Layer 2 output → `ScoreRecord`
 - Layer 3 output → `PortfolioRecord`
 - Layer 4 output → `ApprovedOrderRecord`

--- a/services/r2/paths.py
+++ b/services/r2/paths.py
@@ -167,6 +167,17 @@ def layer1_topic_label_path(as_of_date: str | Date | datetime, run_id: str) -> s
     )
 
 
+def layer1_topic_review_path(as_of_date: str | Date | datetime, run_id: str) -> str:
+    """Return the canonical date-first Layer 1 topic review JSON path."""
+    safe_run_id = _validate_key_part(run_id)
+    return build_r2_key(
+        "features",
+        _format_date(as_of_date),
+        "topic_review",
+        f"{safe_run_id}.json",
+    )
+
+
 def layer1_topic_feature_path(as_of_date: str | Date | datetime, run_id: str) -> str:
     """Return the canonical date-first Layer 1 ticker-day topic feature path."""
     safe_run_id = _validate_key_part(run_id)

--- a/tests/fixtures/layer1_support.py
+++ b/tests/fixtures/layer1_support.py
@@ -47,6 +47,7 @@ from services.r2.paths import (
     layer1_regime_path,
     layer1_sentiment_feature_path,
     layer1_topic_feature_path,
+    layer1_topic_review_path,
     pipeline_manifest_path,
     raw_fundamentals_path,
     raw_macro_path,
@@ -159,10 +160,36 @@ def fake_topic_runner(writer: R2Writer, tickers: Sequence[str]):
             )
         ]
         writer.put_object(output_key, feature_records_to_parquet_bytes(records))
+        writer.put_object(
+            layer1_topic_review_path(config.as_of_date, config.run_id),
+            json.dumps(
+                {
+                    "status": "warn",
+                    "diversity_status": "insufficient_diversity",
+                    "row_count": 1,
+                    "topic_count": 1,
+                    "dominant_topic_id": 0,
+                    "dominant_topic_share": 1.0,
+                    "topics": [
+                        {
+                            "topic_id": 0,
+                            "topic_label": "topic review",
+                            "topic_keywords": ["topic", "review"],
+                            "topic_example_text": "topic review placeholder",
+                            "topic_row_count": 1,
+                            "topic_row_share": 1.0,
+                        }
+                    ],
+                    "rows": [],
+                },
+                sort_keys=True,
+            ),
+        )
         return TextTopicPipelineResult(
             run_id=config.run_id,
             embedding_key="unused",
             topic_label_key="unused",
+            topic_review_key=layer1_topic_review_path(config.as_of_date, config.run_id),
             topic_feature_key=output_key,
             manifest_key=pipeline_manifest_path("layer1_text_topics", config.run_id),
             sentence_rows=1,

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -289,6 +289,7 @@ def test_semantic_review_payload_explains_unreviewable_missing_relevance_gate(
     assert summary["reviewable"] is False
     assert summary["review_status"] == "not_reviewable_missing_relevance_gate"
     assert "Pre-FinBERT relevance gate artifact is missing" in summary["review_explanation"]
+    assert review["missing_evidence_blockers"]
 
 
 def test_semantic_review_payload_adds_human_focused_aggregate_review(
@@ -689,6 +690,16 @@ def test_semantic_review_dashboard_html_is_beginner_friendly_and_collapsed() -> 
     assert "topic-relevance-tab" in html
     assert "topic-relevance-content" in html
     assert "default score shown without support" in html
+    assert "Topic / relevance is not reviewable yet" in html
+    assert "Topic review cards" in html
+    assert "topic_label" in html
+    assert "topic_keywords" in html
+    assert "topic_example_text" in html
+    assert "topic_example_texts" in html
+    assert "topic_row_count" in html
+    assert "topic_row_share" in html
+    assert "topic_probability_mean" in html
+    assert "topic_probability_max" in html
     assert "Ticker-Date Semantic Aggregates" in html
     assert "semantic-aggregate-tab" in html
     assert "Repeated context / aggregate value" in html
@@ -750,6 +761,9 @@ def test_semantic_review_dashboard_html_names_human_review_outputs() -> None:
     )
 
     assert "Topic review diversity warning" in html
+    assert "Topic / relevance is not reviewable yet" in html
+    assert "Topic review cards" in html
+    assert "Topic review rows" in html
     assert "Sentence sentiment label" in html
     assert "Pre-FinBERT relevance gate artifact is missing" in html
     assert "Human-review digest" in html

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -65,7 +65,14 @@ def test_semantic_review_report_includes_benchmark_rows(tmp_path: Path) -> None:
     assert aapl_one["sentence_rows"][0]["row_granularity"] == "sentence-level"
     assert aapl_one["preprocessing_rows"][0]["ticker_mentions"] == ["AAPL"]
     assert aapl_one["topic_evidence"][0]["topic_label"] == "earnings and demand"
+    assert aapl_one["topic_evidence"][0]["topic_keywords"] == ["earnings", "demand", "iphone"]
+    assert aapl_one["topic_evidence"][0]["topic_example_text"]
     assert aapl_one["relevance_gate_rows"][0]["relevance_decision"] == "accepted"
+
+    topic_review = cast(dict[str, Any], report_dict["topic_review"])
+    assert topic_review["topic_count"] == 2
+    assert topic_review["diversity_status"] == "diverse"
+    assert len(cast(list[dict[str, Any]], topic_review["topics"])) == 2
 
     date_groups = {
         str(item["date"]): cast(dict[str, Any], item)
@@ -742,6 +749,7 @@ def test_semantic_review_dashboard_html_names_human_review_outputs() -> None:
         )
     )
 
+    assert "Topic review diversity warning" in html
     assert "Sentence sentiment label" in html
     assert "Pre-FinBERT relevance gate artifact is missing" in html
     assert "Human-review digest" in html

--- a/tests/unit/test_text_topics.py
+++ b/tests/unit/test_text_topics.py
@@ -65,6 +65,24 @@ class _ResettingTopicLabeler:
         return [0 for _ in batch], [0.75 for _ in batch]
 
 
+class _ReviewTopicLabeler:
+    def fit_transform(
+        self,
+        documents: Sequence[str],
+        embeddings: Sequence[Sequence[float]],
+    ) -> tuple[Sequence[int], Sequence[float]]:
+        return [0 for _ in documents], [0.93 for _ in documents]
+
+    def get_topic_info(self) -> pd.DataFrame:
+        return pd.DataFrame(
+            [{"Topic": 0, "Name": "earnings_and_guidance", "Representation": "earnings_and_guidance"}]
+        )
+
+    def get_topic(self, topic_id: int) -> list[tuple[str, float]]:
+        assert topic_id == 0
+        return [("earnings", 0.92), ("guidance", 0.86), ("revenue", 0.81)]
+
+
 def test_compute_text_topics_caches_article_embeddings_and_topic_features() -> None:
     """Article embeddings are cached once while topic labels remain ticker-specific."""
     records = [
@@ -86,12 +104,34 @@ def test_compute_text_topics_caches_article_embeddings_and_topic_features() -> N
     assert len(result.embeddings) == 1
     assert result.embeddings.loc[0, "article_sentence_count"] == 2
     assert len(result.topic_labels) == 2
-    assert {record.ticker for record in result.feature_records} == {"AAPL", "MSFT"}
-    assert all(isinstance(record, FeatureRecord) for record in result.feature_records)
-    aapl = next(record for record in result.feature_records if record.ticker == "AAPL")
-    assert aapl.features["nlp_article_count"] == 1
-    assert aapl.features["nlp_sentence_count"] == 2
-    assert aapl.features["nlp_topic_count"] == 1
+    assert result.topic_review["row_count"] == 2
+    assert result.topic_review["topic_count"] == 1
+    assert result.topic_review["diversity_status"] == "insufficient_diversity"
+    assert len(result.topic_review["rows"]) == 2
+
+
+def test_compute_text_topics_builds_human_readable_topic_review() -> None:
+    """Topic review payload exposes readable labels, keywords, and example text."""
+    result = compute_text_topics(
+        [
+            _record(text="Apple raised guidance and discussed revenue."),
+            _record(text="Management cited stronger earnings and guidance."),
+        ],
+        embedder=_FakeEmbedder(),
+        topic_labeler=_ReviewTopicLabeler(),
+        embedding_config=_embedding_config(),
+        topic_config=_topic_config(),
+    )
+
+    review = result.topic_review
+    assert review["diversity_status"] == "insufficient_diversity"
+    assert review["topic_count"] == 1
+    assert review["dominant_topic_id"] == 0
+    assert review["dominant_topic_share"] == 1.0
+    assert review["topics"][0]["topic_keywords"] == ["earnings", "guidance", "revenue"]
+    assert review["topics"][0]["topic_example_text"]
+    assert review["rows"][0]["topic_row_count"] == 1
+    assert review["rows"][0]["topic_row_share"] == 1.0
 
 
 def test_embedding_cache_key_changes_with_model_revision() -> None:

--- a/tests/unit/test_text_topics_runner.py
+++ b/tests/unit/test_text_topics_runner.py
@@ -28,6 +28,7 @@ from services.r2.paths import (
     layer1_text_embedding_path,
     layer1_topic_feature_path,
     layer1_topic_label_path,
+    layer1_topic_review_path,
     pipeline_manifest_path,
 )
 from services.r2.writer import R2Writer
@@ -70,15 +71,19 @@ def test_run_text_topics_reads_preprocessed_news_and_writes_outputs(
 
     embeddings = pd.read_parquet(io.BytesIO(writer.get_object(result.embedding_key)))
     labels = pd.read_parquet(io.BytesIO(writer.get_object(result.topic_label_key)))
+    review = json.loads(writer.get_object(result.topic_review_key))
     features = pd.read_parquet(io.BytesIO(writer.get_object(result.topic_feature_key)))
     manifest = json.loads(writer.get_object(result.manifest_key))
 
     assert result.embedding_key == layer1_text_embedding_path("2024-01-02", "text-topics-run")
     assert result.topic_label_key == layer1_topic_label_path("2024-01-02", "text-topics-run")
+    assert result.topic_review_key == layer1_topic_review_path("2024-01-02", "text-topics-run")
     assert result.topic_feature_key == layer1_topic_feature_path("2024-01-02", "text-topics-run")
     assert result.manifest_key == pipeline_manifest_path(TEXT_TOPICS_STAGE, "text-topics-run")
     assert len(embeddings) == 1
     assert len(labels) == 2
+    assert review["diversity_status"] == "insufficient_diversity"
+    assert review["topic_count"] == 1
     assert set(features["ticker"]) == {"AAPL", "MSFT"}
     assert manifest["status"] == RunStatus.COMPLETED
     assert manifest["metadata"]["preprocessed_rows"] == 3


### PR DESCRIPTION
Adds human-readable Layer 1 topic review output and wires it through the daily topic runner, evidence report, and dashboard payloads.

Changes:
- build and persist a Layer 1 topic review JSON payload alongside topic labels/features
- surface topic review details in the Layer 1 evidence/report payload
- add insufficient-diversity warnings for catch-all / single-topic runs
- update dashboard rendering and fixtures for the new review data
- add coverage for the new topic review artifact and payload shape

Verification:
- /home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/pytest tests/unit/test_text_topics.py tests/unit/test_text_topics_runner.py tests/unit/test_semantic_review_dashboard.py -v --tb=short
- /home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/pytest tests/unit -v --tb=short
- git diff --check
- /home/juyoungoh/nas/Projects/AI-Stock-Trader/.venv/bin/ruff check .

Closes #261
