### PR TITLE
fix: degrade optional HMM feature-set gaps in semantic dashboard

### DIFF
--- a/app/lab/semantic_review_dashboard.py
+++ b/app/lab/semantic_review_dashboard.py
@@ -286,8 +286,8 @@ def _render_smoke_html(defaults: _DashboardDefaults, payload: Mapping[str, objec
             "to_date": defaults.to_date,
             "ticker": defaults.ticker,
         }
-    )
-    payload_json = json.dumps(payload, sort_keys=True)
+    ).replace("</", "<\\/")
+    payload_json = json.dumps(payload, sort_keys=True).replace("</", "<\\/")
     return f"""<!doctype html>
 <html lang=\"en\">
 <head>

--- a/core/features/aapl_evidence.py
+++ b/core/features/aapl_evidence.py
@@ -1321,6 +1321,15 @@ def _build_hmm_evaluation_context(
     )
     expected_columns = list(HMM_TRAINING_FEATURE_COLUMNS)
     active_columns = [column for column in expected_columns if column not in set(dropped_columns)]
+    training_windows = _training_windows_from_manifests(manifests)
+    regime_layer2_ready = bool(manifests) and all(
+        _maybe_bool(manifest.get("regime_layer2_ready")) is True for manifest in manifests
+    )
+    complete_training_rows_sufficient = _training_rows_are_complete(training_windows)
+    feature_set_status = "complete" if not dropped_columns else "degraded"
+    feature_set_blocking = bool(dropped_columns) and not (
+        regime_layer2_ready and complete_training_rows_sufficient
+    )
     warnings: list[str] = []
     if not source_manifest_keys:
         warnings.append("missing_hmm_manifest")
@@ -1344,13 +1353,17 @@ def _build_hmm_evaluation_context(
         "expected_input_feature_columns": expected_columns,
         "input_feature_columns_used": active_columns,
         "dropped_feature_columns": dropped_columns,
+        "feature_set_status": feature_set_status,
+        "feature_set_blocking": feature_set_blocking,
+        "regime_layer2_ready": regime_layer2_ready,
         "requested_inference_dates": list(dates),
         "observed_inference_dates": observed_dates,
         "missing_inference_dates": missing_dates,
         "unexpected_inference_dates": unexpected_dates,
         "not_evaluated_dates": not_evaluated_dates,
         "stale_manifest_dates": stale_manifest_dates,
-        "training_windows": _training_windows_from_manifests(manifests),
+        "training_windows": training_windows,
+        "complete_training_rows_sufficient": complete_training_rows_sufficient,
         "source_artifact_keys": list(artifact_keys.get("regime", [])),
         "source_manifest_keys": source_manifest_keys,
         "manifest_summaries": manifests,
@@ -1392,6 +1405,37 @@ def _training_windows_from_manifests(
         seen.add(key)
         windows.append(window)
     return windows
+
+
+def _training_rows_are_complete(windows: Sequence[Mapping[str, object]]) -> bool:
+    """Return True when each manifest window has complete training rows available."""
+    if not windows:
+        return False
+    for window in windows:
+        training_rows = _maybe_int(window.get("training_rows"))
+        complete_training_rows = _maybe_int(window.get("complete_training_rows"))
+        if training_rows is None or complete_training_rows is None:
+            return False
+        if training_rows != complete_training_rows:
+            return False
+    return True
+
+
+def _hmm_feature_set_is_blocking(hmm_context: Mapping[str, object]) -> bool:
+    """Return True when a dropped HMM input column should still block acceptance."""
+    dropped_columns = _json_string_list(hmm_context.get("dropped_feature_columns"))
+    if not dropped_columns:
+        return False
+    if not _maybe_bool(hmm_context.get("regime_layer2_ready")):
+        return True
+    if not _maybe_bool(hmm_context.get("complete_training_rows_sufficient")):
+        return True
+    training_windows = hmm_context.get("training_windows")
+    if not isinstance(training_windows, Sequence) or isinstance(training_windows, str):
+        return True
+    return not _training_rows_are_complete(
+        [window for window in training_windows if isinstance(window, Mapping)]
+    )
 
 
 def _load_date_partitioned_artifacts(
@@ -2016,6 +2060,9 @@ def build_layer1_semantic_review_dashboard_smoke_result(
             }
         )
     hmm_warnings = set(_json_string_list(hmm_context.get("warnings")))
+    feature_set_blocking = _maybe_bool(hmm_context.get("feature_set_blocking"))
+    if feature_set_blocking is None:
+        feature_set_blocking = _hmm_feature_set_is_blocking(hmm_context)
     blocker_warnings = {
         "missing_hmm_manifest",
         "missing_hmm_inference_dates",
@@ -2024,6 +2071,8 @@ def build_layer1_semantic_review_dashboard_smoke_result(
         "incomplete_hmm_feature_set",
         "missing_training_window_metadata",
     }
+    if not feature_set_blocking:
+        blocker_warnings.discard("incomplete_hmm_feature_set")
     if hmm_warnings & blocker_warnings:
         failures.append(
             {

--- a/core/features/aapl_evidence.py
+++ b/core/features/aapl_evidence.py
@@ -20,7 +20,10 @@ from core.features.news_assignment_provenance import (
     NEWS_EVIDENCE_RELEVANCE_WEIGHTS,
     NewsEvidenceClass,
 )
-from core.features.regime_training import HMM_TRAINING_FEATURE_COLUMNS
+from core.features.regime_training import (
+    HMM_OPTIONAL_FEATURE_COLUMNS,
+    HMM_TRAINING_FEATURE_COLUMNS,
+)
 from core.features.text_topics import build_topic_review_payload
 from services.r2.paths import (
     layer1_feature_path,
@@ -1319,6 +1322,10 @@ def _build_hmm_evaluation_context(
             for column in _json_string_list(manifest.get("dropped_feature_columns"))
         }
     )
+    optional_columns = set(HMM_OPTIONAL_FEATURE_COLUMNS)
+    non_optional_dropped_columns = [
+        column for column in dropped_columns if column not in optional_columns
+    ]
     expected_columns = list(HMM_TRAINING_FEATURE_COLUMNS)
     active_columns = [column for column in expected_columns if column not in set(dropped_columns)]
     training_windows = _training_windows_from_manifests(manifests)
@@ -1327,8 +1334,8 @@ def _build_hmm_evaluation_context(
     )
     complete_training_rows_sufficient = _training_rows_are_complete(training_windows)
     feature_set_status = "complete" if not dropped_columns else "degraded"
-    feature_set_blocking = bool(dropped_columns) and not (
-        regime_layer2_ready and complete_training_rows_sufficient
+    feature_set_blocking = bool(non_optional_dropped_columns) or (
+        bool(dropped_columns) and not (regime_layer2_ready and complete_training_rows_sufficient)
     )
     warnings: list[str] = []
     if not source_manifest_keys:
@@ -1355,6 +1362,8 @@ def _build_hmm_evaluation_context(
         "dropped_feature_columns": dropped_columns,
         "feature_set_status": feature_set_status,
         "feature_set_blocking": feature_set_blocking,
+        "feature_set_optional_columns": list(HMM_OPTIONAL_FEATURE_COLUMNS),
+        "feature_set_non_optional_dropped_columns": non_optional_dropped_columns,
         "regime_layer2_ready": regime_layer2_ready,
         "requested_inference_dates": list(dates),
         "observed_inference_dates": observed_dates,
@@ -1426,6 +1435,11 @@ def _hmm_feature_set_is_blocking(hmm_context: Mapping[str, object]) -> bool:
     dropped_columns = _json_string_list(hmm_context.get("dropped_feature_columns"))
     if not dropped_columns:
         return False
+    non_optional_dropped_columns = [
+        column for column in dropped_columns if column not in set(HMM_OPTIONAL_FEATURE_COLUMNS)
+    ]
+    if non_optional_dropped_columns:
+        return True
     if not _maybe_bool(hmm_context.get("regime_layer2_ready")):
         return True
     if not _maybe_bool(hmm_context.get("complete_training_rows_sufficient")):

--- a/core/features/regime_training.py
+++ b/core/features/regime_training.py
@@ -30,6 +30,10 @@ HMM_TRAINING_FEATURE_COLUMNS: tuple[str, ...] = (
     "high_yield_spread",
 )
 
+HMM_OPTIONAL_FEATURE_COLUMNS: tuple[str, ...] = (
+    "high_yield_spread",
+)
+
 HMM_TRAINING_COLUMNS: tuple[str, ...] = (
     "date",
     *HMM_TRAINING_FEATURE_COLUMNS,

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -665,6 +665,72 @@ def test_semantic_review_smoke_reports_missing_hmm_manifest_metadata(tmp_path: P
     assert "missing_training_window_metadata" in failure_reasons
 
 
+def test_semantic_review_smoke_allows_degraded_hmm_feature_set_when_layer2_ready(
+    tmp_path: Path,
+) -> None:
+    """Dropped HMM input columns should degrade, not block, when the manifest says layer 2 is ready."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    payload = copy.deepcopy(cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report)))
+    hmm_context = cast(dict[str, Any], payload["hmm_evaluation_context"])
+    hmm_context["warnings"] = ["incomplete_hmm_feature_set"]
+    hmm_context["dropped_feature_columns"] = ["high_yield_spread"]
+    hmm_context["expected_input_feature_columns"] = [
+        "spy_log_return_1d",
+        "spy_return_5d",
+        "spy_realized_vol_21d",
+        "spy_realized_vol_63d",
+        "spy_vol_ratio_21_63",
+        "spy_drawdown_63d",
+        "vix_level",
+        "vix_change_5d",
+        "yield_curve_slope_10y_2y",
+        "yield_curve_slope_10y_3m",
+        "high_yield_spread",
+    ]
+    hmm_context["input_feature_columns_used"] = [
+        "spy_log_return_1d",
+        "spy_return_5d",
+        "spy_realized_vol_21d",
+        "spy_realized_vol_63d",
+        "spy_vol_ratio_21_63",
+        "spy_drawdown_63d",
+        "vix_level",
+        "vix_change_5d",
+        "yield_curve_slope_10y_2y",
+        "yield_curve_slope_10y_3m",
+    ]
+    hmm_context["training_windows"] = [
+        {
+            "train_start_date": "2026-02-02",
+            "train_end_date": "2026-05-20",
+            "macro_load_start_date": "2026-02-02",
+            "macro_load_end_date": "2026-05-22",
+            "training_rows": 770,
+            "complete_training_rows": 770,
+        }
+    ]
+    hmm_context["regime_layer2_ready"] = True
+    hmm_context["feature_set_status"] = "degraded"
+
+    smoke = validate_layer1_semantic_review_dashboard_payload(payload)
+    failures = cast(list[dict[str, Any]], smoke["failures"])
+
+    assert smoke["status"] == "pass"
+    assert smoke["ready_for_final_human_acceptance"] is True
+    assert hmm_context["dropped_feature_columns"] == ["high_yield_spread"]
+    assert hmm_context["feature_set_status"] == "degraded"
+    assert hmm_context["feature_set_blocking"] is False
+    assert hmm_context["warnings"] == ["incomplete_hmm_feature_set"]
+    assert not any(item["stage"] == "hmm_evaluation_context" for item in failures)
+
+
 def test_semantic_review_smoke_reports_missing_stage_keys(tmp_path: Path) -> None:
     """The smoke result should name missing raw stage keys needed to repair the pilot."""
     fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -6,8 +6,11 @@ import json
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
+
 from app.lab.semantic_review_dashboard import _DashboardDefaults, _render_dashboard_html
 from core.features.aapl_evidence import build_layer1_aapl_evidence_report
+from core.features.regime_training import HMM_OPTIONAL_FEATURE_COLUMNS
 from core.features.semantic_review_dashboard import (
     build_layer1_semantic_review_dashboard_payload,
     build_layer1_semantic_review_dashboard_smoke_payload,
@@ -680,7 +683,7 @@ def test_semantic_review_smoke_allows_degraded_hmm_feature_set_when_layer2_ready
     payload = copy.deepcopy(cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report)))
     hmm_context = cast(dict[str, Any], payload["hmm_evaluation_context"])
     hmm_context["warnings"] = ["incomplete_hmm_feature_set"]
-    hmm_context["dropped_feature_columns"] = ["high_yield_spread"]
+    hmm_context["dropped_feature_columns"] = list(HMM_OPTIONAL_FEATURE_COLUMNS)
     hmm_context["expected_input_feature_columns"] = [
         "spy_log_return_1d",
         "spy_return_5d",
@@ -706,6 +709,7 @@ def test_semantic_review_smoke_allows_degraded_hmm_feature_set_when_layer2_ready
         "yield_curve_slope_10y_2y",
         "yield_curve_slope_10y_3m",
     ]
+    hmm_context["feature_set_optional_columns"] = list(HMM_OPTIONAL_FEATURE_COLUMNS)
     hmm_context["training_windows"] = [
         {
             "train_start_date": "2026-02-02",
@@ -717,18 +721,72 @@ def test_semantic_review_smoke_allows_degraded_hmm_feature_set_when_layer2_ready
         }
     ]
     hmm_context["regime_layer2_ready"] = True
+    hmm_context["complete_training_rows_sufficient"] = True
     hmm_context["feature_set_status"] = "degraded"
+    hmm_context["feature_set_blocking"] = None
 
     smoke = validate_layer1_semantic_review_dashboard_payload(payload)
     failures = cast(list[dict[str, Any]], smoke["failures"])
 
     assert smoke["status"] == "pass"
     assert smoke["ready_for_final_human_acceptance"] is True
-    assert hmm_context["dropped_feature_columns"] == ["high_yield_spread"]
+    assert hmm_context["dropped_feature_columns"] == list(HMM_OPTIONAL_FEATURE_COLUMNS)
+    assert hmm_context["feature_set_optional_columns"] == list(HMM_OPTIONAL_FEATURE_COLUMNS)
     assert hmm_context["feature_set_status"] == "degraded"
-    assert hmm_context["feature_set_blocking"] is False
     assert hmm_context["warnings"] == ["incomplete_hmm_feature_set"]
     assert not any(item["stage"] == "hmm_evaluation_context" for item in failures)
+
+
+@pytest.mark.parametrize(
+    "dropped_columns",
+    [
+        ["vix_level"],
+        ["spy_log_return_1d"],
+        ["high_yield_spread", "vix_level"],
+    ],
+)
+def test_semantic_review_smoke_blocks_non_allowlisted_hmm_feature_drops(
+    tmp_path: Path,
+    dropped_columns: list[str],
+) -> None:
+    """Only the allowlisted HMM drop may degrade; other missing inputs must block smoke."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    payload = copy.deepcopy(cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report)))
+    hmm_context = cast(dict[str, Any], payload["hmm_evaluation_context"])
+    hmm_context["warnings"] = ["incomplete_hmm_feature_set"]
+    hmm_context["dropped_feature_columns"] = dropped_columns
+    hmm_context["feature_set_optional_columns"] = list(HMM_OPTIONAL_FEATURE_COLUMNS)
+    hmm_context["training_windows"] = [
+        {
+            "train_start_date": "2026-02-02",
+            "train_end_date": "2026-05-20",
+            "macro_load_start_date": "2026-02-02",
+            "macro_load_end_date": "2026-05-22",
+            "training_rows": 770,
+            "complete_training_rows": 770,
+        }
+    ]
+    hmm_context["regime_layer2_ready"] = True
+    hmm_context["complete_training_rows_sufficient"] = True
+    hmm_context["feature_set_status"] = "degraded"
+    hmm_context["feature_set_blocking"] = None
+
+    smoke = validate_layer1_semantic_review_dashboard_payload(payload)
+    failures = cast(list[dict[str, Any]], smoke["failures"])
+    hmm_failure = next(item for item in failures if item["stage"] == "hmm_evaluation_context")
+
+    assert smoke["status"] == "fail"
+    assert hmm_context["feature_set_optional_columns"] == list(HMM_OPTIONAL_FEATURE_COLUMNS)
+    assert hmm_context["warnings"] == ["incomplete_hmm_feature_set"]
+    assert hmm_failure["reason"] == "hmm_context_blocker_warnings"
+    assert "incomplete_hmm_feature_set" in cast(list[str], hmm_failure["warning_codes"])
 
 
 def test_semantic_review_smoke_reports_missing_stage_keys(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Treat dropped HMM input columns as a non-blocking degraded state when the manifest reports layer 2 ready and training rows are complete.
- Preserve the warning visibility in the dashboard payload.
- Fix browser smoke HTML serialization so embedded closing script tags cannot break JSON parsing.

## Verification
- `./.venv/bin/python -m pytest tests/unit/test_semantic_review_dashboard.py tests/unit/test_aapl_pilot_evidence.py -q`
- `./.venv/bin/ruff check .`
- `git diff --check`
- Fresh smoke run for `layer1-aapl-accuracy-2026-05-06-to-2026-05-28-current-main-20260717-v2-after-pr278` passed.

Closes #279
