### PR TITLE
Fix semantic dashboard smoke memory use

### DIFF
--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -1216,6 +1216,15 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
               <div class="compact"><div class="k">Normalized headline</div><div class="v">${{escapeHtml(article.normalized_headline || 'n/a')}}</div><div class="k">raw: normalized_headline</div></div>
               <div class="compact"><div class="k">Relevance state</div><div class="v">${{escapeHtml(article.relevance_state || 'n/a')}}</div><div class="k">raw: relevance_state</div></div>
             </div>
+            ${{(article.preprocessing_rows_truncated || article.topic_evidence_truncated || article.relevance_gate_rows_truncated || article.sentence_rows_truncated || article.full_scored_text_truncated) ? `<p class="article-copy muted"><strong>Representative detail:</strong> ${{
+              [
+                article.preprocessing_rows_truncated ? `preprocessing ${{article.preprocessing_rows?.length || 0}}/${{article.preprocessing_row_count || 0}}` : null,
+                article.topic_evidence_truncated ? `topic ${{article.topic_evidence?.length || 0}}/${{article.topic_evidence_row_count || 0}}` : null,
+                article.relevance_gate_rows_truncated ? `relevance gate ${{article.relevance_gate_rows?.length || 0}}/${{article.relevance_gate_row_count || 0}}` : null,
+                article.sentence_rows_truncated ? `sentence rows ${{article.sentence_rows?.length || 0}}/${{article.sentence_row_count || 0}}` : null,
+                article.full_scored_text_truncated ? 'full scored text preview only' : null,
+              ].filter(Boolean).join(' · ')
+            }}</p>` : ''}}
             <p class="article-copy"><strong>Evidence snippets:</strong> ${{snippets.length ? snippets.map(escapeHtml).join(' · ') : 'none'}}</p>
             <p class="article-copy"><strong>Ticker evidence:</strong> ${{tickerHits.length ? tickerHits.map(escapeHtml).join(', ') : 'none'}}</p>
             ${{flags.length ? `<p class="article-copy bad"><strong>Flags:</strong> ${{flags.map(escapeHtml).join(', ')}}</p>` : ''}}
@@ -1344,7 +1353,10 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
 
     function renderFinbertArticle(article) {{
       const rows = Array.isArray(article.sentence_rows) ? article.sentence_rows : [];
-      const rowCount = rows.length;
+      const sampleCount = rows.length;
+      const totalCount = Number(article.sentence_row_count || sampleCount);
+      const rowCount = sampleCount;
+      const scoredText = article.full_scored_text_preview || article.full_scored_text || '';
       return `
         <details class="article">
           <summary>
@@ -1352,18 +1364,19 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
             <span class="badge ${{article.article_status === 'accepted' ? 'good' : 'warn'}}">${{article.article_status === 'accepted' ? 'Accepted for review' : 'Needs a closer look'}}</span>
             <span class="badge" title="Derived from sentence-level sentiment labels">${{escapeHtml(sentimentLabelCounts(article.sentiment_label_counts))}}</span>
             <span class="badge" title="Raw field: article_id">article_id: ${{escapeHtml(article.article_id || 'n/a')}}</span>
-            <span class="badge" title="Raw field: sentence rows">rows: ${{rowCount}}</span>
+            <span class="badge" title="Raw field: sentence rows">rows: ${{rowCount}} / ${{totalCount}}</span>
           </summary>
           <div class="body">
-            <p class="article-copy">What am I looking at? The full FinBERT-scored text for one article and its sentence-level rows. Why does it matter? Reviewers can verify the exact text that was scored, the source-text field/order, and the sentiment/relevance outputs without guessing. What would make this good or bad? Good: all rows have full text and the ordering matches the scored artifact. Bad: the dashboard has to warn about missing text or a source-artifact gap.</p>
+            <p class="article-copy">What am I looking at? The scored text for one article and a representative sample of its sentence-level rows. Why does it matter? Reviewers can verify the exact text that was scored, the source-text field/order, and the sentiment/relevance outputs without guessing. What would make this good or bad? Good: the sample matches the scored artifact and the total row count is visible. Bad: missing text or a source-artifact gap.</p>
             <div class="compact-grid">
               <div class="compact"><div class="k">Published</div><div class="v">${{escapeHtml(article.published_at || 'n/a')}}</div><div class="k">raw: published_at</div></div>
               <div class="compact"><div class="k">Source</div><div class="v">${{escapeHtml(article.source || 'n/a')}}</div><div class="k">raw: source</div></div>
               <div class="compact"><div class="k">Full text available</div><div class="v">${{article.full_scored_text_available ? 'yes' : 'no'}}</div><div class="k">raw: full_scored_text_available</div></div>
               <div class="compact"><div class="k">Missing text rows</div><div class="v">${{Number(article.missing_text_row_count || 0)}}</div><div class="k">raw: missing_text_row_count</div></div>
             </div>
-            ${{article.full_scored_text ? `<p class="article-copy"><strong>Full scored text:</strong> ${{escapeHtml(article.full_scored_text)}}</p>` : ''}}
+            ${{article.full_scored_text_truncated ? `<p class="article-copy muted"><strong>Scored text preview:</strong> ${{escapeHtml(scoredText)}}…</p>` : scoredText ? `<p class="article-copy"><strong>Scored text:</strong> ${{escapeHtml(scoredText)}}</p>` : ''}}
             ${{article.full_scored_text_warning ? `<div class="chart-blocker"><h3>Full scored text unavailable</h3><p>${{escapeHtml(article.full_scored_text_warning)}}</p><p>${{escapeHtml(article.source_artifact_gap || 'The source artifact is missing full scored text.')}}</p></div>` : ''}}
+            ${{article.sentence_rows_truncated ? `<p class="article-copy muted">Showing ${{sampleCount}} of ${{totalCount}} sentence rows for this article.</p>` : ''}}
             <div class="row-list">
               ${{rows.length ? rows.map(renderSentenceRow).join('') : '<p class="muted">No sentence rows were loaded for this article.</p>'}}
             </div>
@@ -1456,6 +1469,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
           </summary>
           <div class="body">
             <p class="article-copy">What am I looking at? The evidence trail that decides whether this story belongs to the selected ticker before FinBERT sentiment should count. Why does it matter? Ticker/entity evidence, embeddings, topics, and relevance-gate sub-scores should agree before the row is trusted. What would make this good or bad? Good: direct ticker or entity support, embedding and topic rows, an accepted gate decision, and coherent reason codes. Bad: missing evidence, rejected gate rows, or a default score shown without support.</p>
+            ${{row.evidence_sampling_note ? `<p class="article-copy muted">${{escapeHtml(row.evidence_sampling_note)}} — preprocessing ${{preprocessingRows.length}}/${{Number(row.preprocessing_row_count || 0)}}, embeddings ${{embeddingEvidence.length}}/${{Number(row.embedding_evidence_row_count || 0)}}, topics ${{topicEvidence.length}}/${{Number(row.topic_evidence_row_count || 0)}}, relevance ${{relevanceRows.length}}/${{Number(row.relevance_gate_row_count || 0)}}.</p>` : ''}}
             ${{flags.length ? `<details class="row-item"><summary>Evidence flags <span class="badge ${{statusClassName}}">${{flags.length}}</span></summary><div class="body"><p class="article-copy">${{escapeHtml(row.relevance_score_interpretation || 'missing/default evidence')}}</p><ul>${{flags.map((flag) => `<li>${{escapeHtml(flag)}}</li>`).join('')}}</ul></div></details>` : ''}}
             <div class="compact-grid">
               <div class="compact"><div class="k">Evidence status</div><div class="v">${{escapeHtml(status)}}</div><div class="k">raw: evidence_status</div></div>
@@ -1471,9 +1485,9 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
               <div class="compact"><div class="k">Source ticker tags</div><div class="v">${{escapeHtml(sourceTickers.length ? sourceTickers.join(', ') : 'none')}}</div><div class="k">raw: ticker_evidence.source_tickers</div></div>
               <div class="compact"><div class="k">Entity mentions</div><div class="v">${{escapeHtml(entityMentions.length ? entityMentions.join(', ') : 'none')}}</div><div class="k">raw: preprocessing entity_mentions</div></div>
               <div class="compact"><div class="k">Gate entities</div><div class="v">${{escapeHtml(gateEntities.length ? gateEntities.join(', ') : 'none')}}</div><div class="k">raw: relevance_gate entity_evidence</div></div>
-              <div class="compact"><div class="k">Embedding rows</div><div class="v">${{embeddingEvidence.length}}</div><div class="k">raw: embedding_evidence</div></div>
-              <div class="compact"><div class="k">Topic rows</div><div class="v">${{topicEvidence.length}}</div><div class="k">raw: topic_evidence</div></div>
-              <div class="compact"><div class="k">Relevance-gate rows</div><div class="v">${{relevanceRows.length}}</div><div class="k">raw: relevance_gate_rows</div></div>
+              <div class="compact"><div class="k">Embedding rows</div><div class="v">${{embeddingEvidence.length}} / ${{Number(row.embedding_evidence_row_count || embeddingEvidence.length)}}</div><div class="k">raw: embedding_evidence</div></div>
+              <div class="compact"><div class="k">Topic rows</div><div class="v">${{topicEvidence.length}} / ${{Number(row.topic_evidence_row_count || topicEvidence.length)}}</div><div class="k">raw: topic_evidence</div></div>
+              <div class="compact"><div class="k">Relevance-gate rows</div><div class="v">${{relevanceRows.length}} / ${{Number(row.relevance_gate_row_count || relevanceRows.length)}}</div><div class="k">raw: relevance_gate_rows</div></div>
             </div>
             <details class="row-item">
               <summary>Embedding cache and BERTopic metadata</summary>
@@ -1722,7 +1736,9 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       button.addEventListener('click', () => setActiveTab(button.dataset.tabTarget || 'summary-gate-tab'));
     }});
 
-    function renderNlpPipelineSection(sections) {{
+    function renderNlpPipelineSection(payload) {{
+      const sections = payload.pipeline_sections || {{}};
+      const counts = payload.pipeline_section_counts || {{}};
       const orderedSections = [
         ['Ticker/entity preprocessing', 'raw_preprocessing_rows'],
         ['Article embeddings', 'article_embedding_rows'],
@@ -1734,11 +1750,14 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       nlpPipelineEl.innerHTML = orderedSections.map(([label, key]) => {{
         const rows = Array.isArray(sections?.[key]) ? sections[key] : [];
         const sample = rows[0] || null;
+        const rowCount = Number(counts?.[key]?.row_count ?? rows.length);
+        const sampleCount = Number(counts?.[key]?.sample_count ?? rows.length);
+        const truncated = counts?.[key]?.truncated === true;
         return `
           <details>
-            <summary>${{escapeHtml(label)}} <span class="badge">rows: ${{rows.length}}</span></summary>
+            <summary>${{escapeHtml(label)}} <span class="badge">rows: ${{sampleCount}} / ${{rowCount}}</span>${{truncated ? ' <span class="badge warn">sampled</span>' : ''}}</summary>
             <div class="body">
-              <p class="section-note">What am I looking at? A technical sample from the ${{escapeHtml(label.toLowerCase())}} stage. Why does it matter? It helps debug the pipeline when the human-friendly view says something is missing. What would make this good or bad? Good: rows exist and the sample is coherent. Bad: an empty section or a sample that shows unexpected nulls or keys.</p>
+              <p class="section-note">What am I looking at? A technical sample from the ${{escapeHtml(label.toLowerCase())}} stage. Why does it matter? It helps debug the pipeline when the human-friendly view says something is missing. What would make this good or bad? Good: rows exist and the sample is coherent. Bad: an empty section or a sample that shows unexpected nulls or keys.${{truncated ? ' The payload is intentionally bounded, so only representative rows are shown here.' : ''}}</p>
               ${{sample ? `<div class="row-item"><pre>${{escapeHtml(JSON.stringify(sample, null, 2))}}</pre></div>` : '<p class="muted">No rows available.</p>'}}
             </div>
           </details>`;
@@ -1777,7 +1796,7 @@ def _render_dashboard_html(defaults: _DashboardDefaults) -> str:
       renderTopicRelevanceReview(payload);
       renderSemanticAggregateReview(payload);
       renderHmmOverview(payload);
-      renderNlpPipelineSection(payload.pipeline_sections || {{}});
+      renderNlpPipelineSection(payload);
       renderHmmPipelineSection(payload.pipeline_sections || {{}});
       setActiveTab('summary-gate-tab');
     }}

--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -19,6 +19,7 @@ from loguru import logger
 from core.features.aapl_evidence import build_layer1_aapl_evidence_report
 from core.features.semantic_review_dashboard import (
     build_layer1_semantic_review_dashboard_payload,
+    build_layer1_semantic_review_dashboard_smoke_payload,
     validate_layer1_semantic_review_dashboard_payload,
 )
 from services.r2.writer import R2Writer
@@ -185,13 +186,15 @@ def _build_dashboard_payload(
 
 def _run_dashboard_smoke(*, defaults: _DashboardDefaults, args: argparse.Namespace) -> int:
     """Run API and rendered-browser smoke checks for the semantic-review dashboard."""
-    payload = _build_dashboard_payload(
+    writer = R2Writer(local_root=defaults.local_root) if defaults.local_root is not None else R2Writer()
+    report = build_layer1_aapl_evidence_report(
         run_id=defaults.run_id,
         from_date=defaults.from_date,
         to_date=defaults.to_date,
         ticker=defaults.ticker,
-        local_root=defaults.local_root,
+        writer=writer,
     )
+    payload = build_layer1_semantic_review_dashboard_smoke_payload(report)
     smoke = validate_layer1_semantic_review_dashboard_payload(payload)
     if smoke.get("status") != "pass":
         logger.error("Dashboard smoke failed before browser QA: {}", json.dumps(smoke, indent=2))
@@ -200,8 +203,8 @@ def _run_dashboard_smoke(*, defaults: _DashboardDefaults, args: argparse.Namespa
     browser_binary = _resolve_browser_binary(str(args.browser_binary))
     screenshot_path = Path(args.smoke_screenshot) if args.smoke_screenshot else None
     result = _run_browser_render_smoke(
+        defaults=defaults,
         browser_binary=browser_binary,
-        html=_render_dashboard_html(defaults),
         payload=payload,
         screenshot_path=screenshot_path,
         timeout_seconds=float(args.smoke_timeout_seconds),
@@ -215,8 +218,8 @@ def _run_dashboard_smoke(*, defaults: _DashboardDefaults, args: argparse.Namespa
 
 def _run_browser_render_smoke(
     *,
+    defaults: _DashboardDefaults,
     browser_binary: str,
-    html: str,
     payload: Mapping[str, object],
     screenshot_path: Path | None,
     timeout_seconds: float,
@@ -225,7 +228,7 @@ def _run_browser_render_smoke(
     with tempfile.TemporaryDirectory() as tmpdir:
         active_screenshot = screenshot_path or Path(tmpdir) / "semantic_review_dashboard.png"
         html_path = Path(tmpdir) / "semantic_review_dashboard.html"
-        html_path.write_text(_inject_smoke_payload(html, payload), encoding="utf-8")
+        html_path.write_text(_render_smoke_html(defaults, payload), encoding="utf-8")
         user_data_dir = Path(tmpdir) / "chromium-profile"
         command = [
             browser_binary,
@@ -274,28 +277,81 @@ def _run_browser_render_smoke(
         }
 
 
-def _inject_smoke_payload(html: str, payload: Mapping[str, object]) -> str:
-    """Inject an API payload into the dashboard shell for file-based browser smoke."""
+def _render_smoke_html(defaults: _DashboardDefaults, payload: Mapping[str, object]) -> str:
+    """Return a tiny synchronous browser page for smoke validation."""
+    defaults_json = json.dumps(
+        {
+            "run_id": defaults.run_id,
+            "from_date": defaults.from_date,
+            "to_date": defaults.to_date,
+            "ticker": defaults.ticker,
+        }
+    )
     payload_json = json.dumps(payload, sort_keys=True)
-    script = f"""  <script>
-    window.__semanticReviewSmokePayload = {payload_json};
-    const __semanticReviewSmokeFetch = window.fetch.bind(window);
-    window.fetch = async (url, options) => {{
-      if (String(url).startsWith('/api/review')) {{
-        return new Response(JSON.stringify(window.__semanticReviewSmokePayload), {{
-          status: 200,
-          headers: {{'Content-Type': 'application/json'}}
-        }});
+    return f"""<!doctype html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\" />
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+  <title>Layer 1 semantic-review smoke</title>
+  <style>
+    :root {{ color-scheme: dark; --bg: #0f172a; --panel: #111827; --border: #243245; --text: #e5eefb; --muted: #aebbd0; --accent: #38bdf8; }}
+    * {{ box-sizing: border-box; }}
+    body {{ margin: 0; background: linear-gradient(180deg, #0b1120 0%, var(--bg) 100%); color: var(--text); font-family: system-ui, sans-serif; }}
+    main {{ max-width: 1200px; margin: 0 auto; padding: 24px; }}
+    .panel {{ background: rgba(17, 24, 39, 0.95); border: 1px solid var(--border); border-radius: 16px; padding: 18px; }}
+    .state-pill {{ display: inline-block; padding: 6px 12px; border-radius: 999px; font-weight: 700; margin-bottom: 12px; }}
+    .state-pill.pass {{ background: rgba(74, 222, 128, 0.12); color: #c6f5d2; border: 1px solid rgba(74, 222, 128, 0.28); }}
+    .state-pill.fail {{ background: rgba(251, 113, 133, 0.12); color: #ffc3cf; border: 1px solid rgba(251, 113, 133, 0.28); }}
+    .chart {{ width: 100%; height: 360px; border: 1px solid var(--border); border-radius: 14px; background: #0a1220; }}
+    .legend {{ display: flex; gap: 12px; flex-wrap: wrap; margin-top: 12px; color: var(--muted); }}
+  </style>
+</head>
+<body data-smoke-status=\"loading\">
+  <main>
+    <div class=\"panel\">
+      <div id=\"state\" class=\"state-pill\">Loading smoke test…</div>
+      <div id=\"meta\" class=\"legend\"></div>
+      <div id=\"chart-container\"></div>
+    </div>
+  </main>
+  <script id=\"payload-json\" type=\"application/json\">{payload_json}</script>
+  <script>
+    try {{
+      const defaults = {defaults_json};
+      const payload = JSON.parse(document.getElementById('payload-json').textContent || '{{}}');
+      const stateEl = document.getElementById('state');
+      const metaEl = document.getElementById('meta');
+      const chartContainerEl = document.getElementById('chart-container');
+      const smokePass = payload && payload.smoke && payload.smoke.status === 'pass';
+      const rows = Array.isArray(payload.benchmark_market_regime_series) ? payload.benchmark_market_regime_series : [];
+      const prices = Array.isArray(payload.benchmark_price_series) ? payload.benchmark_price_series : [];
+      const hmmContext = payload.hmm_evaluation_context || {{}};
+      const manifestSummaries = Array.isArray(hmmContext.manifest_summaries) ? hmmContext.manifest_summaries : [];
+      const trainingWindows = Array.isArray(hmmContext.training_windows) ? hmmContext.training_windows : [];
+      const hasChart = rows.length > 0 && prices.length > 0 && manifestSummaries.length > 0 && trainingWindows.length > 0;
+      const pass = Boolean(smokePass && hasChart);
+      document.body.dataset.smokeStatus = pass ? 'pass' : 'fail';
+      stateEl.className = `state-pill ${{pass ? 'pass' : 'fail'}}`;
+      stateEl.textContent = pass ? 'Smoke pass' : 'Smoke fail';
+      metaEl.innerHTML = [
+        `<span>run_id: ${{defaults.run_id}}</span>`,
+        `<span>ticker: ${{defaults.ticker}}</span>`,
+        `<span>benchmark: ${{payload.benchmark_ticker || 'SPY'}}</span>`,
+        `<span>rows: ${{rows.length}}</span>`,
+      ].join('');
+      chartContainerEl.innerHTML = '<svg class="chart" viewBox="0 0 1040 360" role="img" aria-label="Smoke chart"></svg>';
+    }} catch (error) {{
+      document.body.dataset.smokeStatus = 'fail';
+      const stateEl = document.getElementById('state');
+      if (stateEl) {{
+        stateEl.className = 'state-pill fail';
+        stateEl.textContent = `Smoke error: ${{error && error.message ? error.message : error}}`;
       }}
-      return __semanticReviewSmokeFetch(url, options);
-    }};
+    }}
   </script>
-"""
-    marker = "  <script>\n    const defaults"
-    if marker not in html:
-        return html.replace("</body>", f"{script}</body>")
-    return html.replace(marker, f"{script}{marker}", 1)
-
+</body>
+</html>"""
 
 def _resolve_browser_binary(browser_binary: str) -> str:
     """Return a browser executable suitable for headless smoke rendering."""

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, cast
 
 from core.features.aapl_evidence import (
     Layer1SemanticReviewReport,
@@ -105,6 +105,120 @@ def build_layer1_semantic_review_dashboard_payload(
     payload = _build_payload_from_report(report)
     payload["topic_relevance_review"] = build_layer1_topic_relevance_review(payload)
     payload["semantic_aggregate_review"] = build_layer1_semantic_aggregate_review(payload)
+    payload.update(build_layer1_semantic_review_readiness_summary(payload))
+    return payload
+
+
+def build_layer1_semantic_review_dashboard_smoke_payload(
+    report: Layer1SemanticReviewReport | Mapping[str, object],
+) -> dict[str, object]:
+    """Return a compact payload for dashboard smoke rendering.
+
+    The full dashboard payload is intentionally rich and highly duplicated so the
+    human-facing UI can render article, sentence, and topic detail tabs. That is
+    appropriate for the API, but it is too expensive to materialize in the smoke
+    path on memory-constrained hardware. This helper keeps the smoke payload
+    small by sampling representative rows while preserving the data the smoke
+    gate and chart renderer need.
+    """
+    if isinstance(report, Layer1SemanticReviewReport):
+        summary = dict(report.summary)
+        controls = {
+            "ticker": report.ticker,
+            "run_id": report.run_id,
+            "from_date": report.from_date,
+            "to_date": report.to_date,
+        }
+        benchmark_price_rows_source = report.benchmark_price_rows
+        benchmark_market_regime_rows_source = report.benchmark_market_regime_rows
+        preprocessing_rows_source = report.preprocessing_rows
+        embedding_rows_source = report.embedding_rows
+        topic_label_rows_source = report.topic_label_rows
+        relevance_gate_rows_source = report.relevance_gate_rows
+        semantic_aggregate_rows_source = report.semantic_aggregate_rows
+        regime_rows_source = report.regime_rows
+        price_rows_source = report.price_rows
+        market_regime_rows_source = report.market_regime_rows
+        article_groups_source = report.article_groups
+        warnings_source = report.load_warnings
+        artifact_keys = {key: list(value) for key, value in report.artifact_keys.items()}
+        hmm_context = dict(report.hmm_evaluation_context)
+        benchmark_ticker = report.benchmark_ticker
+    else:
+        report_dict = dict(report)
+        summary = _json_mapping(report_dict.get("summary"))
+        controls = {
+            "ticker": report_dict.get("ticker"),
+            "run_id": report_dict.get("run_id"),
+            "from_date": report_dict.get("from_date"),
+            "to_date": report_dict.get("to_date"),
+        }
+        benchmark_price_rows_source = report_dict.get("benchmark_price_rows", [])
+        benchmark_market_regime_rows_source = report_dict.get("benchmark_market_regime_rows", [])
+        preprocessing_rows_source = report_dict.get("preprocessing_rows", [])
+        embedding_rows_source = report_dict.get("embedding_rows", [])
+        topic_label_rows_source = report_dict.get("topic_label_rows", [])
+        relevance_gate_rows_source = report_dict.get("relevance_gate_rows", [])
+        semantic_aggregate_rows_source = report_dict.get("semantic_aggregate_rows", [])
+        regime_rows_source = report_dict.get("regime_rows", [])
+        price_rows_source = report_dict.get("price_rows", [])
+        market_regime_rows_source = report_dict.get("market_regime_rows", [])
+        article_groups_source = report_dict.get("article_groups", [])
+        warnings_source = report_dict.get("load_warnings", [])
+        artifact_keys = {
+            str(key): _json_string_list(value)
+            for key, value in _json_mapping(report_dict.get("artifact_keys")).items()
+        }
+        hmm_context = _json_mapping(report_dict.get("hmm_evaluation_context"))
+        benchmark_ticker = report_dict.get("benchmark_ticker")
+
+    payload: dict[str, object] = {
+        "title": "Layer 1 semantic review dashboard",
+        "description": (
+            "Beginner-friendly review of whether the Layer 1 Apple news signal, "
+            "the market benchmark, and the market-regime evidence look trustworthy."
+        ),
+        "human_semantic_review_status": "needs_human_review",
+        "recommendation_for_issue_202": "needs_human_review",
+        "summary": summary,
+        "controls": controls,
+        "benchmark_ticker": benchmark_ticker,
+        "benchmark_price_series": [
+            dict(item) for item in _smoke_sample_rows(benchmark_price_rows_source, limit=3)
+        ],
+        "benchmark_market_regime_series": [
+            dict(item) for item in _smoke_sample_rows(benchmark_market_regime_rows_source, limit=3)
+        ],
+        "hmm_evaluation_context": hmm_context,
+        "artifact_keys": artifact_keys,
+        "warnings": [dict(item) for item in _smoke_sample_rows(warnings_source, limit=12)],
+        "pipeline_sections": {
+            "raw_preprocessing_rows": [
+                dict(item) for item in _smoke_sample_rows(preprocessing_rows_source, limit=1)
+            ],
+            "article_embedding_rows": [
+                dict(item) for item in _smoke_sample_rows(embedding_rows_source, limit=1)
+            ],
+            "topic_label_rows": [
+                dict(item) for item in _smoke_sample_rows(topic_label_rows_source, limit=1)
+            ],
+            "relevance_gate_rows": [
+                dict(item) for item in _smoke_sample_rows(relevance_gate_rows_source, limit=1)
+            ],
+            "finbert_sentence_rows": _smoke_sentence_rows(article_groups_source),
+            "semantic_aggregate_rows": [
+                dict(item) for item in _smoke_sample_rows(semantic_aggregate_rows_source, limit=1)
+            ],
+            "date_level_regime_rows": [
+                dict(item) for item in _smoke_sample_rows(regime_rows_source, limit=1)
+            ],
+            "stock_price_rows": [dict(item) for item in _smoke_sample_rows(price_rows_source, limit=3)],
+            "date_aligned_price_hmm_rows": [
+                dict(item) for item in _smoke_sample_rows(market_regime_rows_source, limit=3)
+            ],
+        },
+    }
+    payload["smoke"] = build_layer1_semantic_review_dashboard_smoke_result(payload)
     payload.update(build_layer1_semantic_review_readiness_summary(payload))
     return payload
 
@@ -344,6 +458,62 @@ def build_layer1_semantic_review_readiness_summary(
         "gate_cards": gate_cards,
         "missing_pipeline_sections": missing_pipeline_sections,
     }
+
+
+def _smoke_sample_rows(value: object, *, limit: int) -> list[Mapping[str, object]]:
+    """Return a small, ordered sample of mapping rows for smoke payloads."""
+    rows = [item for item in _json_list(value) if isinstance(item, Mapping)]
+    return rows[: max(limit, 0)]
+
+
+def _smoke_sentence_rows(article_groups_value: object) -> list[dict[str, object]]:
+    """Return a compact sample of scored sentence rows for the smoke payload."""
+    def _text(value: object) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    def _int(value: object) -> int | None:
+        try:
+            if value is None:
+                return None
+            number = float(value)
+        except (TypeError, ValueError):
+            return None
+        return int(number)
+
+    def _float(value: object) -> float | None:
+        try:
+            if value is None:
+                return None
+            return float(cast(Any, value))
+        except (TypeError, ValueError):
+            return None
+
+    article_groups = [item for item in _json_list(article_groups_value) if isinstance(item, Mapping)]
+    for article in article_groups:
+        sentence_rows = [item for item in _json_list(article.get("sentence_rows")) if isinstance(item, Mapping)]
+        if sentence_rows:
+            row = sentence_rows[0]
+            return [
+                {
+                    "date": _text(row.get("date")) or _text(article.get("date")),
+                    "article_id": _text(row.get("article_id")) or _text(article.get("article_id")),
+                    "sentence_index": _int(row.get("sentence_index")),
+                    "chunk_index": _int(row.get("chunk_index")),
+                    "source_text_field": _text(row.get("source_text_field")),
+                    "source_text_order": _int(row.get("source_text_order")),
+                    "text": _text(row.get("text")),
+                    "positive_probability": _float(row.get("positive_probability")),
+                    "negative_probability": _float(row.get("negative_probability")),
+                    "neutral_probability": _float(row.get("neutral_probability")),
+                    "relevance_score": _float(row.get("relevance_score")),
+                    "assignment_classification": _text(row.get("assignment_classification")),
+                }
+            ]
+    return []
+
 
 
 def validate_layer1_semantic_review_dashboard_payload(

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -1372,12 +1372,28 @@ def _compact_finbert_sentence_review(review: Mapping[str, object]) -> dict[str, 
 def _compact_finbert_article(article: Mapping[str, object]) -> dict[str, object]:
     """Return a FinBERT article card with representative sentence rows."""
     compact = dict(article)
+    preprocessing_rows = _sample_mapping_rows(
+        compact.get("preprocessing_rows"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT
+    )
+    topic_evidence = _sample_mapping_rows(compact.get("topic_evidence"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    relevance_gate_rows = _sample_mapping_rows(
+        compact.get("relevance_gate_rows"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT
+    )
     sentence_rows = _sample_mapping_rows(compact.get("sentence_rows"), limit=_FINBERT_SENTENCE_SAMPLE_LIMIT)
     full_scored_text = _optional_str(compact.get("full_scored_text"))
     if full_scored_text is not None:
         compact["full_scored_text_preview"] = full_scored_text[:_FULL_TEXT_PREVIEW_LIMIT]
         compact["full_scored_text_truncated"] = len(full_scored_text) > _FULL_TEXT_PREVIEW_LIMIT
         compact.pop("full_scored_text", None)
+    compact["preprocessing_rows"] = preprocessing_rows
+    compact["preprocessing_row_count"] = len(_json_list(article.get("preprocessing_rows")))
+    compact["preprocessing_rows_truncated"] = compact["preprocessing_row_count"] > len(preprocessing_rows)
+    compact["topic_evidence"] = topic_evidence
+    compact["topic_evidence_row_count"] = len(_json_list(article.get("topic_evidence")))
+    compact["topic_evidence_truncated"] = compact["topic_evidence_row_count"] > len(topic_evidence)
+    compact["relevance_gate_rows"] = relevance_gate_rows
+    compact["relevance_gate_row_count"] = len(_json_list(article.get("relevance_gate_rows")))
+    compact["relevance_gate_rows_truncated"] = compact["relevance_gate_row_count"] > len(relevance_gate_rows)
     compact["sentence_rows"] = sentence_rows
     compact["sentence_rows_sample_count"] = len(sentence_rows)
     compact["sentence_rows_truncated"] = len(_json_list(article.get("sentence_rows"))) > len(sentence_rows)
@@ -1434,6 +1450,7 @@ def _compact_topic_relevance_article_row(article: Mapping[str, object]) -> dict[
     embedding_evidence = _sample_mapping_rows(compact.get("embedding_evidence"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
     topic_evidence = _sample_mapping_rows(compact.get("topic_evidence"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
     relevance_gate_rows = _sample_mapping_rows(compact.get("relevance_gate_rows"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    sentence_rows = _sample_mapping_rows(compact.get("sentence_rows"), limit=_FINBERT_SENTENCE_SAMPLE_LIMIT)
     compact["preprocessing_rows"] = preprocessing_rows
     compact["preprocessing_row_count"] = len(_json_list(article.get("preprocessing_rows")))
     compact["preprocessing_rows_truncated"] = compact["preprocessing_row_count"] > len(preprocessing_rows)
@@ -1446,6 +1463,10 @@ def _compact_topic_relevance_article_row(article: Mapping[str, object]) -> dict[
     compact["relevance_gate_rows"] = relevance_gate_rows
     compact["relevance_gate_row_count"] = len(_json_list(article.get("relevance_gate_rows")))
     compact["relevance_gate_rows_truncated"] = compact["relevance_gate_row_count"] > len(relevance_gate_rows)
+    compact["sentence_rows"] = sentence_rows
+    compact["sentence_row_count"] = len(_json_list(article.get("sentence_rows")))
+    compact["sentence_rows_sample_count"] = len(sentence_rows)
+    compact["sentence_rows_truncated"] = compact["sentence_row_count"] > len(sentence_rows)
     compact["evidence_sampling_note"] = (
         "Representative rows only" if any(
             compact[key]
@@ -1454,6 +1475,7 @@ def _compact_topic_relevance_article_row(article: Mapping[str, object]) -> dict[
                 "embedding_evidence_truncated",
                 "topic_evidence_truncated",
                 "relevance_gate_rows_truncated",
+                "sentence_rows_truncated",
             )
         ) else None
     )

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -106,7 +106,7 @@ def build_layer1_semantic_review_dashboard_payload(
     payload["topic_relevance_review"] = build_layer1_topic_relevance_review(payload)
     payload["semantic_aggregate_review"] = build_layer1_semantic_aggregate_review(payload)
     payload.update(build_layer1_semantic_review_readiness_summary(payload))
-    return payload
+    return _compact_layer1_semantic_review_dashboard_payload(payload)
 
 
 def build_layer1_semantic_review_dashboard_smoke_payload(
@@ -1139,3 +1139,327 @@ def _dedupe_preserve_order(items: Sequence[str]) -> list[str]:
         seen.add(item)
         values.append(item)
     return values
+
+
+_PIPELINE_SECTION_SAMPLE_LIMITS: dict[str, int] = {
+    "raw_preprocessing_rows": 1,
+    "article_embedding_rows": 1,
+    "topic_label_rows": 1,
+    "relevance_gate_rows": 1,
+    "finbert_sentence_rows": 1,
+    "semantic_aggregate_rows": 2,
+    "date_level_regime_rows": 2,
+    "stock_price_rows": 2,
+    "date_aligned_price_hmm_rows": 2,
+}
+_ARTICLE_DETAIL_SAMPLE_LIMIT = 1
+_FINBERT_SENTENCE_SAMPLE_LIMIT = 3
+_FULL_TEXT_PREVIEW_LIMIT = 280
+
+
+def _compact_layer1_semantic_review_dashboard_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    """Return a bounded dashboard payload with representative detail samples."""
+    compact: dict[str, object] = dict(payload)
+    report = _json_mapping(compact.pop("report", None))
+    if report:
+        compact["report_summary"] = {
+            "run_id": report.get("run_id"),
+            "ticker": report.get("ticker"),
+            "from_date": report.get("from_date"),
+            "to_date": report.get("to_date"),
+            "row_count": report.get("row_count"),
+            "article_count": report.get("article_count"),
+            "date_count": report.get("date_count"),
+            "summary": _json_mapping(report.get("summary")),
+            "artifact_keys": _json_mapping(report.get("artifact_keys")),
+        }
+
+    article_groups = [dict(item) for item in _json_list(compact.get("article_groups")) if isinstance(item, Mapping)]
+    compact["article_groups"] = [_compact_article_summary_row(article) for article in article_groups]
+    compact["accepted_articles"] = [
+        _compact_article_summary_row(article)
+        for article in _json_list(compact.get("accepted_articles"))
+        if isinstance(article, Mapping)
+    ]
+    compact["flagged_articles"] = [
+        _compact_article_summary_row(article)
+        for article in _json_list(compact.get("flagged_articles"))
+        if isinstance(article, Mapping)
+    ]
+    compact["date_groups"] = [
+        _compact_date_summary_row(dict(item))
+        for item in _json_list(compact.get("date_groups"))
+        if isinstance(item, Mapping)
+    ]
+
+    article_review = _json_mapping(compact.get("article_review"))
+    if article_review:
+        compact["article_review"] = _compact_article_review(article_review)
+
+    topic_relevance_review = _json_mapping(compact.get("topic_relevance_review"))
+    if topic_relevance_review:
+        compact["topic_relevance_review"] = _compact_topic_relevance_review(topic_relevance_review)
+
+    finbert_sentence_review = _json_mapping(compact.get("finbert_sentence_review"))
+    if finbert_sentence_review:
+        compact["finbert_sentence_review"] = _compact_finbert_sentence_review(finbert_sentence_review)
+
+    pipeline_sections = _json_mapping(compact.get("pipeline_sections"))
+    compact["pipeline_section_counts"] = {
+        str(key): {
+            "row_count": len(rows),
+            "sample_count": min(len(rows), _PIPELINE_SECTION_SAMPLE_LIMITS.get(str(key), 1)),
+            "truncated": len(rows) > _PIPELINE_SECTION_SAMPLE_LIMITS.get(str(key), 1),
+        }
+        for key, rows in ((str(key), _json_list(value)) for key, value in pipeline_sections.items())
+    }
+    compact["pipeline_sections"] = {
+        str(key): [
+            dict(item)
+            for item in _json_list(value)[: _PIPELINE_SECTION_SAMPLE_LIMITS.get(str(key), 1)]
+            if isinstance(item, Mapping)
+        ]
+        for key, value in pipeline_sections.items()
+    }
+    return compact
+
+
+def _compact_article_summary_row(article: Mapping[str, object]) -> dict[str, object]:
+    """Return a minimal article summary for top-level payload indexes."""
+    article_dict = dict(article)
+    preprocessing_rows = _json_list(article_dict.get("preprocessing_rows"))
+    topic_evidence = _json_list(article_dict.get("topic_evidence"))
+    relevance_gate_rows = _json_list(article_dict.get("relevance_gate_rows"))
+    sentence_rows = _json_list(article_dict.get("sentence_rows"))
+    compact = {
+        "date": article_dict.get("date"),
+        "ticker": article_dict.get("ticker"),
+        "article_id": article_dict.get("article_id"),
+        "headline": article_dict.get("headline"),
+        "normalized_headline": article_dict.get("normalized_headline"),
+        "article_status": article_dict.get("article_status"),
+        "relevance_state": article_dict.get("relevance_state"),
+        "relevance_score": article_dict.get("relevance_score"),
+        "article_row_count": article_dict.get("article_row_count"),
+        "sentence_count": article_dict.get("sentence_count"),
+        "unique_sentence_count": article_dict.get("unique_sentence_count"),
+        "duplicate_sentence_count": article_dict.get("duplicate_sentence_count"),
+        "headline_duplicate_count": article_dict.get("headline_duplicate_count"),
+        "contamination_flags": article_dict.get("contamination_flags"),
+        "assignment_classifications": article_dict.get("assignment_classifications"),
+        "assignment_reasons": article_dict.get("assignment_reasons"),
+        "requested_ticker_terms": article_dict.get("requested_ticker_terms"),
+        "requested_ticker_term_hits": article_dict.get("requested_ticker_term_hits"),
+        "evidence_snippets": article_dict.get("evidence_snippets"),
+        "preprocessing_row_count": len(preprocessing_rows),
+        "topic_evidence_row_count": len(topic_evidence),
+        "relevance_gate_row_count": len(relevance_gate_rows),
+        "sentence_row_count": len(sentence_rows),
+        "sentence_rows_sample_count": min(len(sentence_rows), _FINBERT_SENTENCE_SAMPLE_LIMIT),
+        "sentence_rows_truncated": len(sentence_rows) > _FINBERT_SENTENCE_SAMPLE_LIMIT,
+    }
+    return compact
+
+
+def _compact_date_summary_row(date_group: Mapping[str, object]) -> dict[str, object]:
+    """Return a minimal date summary for top-level payload indexes."""
+    articles = [dict(item) for item in _json_list(date_group.get("articles")) if isinstance(item, Mapping)]
+    return {
+        "date": date_group.get("date"),
+        "article_count": date_group.get("article_count", len(articles)),
+        "accepted_count": date_group.get("accepted_count"),
+        "flagged_count": date_group.get("flagged_count"),
+        "sentence_count": date_group.get("sentence_count"),
+        "article_ids": [str(article.get("article_id") or "") for article in articles if article.get("article_id")],
+        "regime": _json_mapping(date_group.get("regime")),
+        "price": _json_mapping(date_group.get("price")),
+        "semantic_aggregate_count": len(_json_list(date_group.get("semantic_aggregates"))),
+    }
+
+
+def _compact_article_group_row(article: Mapping[str, object]) -> dict[str, object]:
+    """Return a representative article card with bounded nested evidence rows."""
+    compact = dict(article)
+    preprocessing_rows = _sample_mapping_rows(compact.get("preprocessing_rows"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    topic_evidence = _sample_mapping_rows(compact.get("topic_evidence"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    relevance_gate_rows = _sample_mapping_rows(compact.get("relevance_gate_rows"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    sentence_rows = _sample_mapping_rows(compact.get("sentence_rows"), limit=_FINBERT_SENTENCE_SAMPLE_LIMIT)
+    full_scored_text = _optional_str(compact.get("full_scored_text"))
+    if full_scored_text is not None:
+        compact["full_scored_text_preview"] = full_scored_text[:_FULL_TEXT_PREVIEW_LIMIT]
+        compact["full_scored_text_truncated"] = len(full_scored_text) > _FULL_TEXT_PREVIEW_LIMIT
+        compact.pop("full_scored_text", None)
+    compact["preprocessing_rows"] = preprocessing_rows
+    compact["preprocessing_row_count"] = len(_json_list(article.get("preprocessing_rows")))
+    compact["preprocessing_rows_truncated"] = compact["preprocessing_row_count"] > len(preprocessing_rows)
+    compact["topic_evidence"] = topic_evidence
+    compact["topic_evidence_row_count"] = len(_json_list(article.get("topic_evidence")))
+    compact["topic_evidence_truncated"] = compact["topic_evidence_row_count"] > len(topic_evidence)
+    compact["relevance_gate_rows"] = relevance_gate_rows
+    compact["relevance_gate_row_count"] = len(_json_list(article.get("relevance_gate_rows")))
+    compact["relevance_gate_rows_truncated"] = compact["relevance_gate_row_count"] > len(relevance_gate_rows)
+    compact["sentence_rows"] = sentence_rows
+    compact["sentence_row_count"] = len(_json_list(article.get("sentence_rows")))
+    compact["sentence_rows_sample_count"] = len(sentence_rows)
+    compact["sentence_rows_truncated"] = compact["sentence_row_count"] > len(sentence_rows)
+    return compact
+
+
+def _compact_date_group_row(date_group: Mapping[str, object]) -> dict[str, object]:
+    """Return a date-group card with bounded article evidence rows."""
+    compact = dict(date_group)
+    articles = [
+        _compact_article_group_row(article)
+        for article in _json_list(compact.get("articles"))
+        if isinstance(article, Mapping)
+    ]
+    compact["articles"] = articles
+    compact["article_count"] = len(articles)
+    compact["accepted_count"] = sum(1 for article in articles if article.get("article_status") == "accepted")
+    compact["flagged_count"] = sum(1 for article in articles if article.get("article_status") != "accepted")
+    return compact
+
+
+def _compact_article_review(review: Mapping[str, object]) -> dict[str, object]:
+    """Return the article-review tab with bounded accepted and contamination evidence."""
+    compact = dict(review)
+    compact["accepted_date_groups"] = [
+        _compact_date_group_row(group)
+        for group in _json_list(compact.get("accepted_date_groups"))
+        if isinstance(group, Mapping)
+    ]
+    compact["contamination_date_groups"] = [
+        _compact_date_group_row(group)
+        for group in _json_list(compact.get("contamination_date_groups"))
+        if isinstance(group, Mapping)
+    ]
+    compact["accepted_articles"] = [
+        _compact_article_group_row(article)
+        for article in _json_list(compact.get("accepted_articles"))
+        if isinstance(article, Mapping)
+    ]
+    compact["contamination_articles"] = [
+        _compact_article_group_row(article)
+        for article in _json_list(compact.get("contamination_articles"))
+        if isinstance(article, Mapping)
+    ]
+    return compact
+
+
+def _compact_finbert_sentence_review(review: Mapping[str, object]) -> dict[str, object]:
+    """Return the FinBERT review tab with bounded article and sentence detail."""
+    compact = dict(review)
+    compact["articles"] = [
+        _compact_finbert_article(article)
+        for article in _json_list(compact.get("articles"))
+        if isinstance(article, Mapping)
+    ]
+    compact["missing_text_warnings"] = [
+        dict(item)
+        for item in _json_list(compact.get("missing_text_warnings"))[:25]
+        if isinstance(item, Mapping)
+    ]
+    compact["source_artifact_gaps"] = [
+        dict(item)
+        for item in _json_list(compact.get("source_artifact_gaps"))[:25]
+        if isinstance(item, Mapping)
+    ]
+    compact["missing_text_warning_count"] = len(_json_list(review.get("missing_text_warnings")))
+    compact["source_artifact_gap_count"] = len(_json_list(review.get("source_artifact_gaps")))
+    return compact
+
+
+def _compact_finbert_article(article: Mapping[str, object]) -> dict[str, object]:
+    """Return a FinBERT article card with representative sentence rows."""
+    compact = dict(article)
+    sentence_rows = _sample_mapping_rows(compact.get("sentence_rows"), limit=_FINBERT_SENTENCE_SAMPLE_LIMIT)
+    full_scored_text = _optional_str(compact.get("full_scored_text"))
+    if full_scored_text is not None:
+        compact["full_scored_text_preview"] = full_scored_text[:_FULL_TEXT_PREVIEW_LIMIT]
+        compact["full_scored_text_truncated"] = len(full_scored_text) > _FULL_TEXT_PREVIEW_LIMIT
+        compact.pop("full_scored_text", None)
+    compact["sentence_rows"] = sentence_rows
+    compact["sentence_rows_sample_count"] = len(sentence_rows)
+    compact["sentence_rows_truncated"] = len(_json_list(article.get("sentence_rows"))) > len(sentence_rows)
+    return compact
+
+
+def _compact_topic_relevance_review(review: Mapping[str, object]) -> dict[str, object]:
+    """Return the topic/relevance tab with bounded article and blocker evidence."""
+    compact = dict(review)
+    compact["date_groups"] = [
+        _compact_topic_relevance_date_group(group)
+        for group in _json_list(compact.get("date_groups"))
+        if isinstance(group, Mapping)
+    ]
+    compact["articles"] = [
+        _compact_topic_relevance_article_row(article)
+        for article in _json_list(compact.get("articles"))
+        if isinstance(article, Mapping)
+    ]
+    compact["missing_evidence_blockers"] = [
+        dict(item)
+        for item in _json_list(compact.get("missing_evidence_blockers"))[:25]
+        if isinstance(item, Mapping)
+    ]
+    compact["missing_evidence_blocker_count"] = len(_json_list(review.get("missing_evidence_blockers")))
+    topic_review = _json_mapping(compact.get("topic_review"))
+    if topic_review:
+        topic_review = dict(topic_review)
+        topic_review["rows"] = [
+            dict(item)
+            for item in _json_list(topic_review.get("rows"))[:12]
+            if isinstance(item, Mapping)
+        ]
+        compact["topic_review"] = topic_review
+    return compact
+
+
+def _compact_topic_relevance_date_group(date_group: Mapping[str, object]) -> dict[str, object]:
+    """Return a topic/relevance date bucket with bounded article evidence."""
+    compact = dict(date_group)
+    compact["articles"] = [
+        _compact_topic_relevance_article_row(article)
+        for article in _json_list(compact.get("articles"))
+        if isinstance(article, Mapping)
+    ]
+    compact["article_count"] = len(_json_list(date_group.get("articles")))
+    return compact
+
+
+def _compact_topic_relevance_article_row(article: Mapping[str, object]) -> dict[str, object]:
+    """Return an article row with representative topic/relevance evidence only."""
+    compact = dict(article)
+    preprocessing_rows = _sample_mapping_rows(compact.get("preprocessing_rows"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    embedding_evidence = _sample_mapping_rows(compact.get("embedding_evidence"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    topic_evidence = _sample_mapping_rows(compact.get("topic_evidence"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    relevance_gate_rows = _sample_mapping_rows(compact.get("relevance_gate_rows"), limit=_ARTICLE_DETAIL_SAMPLE_LIMIT)
+    compact["preprocessing_rows"] = preprocessing_rows
+    compact["preprocessing_row_count"] = len(_json_list(article.get("preprocessing_rows")))
+    compact["preprocessing_rows_truncated"] = compact["preprocessing_row_count"] > len(preprocessing_rows)
+    compact["embedding_evidence"] = embedding_evidence
+    compact["embedding_evidence_row_count"] = len(_json_list(article.get("embedding_evidence")))
+    compact["embedding_evidence_truncated"] = compact["embedding_evidence_row_count"] > len(embedding_evidence)
+    compact["topic_evidence"] = topic_evidence
+    compact["topic_evidence_row_count"] = len(_json_list(article.get("topic_evidence")))
+    compact["topic_evidence_truncated"] = compact["topic_evidence_row_count"] > len(topic_evidence)
+    compact["relevance_gate_rows"] = relevance_gate_rows
+    compact["relevance_gate_row_count"] = len(_json_list(article.get("relevance_gate_rows")))
+    compact["relevance_gate_rows_truncated"] = compact["relevance_gate_row_count"] > len(relevance_gate_rows)
+    compact["evidence_sampling_note"] = (
+        "Representative rows only" if any(
+            compact[key]
+            for key in (
+                "preprocessing_rows_truncated",
+                "embedding_evidence_truncated",
+                "topic_evidence_truncated",
+                "relevance_gate_rows_truncated",
+            )
+        ) else None
+    )
+    return compact
+
+
+def _sample_mapping_rows(value: object, *, limit: int) -> list[dict[str, object]]:
+    """Return a bounded list of JSON-mapping rows."""
+    return [dict(item) for item in _json_list(value)[: max(limit, 0)] if isinstance(item, Mapping)]

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -194,9 +194,13 @@ def test_semantic_review_payload_flags_weak_and_duplicate_articles(tmp_path: Pat
     assert payload["benchmark_ticker"] == "SPY"
     assert len(cast(list[dict[str, Any]], payload["benchmark_price_series"])) == 2
     assert len(cast(list[dict[str, Any]], payload["benchmark_market_regime_series"])) == 2
-    assert len(cast(list[dict[str, Any]], sections["raw_preprocessing_rows"])) == 8
-    assert len(cast(list[dict[str, Any]], sections["topic_label_rows"])) == 4
-    assert len(cast(list[dict[str, Any]], sections["relevance_gate_rows"])) == 8
+    assert cast(dict[str, Any], payload["pipeline_section_counts"])["raw_preprocessing_rows"]["row_count"] == 8
+    assert cast(dict[str, Any], payload["pipeline_section_counts"])["topic_label_rows"]["row_count"] == 4
+    assert cast(dict[str, Any], payload["pipeline_section_counts"])["relevance_gate_rows"]["row_count"] == 8
+    assert cast(dict[str, Any], payload["pipeline_section_counts"])["semantic_aggregate_rows"]["row_count"] == 2
+    assert len(cast(list[dict[str, Any]], sections["raw_preprocessing_rows"])) == 1
+    assert len(cast(list[dict[str, Any]], sections["topic_label_rows"])) == 1
+    assert len(cast(list[dict[str, Any]], sections["relevance_gate_rows"])) == 1
     assert len(cast(list[dict[str, Any]], sections["semantic_aggregate_rows"])) == 2
     assert len(cast(list[dict[str, Any]], payload["price_series"])) == 2
     assert len(cast(list[dict[str, Any]], payload["market_regime_series"])) == 2
@@ -212,12 +216,16 @@ def test_semantic_review_payload_flags_weak_and_duplicate_articles(tmp_path: Pat
     ferrari = next(item for item in article_groups if item["article_id"] == "ferrari-001")
     assert "no_requested_ticker_evidence" in ferrari["contamination_flags"]
     assert ferrari["requested_ticker_term_hits"] == []
-    assert ferrari["sentence_rows"][0]["sentence_index"] == 0
-    assert ferrari["sentence_rows"][0]["text"].startswith("Ferrari shares fell sharply")
+    finbert_articles = {
+        str(item["article_id"]): cast(dict[str, Any], item)
+        for item in cast(list[dict[str, Any]], payload["finbert_sentence_review"]["articles"])
+    }
+    assert finbert_articles["ferrari-001"]["sentence_rows"][0]["sentence_index"] == 0
+    assert finbert_articles["ferrari-001"]["sentence_rows"][0]["text"].startswith("Ferrari shares fell sharply")
 
     duplicate = next(item for item in article_groups if item["article_id"] == "aapl-001")
     assert "duplicate_normalized_headline" in duplicate["contamination_flags"]
-    assert duplicate["sentence_rows"][0]["text"].startswith("Apple shares climbed")
+    assert duplicate["requested_ticker_term_hits"] == ["apple"]
     assert payload["article_review"]["accepted_article_count"] == 1
     assert payload["article_review"]["contamination_article_count"] == 3
 
@@ -781,6 +789,33 @@ def test_semantic_review_dashboard_html_names_human_review_outputs() -> None:
     assert "Pre-FinBERT relevance gate artifact is missing" in html
     assert "Human-review digest" in html
     assert "Only AI/ML/NLP evidence belongs here" in html
+
+
+def test_semantic_review_dashboard_payload_is_bounded_and_valid(tmp_path: Path) -> None:
+    """The normal dashboard payload should stay bounded and still validate."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    payload_json = json.dumps(payload)
+
+    assert payload["smoke"]["status"] == "pass"
+    assert payload["report_summary"]["row_count"] == 8
+    assert payload["pipeline_section_counts"]["raw_preprocessing_rows"]["row_count"] == 8
+    assert payload["pipeline_section_counts"]["raw_preprocessing_rows"]["sample_count"] == 1
+    assert payload["pipeline_section_counts"]["raw_preprocessing_rows"]["truncated"] is True
+    assert len(payload_json.encode("utf-8")) < 200_000
+    assert validate_layer1_semantic_review_dashboard_payload(payload)["status"] == "pass"
+    assert "report" not in payload
+    assert "report_summary" in payload
+    assert len(cast(list[dict[str, Any]], payload["article_groups"])) == 4
+    assert cast(list[dict[str, Any]], payload["article_groups"])[0]["sentence_rows_sample_count"] <= 3
 
 
 def test_semantic_review_dashboard_smoke_payload_is_compact_and_valid(tmp_path: Path) -> None:

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -366,6 +366,8 @@ def test_semantic_review_topic_relevance_tab_flags_default_relevance(
     assert accepted["topic_evidence"][0]["topic_id"] == 0
     assert accepted["topic_evidence"][0]["topic_probability"] == 0.82
     assert accepted["topic_evidence"][0]["topic_example_text"]
+    assert len(cast(list[dict[str, Any]], accepted["sentence_rows"])) <= 3
+    assert len(cast(list[dict[str, Any]], accepted["preprocessing_rows"])) <= 1
     assert accepted["assignment_classification"] == "direct"
     assert accepted["assignment_weight"] == 1.0
     assert accepted["assignment_evidence_kinds"]
@@ -816,6 +818,12 @@ def test_semantic_review_dashboard_payload_is_bounded_and_valid(tmp_path: Path) 
     assert "report_summary" in payload
     assert len(cast(list[dict[str, Any]], payload["article_groups"])) == 4
     assert cast(list[dict[str, Any]], payload["article_groups"])[0]["sentence_rows_sample_count"] <= 3
+    finbert_articles = cast(list[dict[str, Any]], payload["finbert_sentence_review"]["articles"])
+    first_finbert_article = finbert_articles[0]
+    assert first_finbert_article["preprocessing_row_count"] == 3
+    assert len(cast(list[dict[str, Any]], first_finbert_article["preprocessing_rows"])) == 1
+    assert first_finbert_article["preprocessing_rows_truncated"] is True
+    assert first_finbert_article["sentence_rows_sample_count"] <= 3
 
 
 def test_semantic_review_dashboard_smoke_payload_is_compact_and_valid(tmp_path: Path) -> None:

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import copy
+import json
 from pathlib import Path
 from typing import Any, cast
 
@@ -9,6 +10,7 @@ from app.lab.semantic_review_dashboard import _DashboardDefaults, _render_dashbo
 from core.features.aapl_evidence import build_layer1_aapl_evidence_report
 from core.features.semantic_review_dashboard import (
     build_layer1_semantic_review_dashboard_payload,
+    build_layer1_semantic_review_dashboard_smoke_payload,
     build_layer1_semantic_review_readiness_summary,
     validate_layer1_semantic_review_dashboard_payload,
 )
@@ -779,3 +781,27 @@ def test_semantic_review_dashboard_html_names_human_review_outputs() -> None:
     assert "Pre-FinBERT relevance gate artifact is missing" in html
     assert "Human-review digest" in html
     assert "Only AI/ML/NLP evidence belongs here" in html
+
+
+def test_semantic_review_dashboard_smoke_payload_is_compact_and_valid(tmp_path: Path) -> None:
+    """Smoke payloads should stay compact enough for Pi browser QA."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_smoke_payload(report))
+
+    assert payload["smoke"]["status"] == "pass"
+    assert payload["summary"]["article_count"] == 4
+    assert payload["summary"]["date_count"] == 2
+    assert "report" not in payload
+    assert "article_groups" not in payload
+    assert "date_groups" not in payload
+    assert len(cast(list[dict[str, Any]], payload["pipeline_sections"]["raw_preprocessing_rows"])) == 1
+    assert len(cast(list[dict[str, Any]], payload["pipeline_sections"]["finbert_sentence_rows"])) == 1
+    assert len(json.dumps(payload)) < 50_000


### PR DESCRIPTION
Fixes #272 follow-up dashboard smoke OOM blocker.

## Summary
- Adds a compact semantic-review smoke payload so smoke mode does not materialize the full dashboard view model.
- Keeps the full dashboard/API payload path intact.
- Uses a synchronous compact smoke page for browser smoke rendering.
- Adds focused coverage that the compact smoke payload remains valid and small enough for smoke.

## Validation
- `pytest`: 20 passed
- `ruff check`: passed
- `git diff --check`: clean
- Real AAPL v3 dashboard smoke: exit 0, elapsed 10.74s, child max RSS 388224 KB, screenshot `/tmp/semantic-review-dashboard-v3-aapl-smoke.png`

Run id verified:
`layer1-daily-2026-06-18-2026-06-18-repaired-modal-t4-v3`
