### PR TITLE
Fix target-conditioned news relevance gate

### DIFF
--- a/core/features/news_relevance.py
+++ b/core/features/news_relevance.py
@@ -341,6 +341,7 @@ def _build_record_analysis(
         assignment_classification=assignment_classification,
         assignment_evidence_kinds=assignment_evidence_kinds,
         ticker_score=ticker_score,
+        financial_score=financial_score,
         competitor_reasons=competitor_reasons,
     )
 
@@ -406,14 +407,11 @@ def _finalize_record_analysis(
     article_contribution_weight = float(article_stats["article_contribution_weight"])
     article_contamination_dominates = bool(article_stats["article_contamination_dominates"])
 
-    category_bonus = {
-        "direct_target_event": 0.18,
-        "supplier_or_input_cost_exposure": 0.12,
-        "competitor_read_through": 0.10,
-        "industry_or_macro_exposure": 0.05,
-        "incidental_comparison": 0.0,
-        "irrelevant": 0.0,
-    }.get(str(analysis["relevance_category"]), 0.0)
+    # Keep the relevance_score backward-compatible with the historical
+    # ticker/financial/topic weighted score.  The target-conditioned category
+    # controls accept/borderline/reject semantics and auditability, but it must
+    # not inflate downstream sentiment weights by itself.
+    category_bonus = 0.0
     relevance_score = min(
         1.0,
         (float(analysis["base_relevance_score"]) * article_contribution_weight) + category_bonus,
@@ -559,6 +557,7 @@ def _target_conditioned_metadata(
     assignment_classification: str | None,
     assignment_evidence_kinds: Sequence[str],
     ticker_score: float,
+    financial_score: float,
     competitor_reasons: Sequence[str],
 ) -> tuple[str, str, str, str, str, float, list[str]]:
     """Return target-conditioned category and audit metadata for a row."""
@@ -566,6 +565,12 @@ def _target_conditioned_metadata(
     lower_text = normalized_text.lower()
     direct_evidence = ticker_score >= 1.0 or assignment_classification == "direct" or (
         assignment_classification == "indirect" and "company_alias_entity_match" in assignment_evidence_kinds
+    )
+    source_tag_financial_evidence = (
+        assignment_classification is None
+        and not competitor_reasons
+        and ticker_score >= 0.45
+        and financial_score >= 0.35
     )
     has_direct_business_context = any(
         _contains_phrase(lower_text, term) for term in _DIRECT_TARGET_BUSINESS_TERMS
@@ -613,6 +618,36 @@ def _target_conditioned_metadata(
             "short_term",
             "supplier_input_cost",
             0.78,
+            reasons,
+        )
+
+    if source_tag_financial_evidence and has_macro_context:
+        category = "industry_or_macro_exposure"
+        reasons.append("target_conditioned_category:industry_or_macro_exposure")
+        reasons.append("causal_channel:industry_macro")
+        reasons.append("source_tag_financial_evidence")
+        return (
+            category,
+            _impact_direction(lower_text),
+            "low",
+            "medium_term",
+            "industry_macro",
+            0.55,
+            reasons,
+        )
+
+    if source_tag_financial_evidence:
+        category = "direct_target_event"
+        reasons.append("target_conditioned_category:direct_target_event")
+        reasons.append("causal_channel:source_tagged_financial_event")
+        reasons.append("source_tag_financial_evidence")
+        return (
+            category,
+            _impact_direction(lower_text),
+            "medium",
+            "short_term",
+            "source_tagged_financial_event",
+            0.62,
             reasons,
         )
 

--- a/core/features/news_relevance.py
+++ b/core/features/news_relevance.py
@@ -30,6 +30,16 @@ RELEVANCE_GATE_COLUMNS: tuple[str, ...] = (
     "ticker_relevance_score",
     "financial_relevance_score",
     "topic_relevance_score",
+    "relevance_category",
+    "target_company_impact_direction",
+    "target_company_impact_magnitude",
+    "impact_horizon",
+    "causal_channel",
+    "target_impact_confidence",
+    "article_contamination_ratio",
+    "article_contamination_count",
+    "article_signal_count",
+    "article_contribution_weight",
     "reason_codes",
     "ticker_evidence",
     "entity_evidence",
@@ -107,6 +117,83 @@ _TICKER_ALIASES: Mapping[str, tuple[str, ...]] = {
     "SPY": ("spy", "s&p 500", "spdr s&p 500 etf trust"),
 }
 
+_DIRECT_TARGET_BUSINESS_TERMS: tuple[str, ...] = (
+    "app store",
+    "device",
+    "devices",
+    "enterprise software",
+    "investor",
+    "investors",
+    "legal",
+    "model",
+    "openai",
+    "options",
+    "ownership",
+    "product",
+    "regulatory",
+    "regulation",
+    "sec",
+    "software",
+    "vision pro",
+)
+_SUPPLIER_INPUT_COST_TERMS: tuple[str, ...] = (
+    "foundry",
+    "input costs",
+    "manufacturing",
+    "semiconductor",
+    "semiconductors",
+    "shortage",
+    "supplier",
+    "supply chain",
+    "tariff",
+)
+_COMPETITOR_READTHROUGH_TERMS: tuple[str, ...] = (
+    "compete",
+    "competitor",
+    "competitors",
+    "peer",
+    "peers",
+    "rival",
+    "rivals",
+    "readthrough",
+)
+_INDUSTRY_MACRO_TERMS: tuple[str, ...] = (
+    "ai",
+    "broad market",
+    "cloud",
+    "datacenter",
+    "federal reserve",
+    "inflation",
+    "interest rates",
+    "market",
+    "markets",
+    "nasdaq",
+    "rates",
+    "sector",
+    "stocks",
+    "wall street",
+)
+_INCIDENTAL_COMPARISON_TERMS: tuple[str, ...] = (
+    "best stocks",
+    "compare",
+    "comparison",
+    "mag 7",
+    "listicle",
+    "roundup",
+    "top stocks",
+    "watchlist",
+)
+_BUSINESS_CONTEXT_CHANNELS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("legal_regulatory", ("antitrust", "lawsuit", "probe", "regulator", "investigation", "ruling")),
+    ("product_device", ("app store", "device", "devices", "iphone", "ipad", "mac", "product", "software", "vision pro")),
+    ("supplier_input_cost", _SUPPLIER_INPUT_COST_TERMS),
+    ("analyst_investor", ("analyst", "analysts", "price target", "rating", "upgrade", "downgrade")),
+    ("ownership", ("ownership", "stake", "shareholder", "shareholders", "buyback", "dividend")),
+    ("ai_chip_device", ("ai chip", "chip", "chips", "compute", "datacenter", "gpu", "server", "servers")),
+    ("options_market", ("options", "calls", "puts", "volatility")),
+    ("enterprise_cloud", ("azure", "cloud", "copilot", "openai", "enterprise software", "subscription")),
+)
+
 
 @dataclass(frozen=True)
 class NewsRelevanceGateConfig:
@@ -159,17 +246,36 @@ def apply_news_relevance_gate(
     topic_lookup = _topic_lookup(topic_labels)
     embedding_lookup = _embedding_lookup(embeddings)
 
+    analyses = [
+        _build_record_analysis(
+            record,
+            topic_lookup=topic_lookup,
+            embedding_lookup=embedding_lookup,
+            config=settings,
+        )
+        for record in records
+    ]
+    article_stats = _article_contamination_stats(analyses)
+
     passed: list[NewsSentimentRecord] = []
     audit_rows: list[dict[str, Any]] = []
     accepted_rows = 0
     borderline_rows = 0
     rejected_rows = 0
 
-    for record in records:
-        decision = _evaluate_record(
-            record,
-            topic_lookup=topic_lookup,
-            embedding_lookup=embedding_lookup,
+    for record, analysis in zip(records, analyses):
+        decision = _finalize_record_analysis(
+            analysis,
+            article_stats=article_stats.get(
+                analysis["article_key"],
+                {
+                    "article_contamination_ratio": 0.0,
+                    "article_contamination_count": 0,
+                    "article_signal_count": 1,
+                    "article_contribution_weight": 1.0,
+                    "article_contamination_dominates": False,
+                },
+            ),
             config=settings,
         )
         audit_rows.append(decision)
@@ -192,14 +298,14 @@ def apply_news_relevance_gate(
     )
 
 
-def _evaluate_record(
+def _build_record_analysis(
     record: NewsSentimentRecord,
     *,
     topic_lookup: Mapping[tuple[str, str, str], Mapping[str, Any]],
     embedding_lookup: Mapping[tuple[str, str], Mapping[str, Any]],
     config: NewsRelevanceGateConfig,
 ) -> dict[str, Any]:
-    """Return one auditable gate decision row for a preprocessed news record."""
+    """Return row-level evidence and base scores for one preprocessed news record."""
     ticker = record.ticker.strip().upper()
     provenance = _provenance(record)
     text = " ".join(part for part in (record.headline, record.text) if part)
@@ -209,8 +315,8 @@ def _evaluate_record(
     entity_mentions = _json_string_list(
         provenance.get("entity_mentions") or list(record.entity_mentions)
     )
-
     assignment_classification = _optional_text(provenance.get("assignment_classification"))
+    assignment_evidence_kinds = _json_string_list(provenance.get("assignment_evidence_kinds"))
 
     ticker_score, ticker_reasons = _ticker_relevance(
         ticker=ticker,
@@ -229,74 +335,401 @@ def _evaluate_record(
         entity_mentions=entity_mentions,
     )
 
-    relevance_score = min(
+    relevance_category, impact_direction, impact_magnitude, impact_horizon, causal_channel, target_confidence, category_reasons = _target_conditioned_metadata(
+        ticker=ticker,
+        normalized_text=normalized_text,
+        assignment_classification=assignment_classification,
+        assignment_evidence_kinds=assignment_evidence_kinds,
+        ticker_score=ticker_score,
+        competitor_reasons=competitor_reasons,
+    )
+
+    base_relevance_score = min(
         1.0,
         (0.65 * ticker_score) + (0.25 * financial_score) + (0.10 * topic_score),
     )
-    reasons = [*ticker_reasons, *financial_reasons, *topic_reasons]
+    if competitor_reasons and relevance_category != "competitor_read_through" and ticker_score < 1.0:
+        base_relevance_score = min(base_relevance_score, 0.30)
+
+    reasons = [*ticker_reasons, *financial_reasons, *topic_reasons, *category_reasons]
     if embedding_row is None:
         reasons.append("missing_embedding")
-    if competitor_reasons and ticker_score < 1.0:
-        relevance_score = min(relevance_score, 0.30)
-        reasons.extend(competitor_reasons)
-
     if financial_score < config.min_financial_score:
         reasons.append("low_financial_relevance")
     if ticker_score <= 0.0:
         reasons.append("low_ticker_relevance")
 
-    if (
-        relevance_score >= config.accepted_threshold
-        and ticker_score >= 0.75
-        and financial_score >= config.min_financial_score
-    ):
-        decision = "accepted"
-    elif (
-        relevance_score >= config.borderline_threshold
-        and ticker_score > 0.0
-        and financial_score >= config.min_financial_score
-        and not competitor_reasons
-    ):
-        decision = "borderline"
-        reasons.append("borderline_ticker_or_topic_evidence")
-    else:
-        decision = "rejected"
-        reasons.append("rejected_by_relevance_gate")
-
-    topic_probability = _optional_float(topic_row.get("topic_probability")) if topic_row else None
-    topic_id = _optional_int(topic_row.get("topic_id")) if topic_row else None
-    embedding_cache_key = (
-        _optional_text(embedding_row.get("embedding_cache_key")) if embedding_row else None
-    )
     return {
         "date": record.date,
         "ticker": ticker,
         "article_id": record.article_id,
+        "article_key": record.article_id or _stable_article_id(record),
         "sentence_index": record.sentence_index,
         "chunk_index": record.chunk_index,
         "headline": record.headline,
         "text": record.text,
         "source": record.source,
         "published_at": record.published_at.isoformat() if record.published_at else None,
-        "relevance_decision": decision,
-        "relevance_score": relevance_score,
         "ticker_relevance_score": ticker_score,
         "financial_relevance_score": financial_score,
         "topic_relevance_score": topic_score,
-        "reason_codes": json.dumps(sorted(set(reasons))),
-        "ticker_evidence": json.dumps(
-            {
-                "source_tickers": source_tickers,
-                "chunk_tickers": chunk_tickers,
-            },
-            sort_keys=True,
-        ),
-        "entity_evidence": json.dumps(entity_mentions),
-        "topic_id": topic_id,
-        "topic_probability": topic_probability,
-        "embedding_cache_key": embedding_cache_key,
+        "relevance_category": relevance_category,
+        "target_company_impact_direction": impact_direction,
+        "target_company_impact_magnitude": impact_magnitude,
+        "impact_horizon": impact_horizon,
+        "causal_channel": causal_channel,
+        "target_impact_confidence": target_confidence,
+        "base_relevance_score": base_relevance_score,
+        "reason_codes": reasons,
+        "ticker_evidence": {
+            "source_tickers": source_tickers,
+            "chunk_tickers": chunk_tickers,
+        },
+        "entity_evidence": entity_mentions,
+        "topic_id": _optional_int(topic_row.get("topic_id")) if topic_row else None,
+        "topic_probability": _optional_float(topic_row.get("topic_probability")) if topic_row else None,
+        "embedding_cache_key": _optional_text(embedding_row.get("embedding_cache_key")) if embedding_row else None,
         "has_embedding": embedding_row is not None,
     }
+
+
+def _finalize_record_analysis(
+    analysis: Mapping[str, Any],
+    *,
+    article_stats: Mapping[str, Any],
+    config: NewsRelevanceGateConfig,
+) -> dict[str, Any]:
+    """Apply article-level contamination adjustments and emit the final audit row."""
+    article_contamination_ratio = float(article_stats["article_contamination_ratio"])
+    article_contamination_count = int(article_stats["article_contamination_count"])
+    article_signal_count = int(article_stats["article_signal_count"])
+    article_contribution_weight = float(article_stats["article_contribution_weight"])
+    article_contamination_dominates = bool(article_stats["article_contamination_dominates"])
+
+    category_bonus = {
+        "direct_target_event": 0.18,
+        "supplier_or_input_cost_exposure": 0.12,
+        "competitor_read_through": 0.10,
+        "industry_or_macro_exposure": 0.05,
+        "incidental_comparison": 0.0,
+        "irrelevant": 0.0,
+    }.get(str(analysis["relevance_category"]), 0.0)
+    relevance_score = min(
+        1.0,
+        (float(analysis["base_relevance_score"]) * article_contribution_weight) + category_bonus,
+    )
+
+    reasons = set(analysis["reason_codes"])
+    if article_contribution_weight < 1.0:
+        reasons.add("article_contribution_capped")
+    if article_contamination_dominates:
+        reasons.add("article_contamination_dominates")
+    if article_contribution_weight < 1.0 or article_contamination_dominates:
+        reasons.add("article_signal_vs_contamination_adjusted")
+
+    category = str(analysis["relevance_category"])
+    target_confidence = float(analysis["target_impact_confidence"])
+    ticker_score = float(analysis["ticker_relevance_score"])
+    financial_score = float(analysis["financial_relevance_score"])
+    direct_business_context = category == "direct_target_event"
+    supported_target_category = category in {
+        "direct_target_event",
+        "supplier_or_input_cost_exposure",
+        "competitor_read_through",
+        "industry_or_macro_exposure",
+    }
+
+    if category == "direct_target_event":
+        if relevance_score >= config.accepted_threshold and not article_contamination_dominates:
+            decision = "accepted"
+        elif relevance_score >= config.borderline_threshold or direct_business_context:
+            decision = "borderline"
+            reasons.add("borderline_ticker_or_topic_evidence")
+        else:
+            decision = "rejected"
+            reasons.add("rejected_by_relevance_gate")
+    elif category in {"supplier_or_input_cost_exposure", "competitor_read_through", "industry_or_macro_exposure"}:
+        if relevance_score >= config.accepted_threshold and not article_contamination_dominates:
+            decision = "accepted"
+        elif relevance_score >= config.borderline_threshold and ticker_score > 0.0:
+            decision = "borderline"
+            reasons.add("borderline_ticker_or_topic_evidence")
+        else:
+            decision = "rejected"
+            reasons.add("rejected_by_relevance_gate")
+    elif category == "incidental_comparison":
+        if (
+            relevance_score >= config.borderline_threshold
+            and ticker_score >= 0.75
+            and not article_contamination_dominates
+        ):
+            decision = "borderline"
+            reasons.add("borderline_ticker_or_topic_evidence")
+        else:
+            decision = "rejected"
+            reasons.add("rejected_by_relevance_gate")
+    else:
+        decision = "rejected"
+        reasons.add("rejected_by_relevance_gate")
+
+    if decision != "rejected" and financial_score < config.min_financial_score:
+        reasons.add("low_financial_relevance")
+    if decision != "rejected" and ticker_score <= 0.0:
+        reasons.add("low_ticker_relevance")
+
+    if supported_target_category and decision in {"accepted", "borderline"}:
+        reasons.add(f"target_category:{category}")
+
+    return {
+        "date": analysis["date"],
+        "ticker": analysis["ticker"],
+        "article_id": analysis["article_id"],
+        "sentence_index": analysis["sentence_index"],
+        "chunk_index": analysis["chunk_index"],
+        "headline": analysis["headline"],
+        "text": analysis["text"],
+        "source": analysis["source"],
+        "published_at": analysis["published_at"],
+        "relevance_decision": decision,
+        "relevance_score": relevance_score,
+        "ticker_relevance_score": analysis["ticker_relevance_score"],
+        "financial_relevance_score": analysis["financial_relevance_score"],
+        "topic_relevance_score": analysis["topic_relevance_score"],
+        "relevance_category": category,
+        "target_company_impact_direction": analysis["target_company_impact_direction"],
+        "target_company_impact_magnitude": analysis["target_company_impact_magnitude"],
+        "impact_horizon": analysis["impact_horizon"],
+        "causal_channel": analysis["causal_channel"],
+        "target_impact_confidence": target_confidence,
+        "article_contamination_ratio": article_contamination_ratio,
+        "article_contamination_count": article_contamination_count,
+        "article_signal_count": article_signal_count,
+        "article_contribution_weight": article_contribution_weight,
+        "reason_codes": json.dumps(sorted(reasons)),
+        "ticker_evidence": json.dumps(analysis["ticker_evidence"], sort_keys=True),
+        "entity_evidence": json.dumps(analysis["entity_evidence"]),
+        "topic_id": analysis["topic_id"],
+        "topic_probability": analysis["topic_probability"],
+        "embedding_cache_key": analysis["embedding_cache_key"],
+        "has_embedding": analysis["has_embedding"],
+    }
+
+
+def _article_contamination_stats(analyses: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Return per-article contamination accounting for the relevance gate."""
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for analysis in analyses:
+        grouped.setdefault(str(analysis["article_key"]), []).append(analysis)
+
+    stats: dict[str, dict[str, Any]] = {}
+    for article_key, rows in grouped.items():
+        total_count = len(rows)
+        signal_count = sum(
+            1
+            for row in rows
+            if row["relevance_category"] in {
+                "direct_target_event",
+                "supplier_or_input_cost_exposure",
+                "competitor_read_through",
+                "industry_or_macro_exposure",
+            }
+        )
+        contamination_count = max(0, total_count - signal_count)
+        contamination_ratio = contamination_count / total_count if total_count else 0.0
+        if contamination_ratio >= 0.75 and signal_count <= 2:
+            contribution_weight = 0.35
+        elif contamination_ratio >= 0.55:
+            contribution_weight = 0.60
+        else:
+            contribution_weight = 1.0
+        stats[article_key] = {
+            "article_contamination_ratio": contamination_ratio,
+            "article_contamination_count": contamination_count,
+            "article_signal_count": signal_count,
+            "article_contribution_weight": contribution_weight,
+            "article_contamination_dominates": contamination_ratio >= 0.70 and signal_count <= max(1, total_count // 4),
+        }
+    return stats
+
+
+def _target_conditioned_metadata(
+    *,
+    ticker: str,
+    normalized_text: str,
+    assignment_classification: str | None,
+    assignment_evidence_kinds: Sequence[str],
+    ticker_score: float,
+    competitor_reasons: Sequence[str],
+) -> tuple[str, str, str, str, str, float, list[str]]:
+    """Return target-conditioned category and audit metadata for a row."""
+    reasons: list[str] = []
+    lower_text = normalized_text.lower()
+    direct_evidence = ticker_score >= 1.0 or assignment_classification == "direct" or (
+        assignment_classification == "indirect" and "company_alias_entity_match" in assignment_evidence_kinds
+    )
+    has_direct_business_context = any(
+        _contains_phrase(lower_text, term) for term in _DIRECT_TARGET_BUSINESS_TERMS
+    )
+    has_supplier_context = any(_contains_phrase(lower_text, term) for term in _SUPPLIER_INPUT_COST_TERMS)
+    has_competitor_context = any(_contains_phrase(lower_text, term) for term in _COMPETITOR_READTHROUGH_TERMS)
+    has_macro_context = any(_contains_phrase(lower_text, term) for term in _INDUSTRY_MACRO_TERMS)
+    has_comparison_context = any(
+        _contains_phrase(lower_text, term) for term in _INCIDENTAL_COMPARISON_TERMS
+    )
+    business_channel, business_terms = _target_business_channel(lower_text)
+
+    if direct_evidence and (has_direct_business_context or business_channel in {
+        "legal_regulatory",
+        "product_device",
+        "analyst_investor",
+        "ownership",
+        "options_market",
+        "enterprise_cloud",
+        "ai_chip_device",
+    }):
+        category = "direct_target_event"
+        reasons.append("target_conditioned_category:direct_target_event")
+        reasons.append(f"causal_channel:{business_channel}")
+        if business_terms:
+            reasons.append("matched_business_terms:" + ",".join(business_terms[:5]))
+        return (
+            category,
+            _impact_direction(lower_text),
+            _impact_magnitude(business_channel),
+            _impact_horizon(business_channel),
+            business_channel,
+            0.92,
+            reasons,
+        )
+
+    if (direct_evidence or assignment_classification == "indirect") and has_supplier_context:
+        category = "supplier_or_input_cost_exposure"
+        reasons.append("target_conditioned_category:supplier_or_input_cost_exposure")
+        reasons.append("causal_channel:supplier_input_cost")
+        return (
+            category,
+            _impact_direction(lower_text),
+            "medium",
+            "short_term",
+            "supplier_input_cost",
+            0.78,
+            reasons,
+        )
+
+    if (direct_evidence or assignment_classification == "indirect") and has_competitor_context:
+        category = "competitor_read_through"
+        reasons.append("target_conditioned_category:competitor_read_through")
+        reasons.append("causal_channel:competitor_readthrough")
+        return (
+            category,
+            _impact_direction(lower_text),
+            "medium",
+            "medium_term",
+            "competitor_readthrough",
+            0.70,
+            reasons,
+        )
+
+    if assignment_classification == "broad_market" or (direct_evidence and has_macro_context):
+        category = "industry_or_macro_exposure"
+        reasons.append("target_conditioned_category:industry_or_macro_exposure")
+        reasons.append("causal_channel:industry_macro")
+        return (
+            category,
+            _impact_direction(lower_text),
+            "low",
+            "medium_term",
+            "industry_macro",
+            0.58,
+            reasons,
+        )
+
+    if assignment_classification == "contamination" and (has_comparison_context or competitor_reasons):
+        category = "incidental_comparison"
+        reasons.append("target_conditioned_category:incidental_comparison")
+        reasons.append("causal_channel:comparison_context")
+        return (
+            category,
+            "unclear",
+            "low",
+            "short_term",
+            "comparison_context",
+            0.30,
+            reasons,
+        )
+
+    if has_comparison_context:
+        category = "incidental_comparison"
+        reasons.append("target_conditioned_category:incidental_comparison")
+        reasons.append("causal_channel:comparison_context")
+        return (
+            category,
+            "unclear",
+            "low",
+            "short_term",
+            "comparison_context",
+            0.30,
+            reasons,
+        )
+
+    if direct_evidence and has_macro_context:
+        category = "industry_or_macro_exposure"
+        reasons.append("target_conditioned_category:industry_or_macro_exposure")
+        reasons.append("causal_channel:industry_macro")
+        return (
+            category,
+            _impact_direction(lower_text),
+            "low",
+            "medium_term",
+            "industry_macro",
+            0.55,
+            reasons,
+        )
+
+    category = "irrelevant"
+    reasons.append("target_conditioned_category:irrelevant")
+    reasons.append("causal_channel:none")
+    return ("irrelevant", "unclear", "low", "unknown", "none", 0.10, reasons)
+
+
+def _target_business_channel(normalized_text: str) -> tuple[str, tuple[str, ...]]:
+    """Return the dominant causal channel and matched terms for a row."""
+    for channel, terms in _BUSINESS_CONTEXT_CHANNELS:
+        matched = tuple(term for term in terms if _contains_phrase(normalized_text, term))
+        if matched:
+            return channel, matched
+    return "none", ()
+
+
+def _impact_direction(normalized_text: str) -> str:
+    """Return a lightweight impact direction for auditability."""
+    if any(term in normalized_text for term in ("boost", "beat", "growth", "higher", "lift", "rises", "strong", "up")):
+        return "positive"
+    if any(term in normalized_text for term in ("fall", "lower", "pressure", "probe", "risk", "lawsuit", "warn", "weak", "down")):
+        return "negative"
+    return "unclear"
+
+
+def _impact_magnitude(channel: str) -> str:
+    """Return a coarse impact magnitude by causal channel."""
+    if channel in {"legal_regulatory", "ai_chip_device", "enterprise_cloud"}:
+        return "high"
+    if channel in {"supplier_input_cost", "competitor_readthrough", "product_device", "analyst_investor", "ownership", "options_market"}:
+        return "medium"
+    if channel == "industry_macro":
+        return "low"
+    return "low"
+
+
+def _impact_horizon(channel: str) -> str:
+    """Return a coarse impact horizon by causal channel."""
+    if channel in {"legal_regulatory", "analyst_investor", "ownership", "options_market"}:
+        return "immediate"
+    if channel in {"product_device", "supplier_input_cost", "enterprise_cloud"}:
+        return "short_term"
+    if channel in {"competitor_readthrough", "industry_macro"}:
+        return "medium_term"
+    return "unknown"
 
 
 def _ticker_relevance(

--- a/tests/unit/test_news_relevance.py
+++ b/tests/unit/test_news_relevance.py
@@ -11,18 +11,63 @@ from core.features.news_relevance import (
     apply_news_relevance_gate,
 )
 
+TARGET_TICKERS = ("AAPL", "AMD", "NVDA", "MSFT")
 
-def test_news_relevance_gate_filters_aapl_contamination_pattern() -> None:
-    """Weak non-AAPL article tags do not flow into AAPL FinBERT scoring."""
-    articles = json.loads(
-        Path("tests/fixtures/news_relevance_gate_articles.json").read_text(
-            encoding="utf-8"
-        )
-    )
+
+def test_news_relevance_gate_target_conditioned_categories_and_contamination_controls() -> None:
+    """Target-conditioned relevance survives direct business-impact rows and downweights listicles."""
+    articles = [
+        {
+            "id": "aapl-direct",
+            "headline": "Apple App Store legal ruling boosts iPhone device sales",
+            "summary": "Analysts say the product update could help investor sentiment and services revenue.",
+            "created_at": "2024-01-02T12:00:00+00:00",
+            "source": "benzinga",
+            "symbols": list(TARGET_TICKERS),
+        },
+        {
+            "id": "amd-supply",
+            "headline": "AMD warns semiconductor supply chain and input costs may pressure margins",
+            "summary": "The chipmaker said manufacturing and foundry issues could weigh on results.",
+            "created_at": "2024-01-02T12:05:00+00:00",
+            "source": "benzinga",
+            "symbols": list(TARGET_TICKERS),
+        },
+        {
+            "id": "nvda-direct",
+            "headline": "NVIDIA GPU demand and datacenter AI-chip sales stay strong",
+            "summary": "Analysts raised price targets after the device and compute update.",
+            "created_at": "2024-01-02T12:10:00+00:00",
+            "source": "benzinga",
+            "symbols": list(TARGET_TICKERS),
+        },
+        {
+            "id": "msft-direct",
+            "headline": "Microsoft Azure, OpenAI and Copilot enterprise software demand lifts outlook",
+            "summary": "The cloud and product update supports investor sentiment.",
+            "created_at": "2024-01-02T12:15:00+00:00",
+            "source": "benzinga",
+            "symbols": list(TARGET_TICKERS),
+        },
+        {
+            "id": "mag7-listicle",
+            "headline": "Markets rally as investors pick five large-cap names",
+            "summary": "Apple, Microsoft, NVIDIA and AMD appear in a roundup of the Mag 7 trade.",
+            "content": (
+                "Treasury yields and the S&P 500 drove the broader market tone. "
+                "The article compares a basket of stocks and only briefly names Apple, Microsoft, NVIDIA and AMD. "
+                "Wall Street traders focused on inflation, rates and market rotation rather than one company."
+            ),
+            "created_at": "2024-01-02T12:20:00+00:00",
+            "source": "benzinga",
+            "symbols": list(TARGET_TICKERS),
+        },
+    ]
+
     records = preprocess_news_articles(
         articles,
         as_of_date="2024-01-02",
-        point_in_time_tickers=("AAPL",),
+        point_in_time_tickers=TARGET_TICKERS,
     )
 
     result = apply_news_relevance_gate(
@@ -32,28 +77,88 @@ def test_news_relevance_gate_filters_aapl_contamination_pattern() -> None:
     )
 
     audit = result.audit_frame
-    by_article = {
-        article_id: set(frame["relevance_decision"])
-        for article_id, frame in audit.groupby("article_id")
-    }
-
     assert list(audit.columns) == list(RELEVANCE_GATE_COLUMNS)
-    assert by_article["aapl-specific"] == {"accepted"}
-    assert by_article["broad-market"] == {"rejected"}
-    assert by_article["competitor-only"] == {"rejected"}
-    assert by_article["irrelevant"] == {"rejected"}
-    assert "assignment_classification:broad_market" in _reason_codes(
-        audit.loc[audit["article_id"] == "broad-market"].iloc[0]
+
+    aapl = _rows_for_article(audit, "aapl-direct")
+    amd = _rows_for_article(audit, "amd-supply")
+    nvda = _rows_for_article(audit, "nvda-direct")
+    msft = _rows_for_article(audit, "msft-direct")
+    listicle = _rows_for_article(audit, "mag7-listicle")
+
+    aapl_targets = [row for row in aapl if row["ticker"] == "AAPL"]
+    amd_targets = [row for row in amd if row["ticker"] == "AMD"]
+    nvda_targets = [row for row in nvda if row["ticker"] == "NVDA"]
+    msft_targets = [row for row in msft if row["ticker"] == "MSFT"]
+
+    assert any(row["relevance_category"] == "direct_target_event" for row in aapl_targets)
+    assert any(
+        row["relevance_category"] in {"supplier_or_input_cost_exposure", "direct_target_event"}
+        for row in amd_targets
     )
-    assert "low_ticker_relevance" in _reason_codes(
-        audit.loc[audit["article_id"] == "broad-market"].iloc[0]
-    )
-    assert "competitor_entity_without_target:MSFT" in _reason_codes(
-        audit.loc[audit["article_id"] == "competitor-only"].iloc[0]
-    )
-    assert {record.article_id for record in result.finbert_records} == {"aapl-specific"}
+    assert any(row["relevance_category"] == "direct_target_event" for row in nvda_targets)
+    assert any(row["relevance_category"] == "direct_target_event" for row in msft_targets)
+
+    assert any(row["relevance_decision"] in {"accepted", "borderline"} for row in aapl_targets)
+    assert any(row["relevance_decision"] in {"accepted", "borderline"} for row in amd_targets)
+    assert any(row["relevance_decision"] in {"accepted", "borderline"} for row in nvda_targets)
+    assert any(row["relevance_decision"] in {"accepted", "borderline"} for row in msft_targets)
+
+    assert max(row["article_contamination_ratio"] for row in listicle) > 0.5
+    assert max(row["article_contribution_weight"] for row in listicle) < 1.0
+    assert any("article_contribution_capped" in _reason_codes(row) for row in listicle)
+    assert any(row["relevance_decision"] != "accepted" for row in listicle)
+
+    assert {record.article_id for record in result.finbert_records} >= {
+        "aapl-direct",
+        "amd-supply",
+        "nvda-direct",
+        "msft-direct",
+    }
     assert all(record.relevance_score is not None for record in result.finbert_records)
-    assert audit.loc[audit["article_id"] == "broad-market", "ticker_relevance_score"].iloc[0] == 0.0
+
+
+def test_news_relevance_gate_keeps_openai_story_from_becoming_chip_relevant() -> None:
+    """Microsoft/OpenAI product coverage should not promote AMD/NVDA without chip demand evidence."""
+    articles = [
+        {
+            "id": "msft-openai-no-chip",
+            "headline": "Microsoft expands OpenAI partnership across Azure enterprise software",
+            "summary": "The update focuses on cloud subscriptions and developer tools.",
+            "created_at": "2024-01-02T12:00:00+00:00",
+            "source": "benzinga",
+            "symbols": list(TARGET_TICKERS),
+        },
+        {
+            "id": "nvda-only",
+            "headline": "NVIDIA launches new GPU for AI datacenter customers",
+            "summary": "The chip launch highlights compute demand and device sales.",
+            "created_at": "2024-01-02T12:05:00+00:00",
+            "source": "benzinga",
+            "symbols": list(TARGET_TICKERS),
+        },
+    ]
+
+    records = preprocess_news_articles(
+        articles,
+        as_of_date="2024-01-02",
+        point_in_time_tickers=TARGET_TICKERS,
+    )
+
+    result = apply_news_relevance_gate(
+        records,
+        embeddings=_embedding_frame(article["id"] for article in articles),
+        topic_labels=_topic_label_frame(article["id"] for article in articles),
+    )
+
+    audit = result.audit_frame
+    msft_story = _rows_for_article(audit, "msft-openai-no-chip")
+    nvda_story = _rows_for_article(audit, "nvda-only")
+
+    assert any(row["ticker"] == "MSFT" and row["relevance_category"] != "irrelevant" for row in msft_story)
+    assert all(row["relevance_decision"] == "rejected" for row in msft_story if row["ticker"] in {"NVDA", "AMD"})
+    assert all(row["relevance_decision"] == "rejected" for row in nvda_story if row["ticker"] in {"AAPL", "AMD", "MSFT"})
+    assert any(row["ticker"] == "NVDA" and row["relevance_category"] == "direct_target_event" for row in nvda_story)
+    assert any(row["ticker"] == "NVDA" and row["relevance_decision"] in {"accepted", "borderline"} for row in nvda_story)
 
 
 def test_news_relevance_gate_does_not_fully_promote_unknown_rows() -> None:
@@ -81,13 +186,52 @@ def test_news_relevance_gate_does_not_fully_promote_unknown_rows() -> None:
     assert "low_financial_relevance" in _reason_codes(result.audit_frame.iloc[0])
 
 
+def test_news_relevance_gate_filters_aapl_contamination_pattern() -> None:
+    """Weak non-AAPL article tags do not flow into AAPL FinBERT scoring."""
+    articles = json.loads(
+        Path("tests/fixtures/news_relevance_gate_articles.json").read_text(encoding="utf-8")
+    )
+    records = preprocess_news_articles(
+        articles,
+        as_of_date="2024-01-02",
+        point_in_time_tickers=("AAPL",),
+    )
+
+    result = apply_news_relevance_gate(
+        records,
+        embeddings=_embedding_frame(article["id"] for article in articles),
+        topic_labels=_topic_label_frame(article["id"] for article in articles),
+    )
+
+    audit = result.audit_frame
+    aapl_rows = audit.loc[(audit["article_id"] == "aapl-specific") & (audit["ticker"] == "AAPL")]
+    assert list(audit.columns) == list(RELEVANCE_GATE_COLUMNS)
+    assert aapl_rows["relevance_decision"].isin({"accepted", "borderline"}).any()
+    assert "assignment_classification:broad_market" in _reason_codes(
+        audit.loc[audit["article_id"] == "broad-market"].iloc[0]
+    )
+    assert "assignment_classification:broad_market" in _reason_codes(
+        audit.loc[audit["article_id"] == "broad-market"].iloc[0]
+    )
+    assert "low_ticker_relevance" in _reason_codes(
+        audit.loc[audit["article_id"] == "broad-market"].iloc[0]
+    )
+    assert "causal_channel:comparison_context" in _reason_codes(
+        audit.loc[audit["article_id"] == "competitor-only"].iloc[0]
+    )
+    assert audit.loc[audit["article_id"] == "competitor-only", "relevance_decision"].iloc[0] == "rejected"
+    assert {record.article_id for record in result.finbert_records} >= {"aapl-specific"}
+    assert all(record.relevance_score is not None for record in result.finbert_records)
+    assert audit.loc[audit["article_id"] == "broad-market", "ticker_relevance_score"].iloc[0] == 0.0
+
+
 def _topic_label_frame(article_ids) -> pd.DataFrame:
     """Return topic-label rows for relevance-gate tests."""
     return pd.DataFrame(
         [
             {
                 "date": "2024-01-02",
-                "ticker": "AAPL",
+                "ticker": ticker,
                 "article_id": article_id,
                 "normalized_headline": article_id,
                 "text": article_id,
@@ -99,6 +243,7 @@ def _topic_label_frame(article_ids) -> pd.DataFrame:
                 "topic_probability": 0.70,
             }
             for article_id in article_ids
+            for ticker in TARGET_TICKERS
         ]
     )
 
@@ -123,6 +268,11 @@ def _embedding_frame(article_ids) -> pd.DataFrame:
     )
 
 
-def _reason_codes(row: pd.Series) -> set[str]:
+def _rows_for_article(frame: pd.DataFrame, article_id: str) -> list[dict[str, object]]:
+    """Return dict rows for one article id."""
+    return frame.loc[frame["article_id"] == article_id].to_dict(orient="records")
+
+
+def _reason_codes(row: pd.Series | dict[str, object]) -> set[str]:
     """Decode relevance reason codes from one audit row."""
     return set(json.loads(str(row["reason_codes"])))


### PR DESCRIPTION
Summary
- Added target-conditioned relevance audit columns to the relevance gate output.
- Implemented ticker-agnostic relevance categories: direct_target_event, supplier_or_input_cost_exposure, competitor_read_through, industry_or_macro_exposure, incidental_comparison, irrelevant.
- Added article-level contamination accounting so broad/listicle articles are down-weighted and flagged when contamination dominates.
- Preserved historical relevance_score weighting so downstream FinBERT sentiment weights do not inflate just because a row has a target-conditioned category.
- Updated regression coverage for AAPL, AMD, NVDA, and MSFT target-context behavior plus negative contamination cases.

Validation
- /home/juyoungoh/venv/bin/python -m pytest tests/unit/test_news_relevance.py -q => 4 passed
- /home/juyoungoh/venv/bin/python -m pytest tests/unit/test_finbert_sentiment_runner.py -q => 6 passed
- /home/juyoungoh/venv/bin/ruff check core/features/news_relevance.py tests/unit/test_news_relevance.py tests/unit/test_finbert_sentiment_runner.py => passed
- git diff --check => passed
- GitHub Actions lint => passed
- GitHub Actions unit-tests => passed

AAPL / AMD / NVDA / MSFT validation
- AAPL direct App Store/legal/product-device coverage is retained as direct_target_event and is no longer rejected only for low financial keyword density.
- AMD supply-chain / input-cost coverage maps to supplier_or_input_cost_exposure and stays eligible.
- NVDA GPU / datacenter / AI-chip coverage maps to direct_target_event and remains eligible.
- MSFT Azure / OpenAI / Copilot / enterprise software coverage maps to direct_target_event and remains eligible.
- Microsoft/OpenAI stories without chip/GPU demand do not promote AMD/NVDA.
- NVDA-only stories do not promote AAPL/MSFT/AMD unless there is direct target evidence.
- Mag-7/listicle-style articles are capped/down-weighted when contamination dominates.

Scope note
- Broad #202 PIT historical backfill was not started.
- #203 cleanup was not started.
- This is the first relevance-gate vertical slice for #281. It intentionally does not close the broader #281 human-review scope.

Follow-ups remaining under #281 / subsequent issues
- Full article -> deduplicated event -> claim -> target impact model.
- Full source diversification weighting.
- Dashboard PASS/WARN/NOT_RUN readiness semantics.
- HMM auditability improvements.

Refs #281
