### PR TITLE
fix: repair sentiment aggregation after relevance diagnostics

### DIFF
--- a/core/features/catalog.py
+++ b/core/features/catalog.py
@@ -302,6 +302,41 @@ def feature_catalog() -> dict[str, FeatureRule]:
         "nlp_semantic_warning_codes",
     ):
         rules[name] = FeatureRule(owner="sentiment", kind="string", required=False)
+    for name in (
+        "nlp_relevance_category",
+        "nlp_target_impact_direction",
+        "nlp_target_impact_magnitude",
+        "nlp_target_impact_horizon",
+        "nlp_causal_channel",
+        "nlp_document_sentiment",
+    ):
+        rules[name] = FeatureRule(owner="sentiment", kind="string", required=False)
+    rules["nlp_target_impact_confidence"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    rules["nlp_article_contamination_ratio"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+        minimum=0.0,
+        maximum=1.0,
+    )
+    for name in (
+        "nlp_article_contamination_count",
+        "nlp_article_signal_count",
+    ):
+        rules[name] = FeatureRule(owner="sentiment", kind="number", required=False, minimum=0.0)
+    rules["nlp_article_contribution_weight"] = FeatureRule(
+        owner="sentiment",
+        kind="number",
+        required=False,
+        minimum=0.0,
+        maximum=1.0,
+    )
 
     rules["regime_label"] = FeatureRule(
         owner="regime",

--- a/core/features/sentiment_features.py
+++ b/core/features/sentiment_features.py
@@ -709,6 +709,13 @@ def _attach_relevance_evidence(
     for column in RELEVANCE_EVIDENCE_OPTIONAL_COLUMNS:
         if column not in gate_frame.columns:
             gate_frame[column] = None
+    reason_codes_series = gate_frame.get("reason_codes")
+    if reason_codes_series is None:
+        gate_frame["reason_codes"] = "[]"
+    else:
+        gate_frame["reason_codes"] = reason_codes_series.map(
+            lambda value: json.dumps(_json_string_list(value), sort_keys=True, separators=(",", ":"))
+        )
 
     selected_columns = [
         "_artifact_date",
@@ -1301,11 +1308,12 @@ def _normalize_optional_string(value: Any) -> str | None:
 
 def _first_non_null(values: pd.Series) -> Any:
     """Return the first non-missing value from a series."""
+    pd = _require_pandas()
     for value in values.tolist():
         if value is None:
             continue
         try:
-            if value != value:
+            if pd.isna(value):
                 continue
         except (TypeError, ValueError):
             pass

--- a/core/features/sentiment_features.py
+++ b/core/features/sentiment_features.py
@@ -74,6 +74,21 @@ RELEVANCE_EVIDENCE_COLUMNS: frozenset[str] = frozenset(
     }
 )
 
+RELEVANCE_EVIDENCE_OPTIONAL_COLUMNS: tuple[str, ...] = (
+    "relevance_category",
+    "target_context_score",
+    "document_sentiment",
+    "target_company_impact_direction",
+    "target_company_impact_magnitude",
+    "impact_horizon",
+    "causal_channel",
+    "target_impact_confidence",
+    "article_contamination_ratio",
+    "article_contamination_count",
+    "article_signal_count",
+    "article_contribution_weight",
+)
+
 SENTIMENT_FEATURE_COLUMNS: tuple[str, ...] = (
     "nlp_sentiment_positive",
     "nlp_sentiment_negative",
@@ -102,6 +117,17 @@ SENTIMENT_FEATURE_COLUMNS: tuple[str, ...] = (
     "nlp_source_weight_summary",
     "nlp_relevance_reason_codes",
     "nlp_semantic_warning_codes",
+    "nlp_relevance_category",
+    "nlp_target_impact_direction",
+    "nlp_target_impact_magnitude",
+    "nlp_target_impact_horizon",
+    "nlp_target_impact_confidence",
+    "nlp_causal_channel",
+    "nlp_document_sentiment",
+    "nlp_article_contamination_ratio",
+    "nlp_article_contamination_count",
+    "nlp_article_signal_count",
+    "nlp_article_contribution_weight",
 )
 
 DIRECT_RELEVANCE_SCORE = 1.0
@@ -426,6 +452,29 @@ def sentiment_feature_records_from_scored_news(
                         sort_keys=True,
                         separators=(",", ":"),
                     ),
+                    "nlp_relevance_category": _first_non_null(group["_relevance_category"]),
+                    "nlp_target_impact_direction": _first_non_null(
+                        group["_target_company_impact_direction"]
+                    ),
+                    "nlp_target_impact_magnitude": _first_non_null(
+                        group["_target_company_impact_magnitude"]
+                    ),
+                    "nlp_target_impact_horizon": _first_non_null(group["_impact_horizon"]),
+                    "nlp_target_impact_confidence": _first_non_null(
+                        group["_target_impact_confidence"]
+                    ),
+                    "nlp_causal_channel": _first_non_null(group["_causal_channel"]),
+                    "nlp_document_sentiment": _first_non_null(group["_document_sentiment"]),
+                    "nlp_article_contamination_ratio": _first_non_null(
+                        group["_article_contamination_ratio"]
+                    ),
+                    "nlp_article_contamination_count": _first_non_null(
+                        group["_article_contamination_count"]
+                    ),
+                    "nlp_article_signal_count": _first_non_null(group["_article_signal_count"]),
+                    "nlp_article_contribution_weight": _first_non_null(
+                        group["_article_contribution_weight"]
+                    ),
                 },
             )
         )
@@ -615,6 +664,18 @@ def _attach_relevance_evidence(
         "_ticker_relevance_score",
         "_financial_relevance_score",
         "_topic_relevance_score",
+        "_relevance_category",
+        "_target_context_score",
+        "_document_sentiment",
+        "_target_company_impact_direction",
+        "_target_company_impact_magnitude",
+        "_impact_horizon",
+        "_causal_channel",
+        "_target_impact_confidence",
+        "_article_contamination_ratio",
+        "_article_contamination_count",
+        "_article_signal_count",
+        "_article_contribution_weight",
         "_relevance_reason_codes",
     ):
         frame[column] = None
@@ -644,21 +705,25 @@ def _attach_relevance_evidence(
     )
     if len(gate_frame) == 0:
         return frame
-    gate_frame = gate_frame.loc[
-        :,
-        [
-            "_artifact_date",
-            "_join_ticker",
-            "_join_article_id",
-            "_join_sentence_index",
-            "_join_chunk_index",
-            "relevance_decision",
-            "ticker_relevance_score",
-            "financial_relevance_score",
-            "topic_relevance_score",
-            "reason_codes",
-        ],
-    ].drop_duplicates(
+
+    for column in RELEVANCE_EVIDENCE_OPTIONAL_COLUMNS:
+        if column not in gate_frame.columns:
+            gate_frame[column] = None
+
+    selected_columns = [
+        "_artifact_date",
+        "_join_ticker",
+        "_join_article_id",
+        "_join_sentence_index",
+        "_join_chunk_index",
+        "relevance_decision",
+        "ticker_relevance_score",
+        "financial_relevance_score",
+        "topic_relevance_score",
+        "reason_codes",
+        *RELEVANCE_EVIDENCE_OPTIONAL_COLUMNS,
+    ]
+    gate_frame = gate_frame.loc[:, selected_columns].drop_duplicates(
         subset=[
             "_artifact_date",
             "_join_ticker",
@@ -674,6 +739,18 @@ def _attach_relevance_evidence(
             "ticker_relevance_score": "_ticker_relevance_score",
             "financial_relevance_score": "_financial_relevance_score",
             "topic_relevance_score": "_topic_relevance_score",
+            "relevance_category": "_relevance_category",
+            "target_context_score": "_target_context_score",
+            "document_sentiment": "_document_sentiment",
+            "target_company_impact_direction": "_target_company_impact_direction",
+            "target_company_impact_magnitude": "_target_company_impact_magnitude",
+            "impact_horizon": "_impact_horizon",
+            "causal_channel": "_causal_channel",
+            "target_impact_confidence": "_target_impact_confidence",
+            "article_contamination_ratio": "_article_contamination_ratio",
+            "article_contamination_count": "_article_contamination_count",
+            "article_signal_count": "_article_signal_count",
+            "article_contribution_weight": "_article_contribution_weight",
             "reason_codes": "_relevance_reason_codes",
         }
     )
@@ -695,6 +772,18 @@ def _attach_relevance_evidence(
             "_ticker_relevance_score",
             "_financial_relevance_score",
             "_topic_relevance_score",
+            "_relevance_category",
+            "_target_context_score",
+            "_document_sentiment",
+            "_target_company_impact_direction",
+            "_target_company_impact_magnitude",
+            "_impact_horizon",
+            "_causal_channel",
+            "_target_impact_confidence",
+            "_article_contamination_ratio",
+            "_article_contamination_count",
+            "_article_signal_count",
+            "_article_contribution_weight",
             "_relevance_reason_codes",
         ],
         errors="ignore",
@@ -1208,6 +1297,20 @@ def _normalize_optional_string(value: Any) -> str | None:
         pass
     text = str(value).strip()
     return text or None
+
+
+def _first_non_null(values: pd.Series) -> Any:
+    """Return the first non-missing value from a series."""
+    for value in values.tolist():
+        if value is None:
+            continue
+        try:
+            if value != value:
+                continue
+        except (TypeError, ValueError):
+            pass
+        return value
+    return None
 
 
 def _empty_frame(pd: Any) -> pd.DataFrame:

--- a/tests/unit/test_feature_catalog.py
+++ b/tests/unit/test_feature_catalog.py
@@ -60,6 +60,18 @@ def test_feature_catalog_registers_sentiment_semantic_features() -> None:
         assert catalog[feature_name].owner in {"sentiment", "nlp"}
         assert catalog[feature_name].required is False
 
+    assert catalog["nlp_relevance_category"].kind == "string"
+    assert catalog["nlp_target_impact_direction"].kind == "string"
+    assert catalog["nlp_target_impact_magnitude"].kind == "string"
+    assert catalog["nlp_target_impact_horizon"].kind == "string"
+    assert catalog["nlp_target_impact_confidence"].kind == "number"
+    assert catalog["nlp_causal_channel"].kind == "string"
+    assert catalog["nlp_document_sentiment"].kind == "string"
+    assert catalog["nlp_article_contamination_ratio"].kind == "number"
+    assert catalog["nlp_article_contamination_count"].kind == "number"
+    assert catalog["nlp_article_signal_count"].kind == "number"
+    assert catalog["nlp_article_contribution_weight"].kind == "number"
+
     assert (
         validate_feature_value(
             "nlp_sentiment_topic_score",

--- a/tests/unit/test_sentiment_features.py
+++ b/tests/unit/test_sentiment_features.py
@@ -27,6 +27,8 @@ def _row(
     date: str = "2024-04-10",
     ticker: str = "AAPL",
     article_id: str = "article-1",
+    sentence_index: int = 0,
+    chunk_index: int = 0,
     source: str | None = "Reuters",
     published_at: str | None = None,
     sentiment_positive: float = 0.8,
@@ -40,6 +42,8 @@ def _row(
         "date": date,
         "ticker": ticker,
         "article_id": article_id,
+        "sentence_index": sentence_index,
+        "chunk_index": chunk_index,
         "source": source,
         "published_at": published_at or f"{date}T14:30:00Z",
         "sentiment_positive": sentiment_positive,
@@ -48,6 +52,38 @@ def _row(
         "sentiment_score": sentiment_score,
         "relevance_score": relevance_score,
     }
+
+
+def _relevance_gate_row(
+    *,
+    date: str = "2024-04-10",
+    ticker: str = "AAPL",
+    article_id: str = "article-1",
+    sentence_index: int = 0,
+    chunk_index: int = 0,
+    relevance_decision: str = "accepted",
+    relevance_score: float = 1.0,
+    ticker_relevance_score: float = 1.0,
+    financial_relevance_score: float = 1.0,
+    topic_relevance_score: float = 1.0,
+    **extra: object,
+) -> dict[str, object]:
+    """Build one relevance-gate audit row."""
+    row = {
+        "date": date,
+        "ticker": ticker,
+        "article_id": article_id,
+        "sentence_index": sentence_index,
+        "chunk_index": chunk_index,
+        "relevance_decision": relevance_decision,
+        "relevance_score": relevance_score,
+        "ticker_relevance_score": ticker_relevance_score,
+        "financial_relevance_score": financial_relevance_score,
+        "topic_relevance_score": topic_relevance_score,
+        "reason_codes": json.dumps(["legacy_relevance_evidence"], sort_keys=True),
+    }
+    row.update(extra)
+    return row
 
 
 class _FakeScorer:
@@ -180,6 +216,108 @@ def test_score_news_sentiment_requires_explicit_relevance_evidence() -> None:
     assert relevance_by_article["context-aapl"] == pytest.approx(0.25)
     assert relevance_by_article["context-msft"] == pytest.approx(0.25)
     assert relevance_by_article["noise-nvda"] is None
+
+
+def test_sentiment_feature_records_accept_legacy_relevance_gate_without_optional_target_fields() -> None:
+    """Legacy relevance-gate rows should still attach and leave optional target fields empty."""
+    scored_news = pd.DataFrame([
+        _row(article_id="legacy-aapl", sentence_index=0, relevance_score=0.75),
+    ])
+    relevance_gate = pd.DataFrame(
+        [
+            _relevance_gate_row(
+                article_id="legacy-aapl",
+                relevance_decision="accepted",
+                relevance_score=0.75,
+                ticker_relevance_score=1.0,
+                financial_relevance_score=0.8,
+                topic_relevance_score=0.6,
+                reason_codes=json.dumps(["legacy_relevance_evidence"], sort_keys=True),
+            )
+        ]
+    )
+
+    records = sentiment_feature_records_from_scored_news(
+        scored_news,
+        relevance_gate=relevance_gate,
+        credibility_config=SourceCredibilityConfig(
+            default_source_weight=1.0,
+            source_weights={},
+        ),
+    )
+
+    assert len(records) == 1
+    features = records[0].features
+    assert features["nlp_relevance_category"] is None
+    assert features["nlp_target_impact_direction"] is None
+    assert features["nlp_target_impact_magnitude"] is None
+    assert features["nlp_target_impact_horizon"] is None
+    assert features["nlp_target_impact_confidence"] is None
+    assert features["nlp_causal_channel"] is None
+    assert features["nlp_document_sentiment"] is None
+    assert features["nlp_article_contamination_ratio"] is None
+    assert features["nlp_article_contamination_count"] is None
+    assert features["nlp_article_signal_count"] is None
+    assert features["nlp_article_contribution_weight"] is None
+
+
+def test_sentiment_feature_records_propagate_optional_target_impact_fields() -> None:
+    """Optional relevance-gate target-impact fields should flow into sentiment features."""
+    scored_news = pd.DataFrame([
+        _row(article_id="target-aapl", sentence_index=0, relevance_score=0.9),
+    ])
+    relevance_gate = pd.DataFrame(
+        [
+            _relevance_gate_row(
+                article_id="target-aapl",
+                relevance_decision="accepted",
+                relevance_score=0.9,
+                ticker_relevance_score=1.0,
+                financial_relevance_score=0.85,
+                topic_relevance_score=0.7,
+                relevance_category="direct_target_event",
+                target_context_score=0.88,
+                document_sentiment="bullish",
+                target_company_impact_direction="positive",
+                target_company_impact_magnitude="high",
+                impact_horizon="short_term",
+                causal_channel="product_device",
+                target_impact_confidence=0.93,
+                article_contamination_ratio=0.12,
+                article_contamination_count=1,
+                article_signal_count=3,
+                article_contribution_weight=0.6,
+                reason_codes=json.dumps(
+                    ["legacy_relevance_evidence", "article_contribution_capped"],
+                    sort_keys=True,
+                ),
+            )
+        ]
+    )
+
+    records = sentiment_feature_records_from_scored_news(
+        scored_news,
+        relevance_gate=relevance_gate,
+        credibility_config=SourceCredibilityConfig(
+            default_source_weight=1.0,
+            source_weights={},
+        ),
+    )
+
+    assert len(records) == 1
+    features = records[0].features
+    assert features["nlp_relevance_category"] == "direct_target_event"
+    assert features["nlp_target_impact_direction"] == "positive"
+    assert features["nlp_target_impact_magnitude"] == "high"
+    assert features["nlp_target_impact_horizon"] == "short_term"
+    assert features["nlp_target_impact_confidence"] == 0.93
+    assert features["nlp_causal_channel"] == "product_device"
+    assert features["nlp_document_sentiment"] == "bullish"
+    assert features["nlp_article_contamination_ratio"] == 0.12
+    assert features["nlp_article_contamination_count"] == 1
+    assert features["nlp_article_signal_count"] == 3
+    assert features["nlp_article_contribution_weight"] == 0.6
+    assert "article_contribution_capped" in json.loads(str(features["nlp_relevance_reason_codes"]))
 
 
 def test_score_news_sentiment_skips_rows_without_text_or_headline() -> None:

--- a/tests/unit/test_sentiment_features.py
+++ b/tests/unit/test_sentiment_features.py
@@ -218,22 +218,72 @@ def test_score_news_sentiment_requires_explicit_relevance_evidence() -> None:
     assert relevance_by_article["noise-nvda"] is None
 
 
-def test_sentiment_feature_records_accept_legacy_relevance_gate_without_optional_target_fields() -> None:
-    """Legacy relevance-gate rows should still attach and leave optional target fields empty."""
+def test_sentiment_feature_records_accept_legacy_relevance_gate_without_reason_codes() -> None:
+    """Legacy relevance-gate rows without reason codes should still attach cleanly."""
     scored_news = pd.DataFrame([
         _row(article_id="legacy-aapl", sentence_index=0, relevance_score=0.75),
     ])
     relevance_gate = pd.DataFrame(
         [
-            _relevance_gate_row(
-                article_id="legacy-aapl",
-                relevance_decision="accepted",
-                relevance_score=0.75,
-                ticker_relevance_score=1.0,
-                financial_relevance_score=0.8,
-                topic_relevance_score=0.6,
-                reason_codes=json.dumps(["legacy_relevance_evidence"], sort_keys=True),
-            )
+            {
+                "date": "2024-04-10",
+                "ticker": "AAPL",
+                "article_id": "legacy-aapl",
+                "sentence_index": 0,
+                "chunk_index": 0,
+                "relevance_decision": "accepted",
+                "relevance_score": 0.75,
+                "ticker_relevance_score": 1.0,
+                "financial_relevance_score": 0.8,
+                "topic_relevance_score": 0.6,
+            }
+        ]
+    )
+
+    records = sentiment_feature_records_from_scored_news(
+        scored_news,
+        relevance_gate=relevance_gate,
+        credibility_config=SourceCredibilityConfig(
+            default_source_weight=1.0,
+            source_weights={},
+        ),
+    )
+
+    assert len(records) == 1
+    assert records[0].features["nlp_relevance_reason_codes"] == "[]"
+
+
+def test_sentiment_feature_records_normalize_missing_target_impact_fields_to_none() -> None:
+    """Missing semantic target-impact values should stay None instead of pd.NA."""
+    scored_news = pd.DataFrame([
+        _row(article_id="target-aapl", sentence_index=0, relevance_score=0.9),
+    ])
+    relevance_gate = pd.DataFrame(
+        [
+            {
+                "date": "2024-04-10",
+                "ticker": "AAPL",
+                "article_id": "target-aapl",
+                "sentence_index": 0,
+                "chunk_index": 0,
+                "relevance_decision": "accepted",
+                "relevance_score": 0.9,
+                "ticker_relevance_score": 1.0,
+                "financial_relevance_score": 0.85,
+                "topic_relevance_score": 0.7,
+                "relevance_category": pd.NA,
+                "target_company_impact_direction": pd.NA,
+                "target_company_impact_magnitude": pd.NA,
+                "impact_horizon": pd.NA,
+                "target_impact_confidence": pd.NA,
+                "causal_channel": pd.NA,
+                "document_sentiment": pd.NA,
+                "article_contamination_ratio": pd.NA,
+                "article_contamination_count": pd.NA,
+                "article_signal_count": pd.NA,
+                "article_contribution_weight": pd.NA,
+                "reason_codes": json.dumps([], sort_keys=True),
+            }
         ]
     )
 


### PR DESCRIPTION
## Summary
- repairs sentiment aggregation compatibility after the #281 relevance/readiness diagnostics slices
- keeps relevance-gate attachment backward compatible when optional target-impact / contamination columns are absent
- propagates optional target-impact and article-contamination fields into final sentiment feature records when present
- adds regression coverage for legacy relevance-gate rows and optional target-impact propagation

Refs #281

## Verification
- `/home/juyoungoh/venv/bin/python -m pytest tests/unit/test_sentiment_features.py -q` -> 22 passed
- `/home/juyoungoh/venv/bin/python -m pytest tests/unit/test_news_relevance.py tests/unit/test_semantic_review_dashboard.py -q` -> 32 passed
- `/home/juyoungoh/venv/bin/ruff check core/features/sentiment_features.py tests/unit/test_sentiment_features.py core/features/news_relevance.py core/features/semantic_review_dashboard.py tests/unit/test_news_relevance.py tests/unit/test_semantic_review_dashboard.py` -> All checks passed
- `git diff --check origin/main...HEAD` -> clean

## Scope notes
- Broad #202 PIT historical backfill was not started.
- #203 cleanup was not started.
