### PR TITLE
fix: expose target impact review evidence

### DIFF
--- a/core/features/aapl_evidence.py
+++ b/core/features/aapl_evidence.py
@@ -728,6 +728,7 @@ def _build_article_groups(
                 ]
             )
         )
+        article_relevance_rows = relevance_by_article.get((str(date_text), str(article_id)), [])
         article_groups.append(
             SemanticReviewArticleGroup(
                 article_id=str(article_id),
@@ -754,7 +755,7 @@ def _build_article_groups(
                 evidence_snippets=evidence_snippets,
                 preprocessing_rows=preprocessing_by_article.get((str(date_text), str(article_id)), []),
                 topic_evidence=topic_by_article.get((str(date_text), str(article_id)), []),
-                relevance_gate_rows=relevance_by_article.get((str(date_text), str(article_id)), []),
+                relevance_gate_rows=_compact_article_relevance_rows(article_relevance_rows),
                 sentence_rows=sentence_rows,
             )
         )
@@ -1747,6 +1748,26 @@ def _relevance_gate_rows(
                 "ticker_relevance_score": _maybe_float(row.get("ticker_relevance_score")),
                 "financial_relevance_score": _maybe_float(row.get("financial_relevance_score")),
                 "topic_relevance_score": _maybe_float(row.get("topic_relevance_score")),
+                "target_context_score": _maybe_float(row.get("target_context_score")),
+                "direct_target_relevance": _maybe_float(row.get("target_context_score")),
+                "relevance_category": _optional_str(row.get("relevance_category")),
+                "relationship_to_target": _optional_str(row.get("relevance_category")),
+                "target_relationship": _optional_str(row.get("relevance_category")),
+                "document_sentiment": _optional_str(row.get("document_sentiment")),
+                "target_company_impact_direction": _optional_str(row.get("target_company_impact_direction")),
+                "target_company_impact_magnitude": _optional_str(row.get("target_company_impact_magnitude")),
+                "impact_horizon": _optional_str(row.get("impact_horizon")),
+                "causal_channel": _optional_str(row.get("causal_channel")),
+                "target_impact_confidence": _maybe_float(row.get("target_impact_confidence")),
+                "article_contamination_ratio": _maybe_float(row.get("article_contamination_ratio")),
+                "article_contamination_count": _maybe_int(row.get("article_contamination_count")),
+                "article_signal_count": _maybe_int(row.get("article_signal_count")),
+                "article_contribution_weight": _maybe_float(row.get("article_contribution_weight")),
+                "included_in_signal": _target_row_included_in_signal(row),
+                "final_contribution": _target_row_final_contribution(row),
+                "final_signal_contribution": _target_row_final_contribution(row),
+                "target_impact_evidence_status": _target_row_evidence_status(row),
+                "target_impact_missing_flags": _target_row_missing_flags(row),
                 "reason_codes": _json_string_list(row.get("reason_codes")),
                 "ticker_evidence": _json_mapping(row.get("ticker_evidence")),
                 "entity_evidence": _json_string_list(row.get("entity_evidence")),
@@ -1803,6 +1824,150 @@ def _semantic_aggregate_rows(
             }
         )
     return _sort_evidence_rows(rows)
+
+
+def _compact_article_relevance_rows(rows: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    """Return a compact per-article relevance copy; canonical full rows stay in pipeline_sections."""
+    compact_rows: list[dict[str, object]] = []
+    for row in rows:
+        compact_rows.append(
+            {
+                "date": _optional_str(row.get("date")),
+                "ticker": _optional_str(row.get("ticker")),
+                "article_id": _optional_str(row.get("article_id")),
+                "sentence_index": _maybe_int(row.get("sentence_index")),
+                "relevance_decision": _optional_str(row.get("relevance_decision")),
+                "relevance_score": _maybe_float(row.get("relevance_score")),
+                "target_context_score": _maybe_float(row.get("target_context_score")),
+                "relevance_category": _optional_str(row.get("relevance_category")),
+                "target_company_impact_direction": _optional_str(row.get("target_company_impact_direction")),
+                "article_contribution_weight": _maybe_float(row.get("article_contribution_weight")),
+                "included_in_signal": _target_row_included_in_signal(row),
+                "final_contribution": _target_row_final_contribution(row),
+                "reason_codes": _json_string_list(row.get("reason_codes")),
+            }
+        )
+    return compact_rows
+
+
+_TARGET_SIGNAL_CATEGORIES = frozenset(
+    {
+        "direct_target_event",
+        "supplier_or_input_cost_exposure",
+        "competitor_read_through",
+        "industry_or_macro_exposure",
+    }
+)
+
+
+def _target_impact_summary(rows: Sequence[Mapping[str, object]]) -> dict[str, object]:
+    """Return article-level target-impact inclusion evidence for review payloads."""
+    category = _first_row_text(rows, "relevance_category")
+    target_context_score = _first_row_float(rows, "target_context_score")
+    contribution_weight = _first_row_float(rows, "article_contribution_weight")
+    included = any(_target_row_included_in_signal(row) for row in rows)
+    final_contribution = contribution_weight if included else (0.0 if rows else None)
+    missing_flags = sorted({flag for row in rows for flag in _target_row_missing_flags(row)})
+    status = "missing" if not rows else ("included" if included else "excluded")
+    return {
+        "relationship_to_target": category,
+        "target_relationship": category,
+        "target_context_score": target_context_score,
+        "direct_target_relevance": target_context_score,
+        "document_sentiment": _first_row_text(rows, "document_sentiment"),
+        "target_company_impact_direction": _first_row_text(rows, "target_company_impact_direction"),
+        "target_company_impact_magnitude": _first_row_text(rows, "target_company_impact_magnitude"),
+        "impact_horizon": _first_row_text(rows, "impact_horizon"),
+        "causal_channel": _first_row_text(rows, "causal_channel"),
+        "target_impact_confidence": _first_row_float(rows, "target_impact_confidence"),
+        "article_contamination_ratio": _first_row_float(rows, "article_contamination_ratio"),
+        "article_contamination_count": _first_row_int(rows, "article_contamination_count"),
+        "article_signal_count": _first_row_int(rows, "article_signal_count"),
+        "article_contribution_weight": contribution_weight,
+        "included_in_signal": included,
+        "final_contribution": final_contribution,
+        "final_signal_contribution": final_contribution,
+        "target_impact_evidence_status": status,
+        "target_impact_missing_flags": missing_flags,
+    }
+
+
+def _target_row_included_in_signal(row: Mapping[str, object]) -> bool:
+    """Return True only for target-impact rows that can contribute to ticker signal."""
+    category = _optional_str(row.get("relevance_category"))
+    decision = (_optional_str(row.get("relevance_decision")) or "").lower()
+    signal_count = _maybe_int(row.get("article_signal_count"))
+    contribution_weight = _maybe_float(row.get("article_contribution_weight"))
+    return bool(
+        category in _TARGET_SIGNAL_CATEGORIES
+        and decision in {"accepted", "borderline"}
+        and (signal_count is None or signal_count > 0)
+        and (contribution_weight is None or contribution_weight > 0.0)
+    )
+
+
+def _target_row_final_contribution(row: Mapping[str, object]) -> float | None:
+    """Return deterministic final article contribution for review displays."""
+    if row is None:
+        return None
+    if not _target_row_included_in_signal(row):
+        return 0.0
+    weight = _maybe_float(row.get("article_contribution_weight"))
+    return 1.0 if weight is None else weight
+
+
+def _target_row_evidence_status(row: Mapping[str, object]) -> str:
+    """Return included/excluded/missing target-impact evidence status."""
+    if row is None:
+        return "missing"
+    if _target_row_missing_flags(row):
+        return "missing" if not _target_row_included_in_signal(row) else "included_with_missing_fields"
+    return "included" if _target_row_included_in_signal(row) else "excluded"
+
+
+def _target_row_missing_flags(row: Mapping[str, object]) -> list[str]:
+    """Return missing target-impact fields that block final semantic acceptance."""
+    flags: list[str] = []
+    for field_name in (
+        "relevance_category",
+        "target_context_score",
+        "target_company_impact_direction",
+        "target_company_impact_magnitude",
+        "impact_horizon",
+        "causal_channel",
+        "target_impact_confidence",
+        "article_contribution_weight",
+    ):
+        if _optional_str(row.get(field_name)) is None:
+            flags.append(f"missing_{field_name}")
+    return flags
+
+
+def _first_row_text(rows: Sequence[Mapping[str, object]], field_name: str) -> str | None:
+    """Return first non-empty text value for an article-level field."""
+    for row in rows:
+        value = _optional_str(row.get(field_name))
+        if value is not None:
+            return value
+    return None
+
+
+def _first_row_float(rows: Sequence[Mapping[str, object]], field_name: str) -> float | None:
+    """Return first finite float value for an article-level field."""
+    for row in rows:
+        value = _maybe_float(row.get(field_name))
+        if value is not None:
+            return value
+    return None
+
+
+def _first_row_int(rows: Sequence[Mapping[str, object]], field_name: str) -> int | None:
+    """Return first integer value for an article-level field."""
+    for row in rows:
+        value = _maybe_int(row.get(field_name))
+        if value is not None:
+            return value
+    return None
 
 
 def _rows_by_article(

--- a/core/features/news_relevance.py
+++ b/core/features/news_relevance.py
@@ -30,7 +30,9 @@ RELEVANCE_GATE_COLUMNS: tuple[str, ...] = (
     "ticker_relevance_score",
     "financial_relevance_score",
     "topic_relevance_score",
+    "target_context_score",
     "relevance_category",
+    "document_sentiment",
     "target_company_impact_direction",
     "target_company_impact_magnitude",
     "impact_horizon",
@@ -176,7 +178,11 @@ _INDUSTRY_MACRO_TERMS: tuple[str, ...] = (
 _INCIDENTAL_COMPARISON_TERMS: tuple[str, ...] = (
     "best stocks",
     "compare",
+    "compares",
+    "compared with",
+    "compared to",
     "comparison",
+    "price comparison",
     "mag 7",
     "listicle",
     "roundup",
@@ -375,6 +381,8 @@ def _build_record_analysis(
         "financial_relevance_score": financial_score,
         "topic_relevance_score": topic_score,
         "relevance_category": relevance_category,
+        "target_context_score": _target_context_score(relevance_category),
+        "document_sentiment": _document_sentiment_label(impact_direction),
         "target_company_impact_direction": impact_direction,
         "target_company_impact_magnitude": impact_magnitude,
         "impact_horizon": impact_horizon,
@@ -456,16 +464,10 @@ def _finalize_record_analysis(
             decision = "rejected"
             reasons.add("rejected_by_relevance_gate")
     elif category == "incidental_comparison":
-        if (
-            relevance_score >= config.borderline_threshold
-            and ticker_score >= 0.75
-            and not article_contamination_dominates
-        ):
-            decision = "borderline"
-            reasons.add("borderline_ticker_or_topic_evidence")
-        else:
-            decision = "rejected"
-            reasons.add("rejected_by_relevance_gate")
+        relevance_score = min(relevance_score, float(analysis.get("target_context_score") or 0.15))
+        decision = "rejected"
+        reasons.add("incidental_comparison_excluded_from_signal")
+        reasons.add("rejected_by_relevance_gate")
     else:
         decision = "rejected"
         reasons.add("rejected_by_relevance_gate")
@@ -493,7 +495,9 @@ def _finalize_record_analysis(
         "ticker_relevance_score": analysis["ticker_relevance_score"],
         "financial_relevance_score": analysis["financial_relevance_score"],
         "topic_relevance_score": analysis["topic_relevance_score"],
+        "target_context_score": analysis["target_context_score"],
         "relevance_category": category,
+        "document_sentiment": analysis["document_sentiment"],
         "target_company_impact_direction": analysis["target_company_impact_direction"],
         "target_company_impact_magnitude": analysis["target_company_impact_magnitude"],
         "impact_horizon": analysis["impact_horizon"],
@@ -582,6 +586,20 @@ def _target_conditioned_metadata(
         _contains_phrase(lower_text, term) for term in _INCIDENTAL_COMPARISON_TERMS
     )
     business_channel, business_terms = _target_business_channel(lower_text)
+
+    if has_comparison_context:
+        category = "incidental_comparison"
+        reasons.append("target_conditioned_category:incidental_comparison")
+        reasons.append("causal_channel:comparison_context")
+        return (
+            category,
+            "none",
+            "low",
+            "same_day",
+            "comparison_context",
+            0.15,
+            reasons,
+        )
 
     if direct_evidence and (has_direct_business_context or business_channel in {
         "legal_regulatory",
@@ -679,31 +697,17 @@ def _target_conditioned_metadata(
             reasons,
         )
 
-    if assignment_classification == "contamination" and (has_comparison_context or competitor_reasons):
+    if assignment_classification == "contamination" and competitor_reasons:
         category = "incidental_comparison"
         reasons.append("target_conditioned_category:incidental_comparison")
         reasons.append("causal_channel:comparison_context")
         return (
             category,
-            "unclear",
+            "none",
             "low",
-            "short_term",
+            "same_day",
             "comparison_context",
-            0.30,
-            reasons,
-        )
-
-    if has_comparison_context:
-        category = "incidental_comparison"
-        reasons.append("target_conditioned_category:incidental_comparison")
-        reasons.append("causal_channel:comparison_context")
-        return (
-            category,
-            "unclear",
-            "low",
-            "short_term",
-            "comparison_context",
-            0.30,
+            0.15,
             reasons,
         )
 
@@ -725,6 +729,27 @@ def _target_conditioned_metadata(
     reasons.append("target_conditioned_category:irrelevant")
     reasons.append("causal_channel:none")
     return ("irrelevant", "unclear", "low", "unknown", "none", 0.10, reasons)
+
+
+def _target_context_score(relevance_category: str) -> float:
+    """Return direct target-context evidence strength for audit display."""
+    return {
+        "direct_target_event": 0.96,
+        "supplier_or_input_cost_exposure": 0.80,
+        "competitor_read_through": 0.65,
+        "industry_or_macro_exposure": 0.45,
+        "incidental_comparison": 0.08,
+        "irrelevant": 0.0,
+    }.get(relevance_category, 0.0)
+
+
+def _document_sentiment_label(impact_direction: str) -> str:
+    """Map deterministic lexical impact direction to document sentiment label."""
+    if impact_direction in {"positive", "negative"}:
+        return impact_direction
+    if impact_direction == "none":
+        return "neutral"
+    return "unclear"
 
 
 def _target_business_channel(normalized_text: str) -> tuple[str, tuple[str, ...]]:

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -1,7 +1,7 @@
 """UI payload helpers for the Layer 1 semantic-review dashboard."""
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -381,6 +381,11 @@ def build_layer1_topic_relevance_review(
                 if "default_relevance_without_supporting_evidence"
                 in _json_string_list(row.get("missing_evidence_flags"))
             ),
+            "target_impact_included_count": sum(1 for row in rows if row.get("included_in_signal") is True),
+            "target_impact_excluded_count": sum(1 for row in rows if row.get("included_in_signal") is False),
+            "target_impact_missing_count": sum(
+                1 for row in rows if _json_string_list(row.get("target_impact_missing_flags"))
+            ),
             **reviewability,
         },
         "date_groups": date_groups,
@@ -741,6 +746,7 @@ def _topic_relevance_article_row(
     )
     topic_score = _first_float([row.get("topic_relevance_score") for row in relevance_rows])
     assignment_fields = _first_assignment_provenance_fields(preprocessing_rows)
+    target_impact = _target_impact_review_summary(article, relevance_rows)
     has_embedding = bool(embedding_rows)
     has_topic = bool(topic_rows)
     has_relevance_gate = bool(relevance_rows)
@@ -784,6 +790,7 @@ def _topic_relevance_article_row(
         "ticker_relevance_score": ticker_score,
         "financial_relevance_score": financial_score,
         "topic_relevance_score": topic_score,
+        **target_impact,
         "reason_codes": reason_codes,
         "assignment_classification": assignment_fields["assignment_classification"],
         "assignment_reason": assignment_fields["assignment_reason"],
@@ -830,9 +837,147 @@ def _topic_relevance_article_row(
             }
             for row in topic_rows
         ],
-        "relevance_gate_rows": [dict(row) for row in relevance_rows],
+        "relevance_gate_rows": _compact_topic_relevance_gate_rows(relevance_rows),
         "preprocessing_rows": [dict(row) for row in preprocessing_rows],
     }
+
+
+def _compact_topic_relevance_gate_rows(rows: Sequence[Mapping[str, object]]) -> list[dict[str, object]]:
+    """Return compact row evidence for the article tab; full rows remain in pipeline_sections."""
+    compact_rows: list[dict[str, object]] = []
+    for row in rows:
+        compact_rows.append(
+            {
+                "date": row.get("date"),
+                "ticker": row.get("ticker"),
+                "article_id": row.get("article_id"),
+                "sentence_index": row.get("sentence_index"),
+                "relevance_decision": row.get("relevance_decision"),
+                "relevance_score": row.get("relevance_score"),
+                "target_context_score": row.get("target_context_score"),
+                "relevance_category": row.get("relevance_category"),
+                "target_company_impact_direction": row.get("target_company_impact_direction"),
+                "article_contribution_weight": row.get("article_contribution_weight"),
+                "included_in_signal": _target_row_included_in_signal(row),
+                "final_contribution": row.get("final_contribution"),
+                "reason_codes": _json_string_list(row.get("reason_codes")),
+            }
+        )
+    return compact_rows
+
+
+_TARGET_SIGNAL_CATEGORIES = frozenset(
+    {
+        "direct_target_event",
+        "supplier_or_input_cost_exposure",
+        "competitor_read_through",
+        "industry_or_macro_exposure",
+    }
+)
+
+
+def _target_impact_review_summary(
+    article: Mapping[str, object],
+    relevance_rows: Sequence[Mapping[str, object]],
+) -> dict[str, object]:
+    """Return article-level target-impact and final contribution review fields."""
+    category = _first_text([row.get("relevance_category") for row in relevance_rows] + [article.get("relationship_to_target")])
+    target_context_score = _first_float([row.get("target_context_score") for row in relevance_rows] + [article.get("target_context_score")])
+    contribution_weight = _first_float([row.get("article_contribution_weight") for row in relevance_rows] + [article.get("article_contribution_weight")])
+    included = any(_target_row_included_in_signal(row) for row in relevance_rows)
+    final_contribution = contribution_weight if included else (0.0 if relevance_rows else None)
+    missing_flags = sorted({flag for row in relevance_rows for flag in _target_row_missing_flags(row)})
+    status = "missing" if not relevance_rows else ("included" if included else "excluded")
+    return {
+        "relationship_to_target": category,
+        "target_relationship": category,
+        "relevance_category": category,
+        "target_context_score": target_context_score,
+        "direct_target_relevance": target_context_score,
+        "document_sentiment": _first_text(row.get("document_sentiment") for row in relevance_rows),
+        "target_company_impact_direction": _first_text(row.get("target_company_impact_direction") for row in relevance_rows),
+        "target_company_impact_magnitude": _first_text(row.get("target_company_impact_magnitude") for row in relevance_rows),
+        "impact_horizon": _first_text(row.get("impact_horizon") for row in relevance_rows),
+        "causal_channel": _first_text(row.get("causal_channel") for row in relevance_rows),
+        "target_impact_confidence": _first_float(row.get("target_impact_confidence") for row in relevance_rows),
+        "article_contamination_ratio": _first_float(row.get("article_contamination_ratio") for row in relevance_rows),
+        "article_contamination_count": _first_int(row.get("article_contamination_count") for row in relevance_rows),
+        "article_signal_count": _first_int(row.get("article_signal_count") for row in relevance_rows),
+        "article_contribution_weight": contribution_weight,
+        "included_in_signal": included,
+        "final_contribution": final_contribution,
+        "final_signal_contribution": final_contribution,
+        "target_impact_evidence_status": status,
+        "target_impact_missing_flags": missing_flags,
+    }
+
+
+def _target_row_included_in_signal(row: Mapping[str, object]) -> bool:
+    """Return True only when a relevance-gate row contributes target-conditioned signal."""
+    category = _optional_str(row.get("relevance_category"))
+    decision = (_optional_str(row.get("relevance_decision")) or "").lower()
+    signal_count = _coerce_int(row.get("article_signal_count"))
+    contribution_weight = _maybe_float(row.get("article_contribution_weight"))
+    return bool(
+        category in _TARGET_SIGNAL_CATEGORIES
+        and decision in {"accepted", "borderline"}
+        and (signal_count is None or signal_count > 0)
+        and (contribution_weight is None or contribution_weight > 0.0)
+    )
+
+
+def _target_row_missing_flags(row: Mapping[str, object]) -> list[str]:
+    """Return missing target-impact fields for dashboard blockers."""
+    flags: list[str] = []
+    for field_name in (
+        "relevance_category",
+        "target_context_score",
+        "target_company_impact_direction",
+        "target_company_impact_magnitude",
+        "impact_horizon",
+        "causal_channel",
+        "target_impact_confidence",
+        "article_contribution_weight",
+    ):
+        if _optional_str(row.get(field_name)) is None:
+            flags.append(f"missing_{field_name}")
+    return flags
+
+
+def _first_text(values: object) -> str | None:
+    """Return first non-empty text in an iterable."""
+    iterable: Iterable[object]
+    if isinstance(values, Iterable) and not isinstance(values, (str, bytes, Mapping)):
+        iterable = values
+    else:
+        iterable = [values]
+    for value in iterable:
+        text = _optional_str(value)
+        if text is not None:
+            return text
+    return None
+
+
+def _first_int(values: object) -> int | None:
+    """Return first integer in an iterable."""
+    iterable: Iterable[object]
+    if isinstance(values, Iterable) and not isinstance(values, (str, bytes, Mapping)):
+        iterable = values
+    else:
+        iterable = [values]
+    for value in iterable:
+        number = _maybe_float(value)
+        if number is not None:
+            return int(number)
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    """Return an int when a single value is numeric."""
+    number = _maybe_float(value)
+    if number is None:
+        return None
+    return int(number)
 
 
 def _topic_relevance_missing_flags(
@@ -1328,7 +1473,12 @@ def _first_assignment_provenance_fields(
 
 
 def _first_float(values: object) -> float | None:
-    for value in _json_list(values):
+    iterable: Iterable[object]
+    if isinstance(values, Iterable) and not isinstance(values, (str, bytes, Mapping)):
+        iterable = values
+    else:
+        iterable = [values]
+    for value in iterable:
         number = _maybe_float(value)
         if number is not None:
             return number

--- a/tests/unit/test_news_relevance.py
+++ b/tests/unit/test_news_relevance.py
@@ -225,6 +225,49 @@ def test_news_relevance_gate_filters_aapl_contamination_pattern() -> None:
     assert audit.loc[audit["article_id"] == "broad-market", "ticker_relevance_score"].iloc[0] == 0.0
 
 
+def test_news_relevance_gate_excludes_snap_vision_pro_comparison_from_aapl_signal() -> None:
+    """Snap story with only a Vision Pro comparison must not become AAPL signal."""
+    articles = [
+        {
+            "id": "snap-vision-pro-comparison",
+            "headline": "'Sad' That No One Will Tell Snap CEO The Truth About Horrendous Product Design",
+            "summary": (
+                "The story is about Snap and says its product price compares with Apple's "
+                "Vision Pro as a price comparison only."
+            ),
+            "content": (
+                "Snap shares are down and the article criticizes Snap's wearable product. "
+                "Apple appears only as a Vision Pro price comparison, with no direct Apple "
+                "business claim."
+            ),
+            "created_at": "2024-01-02T12:00:00+00:00",
+            "source": "benzinga",
+            "symbols": ["SNAP", "AAPL"],
+        }
+    ]
+    records = preprocess_news_articles(
+        articles,
+        as_of_date="2024-01-02",
+        point_in_time_tickers=("AAPL",),
+    )
+
+    result = apply_news_relevance_gate(
+        records,
+        embeddings=_embedding_frame(article["id"] for article in articles),
+        topic_labels=_topic_label_frame(article["id"] for article in articles),
+    )
+
+    aapl_rows = _rows_for_article(result.audit_frame, "snap-vision-pro-comparison")
+    incidental_rows = [row for row in aapl_rows if row["relevance_category"] == "incidental_comparison"]
+    assert incidental_rows
+    assert all(row["relevance_decision"] == "rejected" for row in aapl_rows)
+    assert all(row["target_context_score"] <= 0.08 for row in incidental_rows)
+    assert all(row["target_company_impact_direction"] == "none" for row in incidental_rows)
+    assert all(row["article_signal_count"] == 0 for row in aapl_rows)
+    assert all(record.article_id != "snap-vision-pro-comparison" for record in result.finbert_records)
+    assert any("incidental_comparison_excluded_from_signal" in _reason_codes(row) for row in incidental_rows)
+
+
 def _topic_label_frame(article_ids) -> pd.DataFrame:
     """Return topic-label rows for relevance-gate tests."""
     return pd.DataFrame(

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -1031,6 +1031,48 @@ def test_semantic_review_dashboard_html_names_human_review_outputs() -> None:
     assert "Only AI/ML/NLP evidence belongs here" in html
 
 
+def test_semantic_review_payload_exposes_target_impact_signal_inclusion(tmp_path: Path) -> None:
+    """Article review rows should show relationship, target impact, and final inclusion status."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    report_dict = cast(dict[str, Any], report.to_dict())
+    for row in cast(list[dict[str, Any]], report_dict["relevance_gate_rows"]):
+        if row["article_id"] == "aapl-001":
+            row.update(
+                {
+                    "relevance_category": "incidental_comparison",
+                    "relationship_to_target": "incidental_comparison",
+                    "target_context_score": 0.08,
+                    "target_company_impact_direction": "none",
+                    "target_company_impact_magnitude": "low",
+                    "impact_horizon": "same_day",
+                    "causal_channel": "comparison_context",
+                    "target_impact_confidence": 0.15,
+                    "article_signal_count": 0,
+                    "article_contribution_weight": 0.35,
+                    "relevance_decision": "rejected",
+                }
+            )
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report_dict))
+    articles = cast(list[dict[str, Any]], payload["topic_relevance_review"]["articles"])
+    article = next(row for row in articles if row["article_id"] == "aapl-001")
+
+    assert article["relationship_to_target"] == "incidental_comparison"
+    assert article["target_context_score"] == 0.08
+    assert article["target_company_impact_direction"] == "none"
+    assert article["included_in_signal"] is False
+    assert article["final_contribution"] == 0.0
+    assert article["target_impact_evidence_status"] == "excluded"
+    assert article["target_impact_missing_flags"] == []
+
+
 def test_semantic_review_dashboard_payload_is_bounded_and_valid(tmp_path: Path) -> None:
     """The normal dashboard payload should stay bounded and still validate."""
     fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")


### PR DESCRIPTION
## Summary

Refs #281.

This slice addresses the user's latest archive critique that the stock audit still conflates article sentiment, ticker mention relevance, and expected target impact.

Changes:
- Treat comparison-only AAPL mentions (e.g. Snap/Vision Pro price comparisons) as `incidental_comparison`, rejected from AAPL signal, with `target_context_score <= 0.08` and `article_signal_count = 0`.
- Add target-conditioned review fields to relevance-gate evidence:
  - `target_context_score`
  - `document_sentiment`
  - `target_company_impact_direction`
  - `target_company_impact_magnitude`
  - `impact_horizon`
  - `causal_channel`
  - `target_impact_confidence`
  - contribution/inclusion fields in review payloads
- Expand semantic-review/dashboard payload article rows so reviewers can see:
  - `relationship_to_target`
  - `included_in_signal`
  - `final_contribution`
  - missing target-impact evidence flags
- Keep the canonical full relevance-gate rows in `pipeline_sections`, while compacting duplicated article-row copies to preserve dashboard payload size bounds.
- Add regressions for the Snap/Vision-Pro contamination pattern and dashboard target-impact inclusion visibility.

## Verification

Local gates run from `.worktrees/issue-281-target-impact-review-evidence`:

```text
/home/juyoungoh/venv/bin/python -m pytest tests/unit/test_news_relevance.py tests/unit/test_semantic_review_dashboard.py tests/unit/test_sentiment_features.py tests/unit/test_feature_catalog.py -q
65 passed in 9.28s

/home/juyoungoh/venv/bin/ruff check core/features/news_relevance.py core/features/aapl_evidence.py core/features/semantic_review_dashboard.py tests/unit/test_news_relevance.py tests/unit/test_semantic_review_dashboard.py tests/unit/test_sentiment_features.py tests/unit/test_feature_catalog.py
All checks passed!

git diff --check
clean
```

Additional manual probe before codifying the regression:
- Snap/Vision-Pro comparison rows were rejected.
- Incidental rows had `target_context_score = 0.08`.
- Article had `article_signal_count = 0`.
- No `snap-vision-pro-comparison` records flowed into FinBERT.

## Guardrails

- Broad #202 PIT historical backfill was not started.
- #203 cleanup was not started.
- This PR is a target-impact evidence/semantic-review slice only; it does not claim the current archive is semantically accepted until a fresh regenerated dashboard/archive is reviewed.