### PR TITLE
fix: repair semantic acceptance review after target evidence

### DIFF
--- a/core/features/aapl_evidence.py
+++ b/core/features/aapl_evidence.py
@@ -2954,7 +2954,24 @@ class HumanReviewRow:
     finbert_score: float | None
     relevance_score: float | None
     regime: str | None
-    notes: str | None
+    relationship_to_target: str | None = None
+    target_context_score: float | None = None
+    document_sentiment: str | None = None
+    target_company_impact_direction: str | None = None
+    target_company_impact_magnitude: str | None = None
+    impact_horizon: str | None = None
+    causal_channel: str | None = None
+    target_impact_confidence: float | None = None
+    included_in_signal: bool | None = None
+    final_contribution: float | None = None
+    final_signal_contribution: float | None = None
+    target_impact_missing_flags: list[str] = field(default_factory=list)
+    article_signal_count: int | None = None
+    article_contamination_ratio: float | None = None
+    semantic_warning_codes: list[str] = field(default_factory=list)
+    source_count: int | None = None
+    dominant_source_weight_share: float | None = None
+    notes: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable row payload."""
@@ -3094,6 +3111,7 @@ def build_aapl_pilot_evidence_bundle(
         else ("do_not_proceed" if not machine_passed else "needs_human_review")
     )
     human_rows = _build_human_review_rows(
+        report,
         active_writer,
         active_ticker,
         expected_trading_dates,
@@ -3172,6 +3190,23 @@ def render_aapl_pilot_human_review_csv(bundle: AAPLPilotEvidenceBundle) -> str:
         "finbert_score",
         "relevance_score",
         "regime",
+        "relationship_to_target",
+        "target_context_score",
+        "document_sentiment",
+        "target_company_impact_direction",
+        "target_company_impact_magnitude",
+        "impact_horizon",
+        "causal_channel",
+        "target_impact_confidence",
+        "included_in_signal",
+        "final_contribution",
+        "final_signal_contribution",
+        "target_impact_missing_flags",
+        "article_signal_count",
+        "article_contamination_ratio",
+        "semantic_warning_codes",
+        "source_count",
+        "dominant_source_weight_share",
         "notes",
     ]
     writer = csv.DictWriter(buffer, fieldnames=fieldnames)
@@ -3199,6 +3234,7 @@ def write_aapl_pilot_evidence_outputs(
 
 
 def _build_human_review_rows(
+    report: Layer1SemanticReviewReport,
     writer: R2Writer,
     ticker: str,
     trading_date_list: Sequence[str],
@@ -3206,6 +3242,17 @@ def _build_human_review_rows(
 ) -> list[HumanReviewRow]:
     """Build one human-review row per trading date from scored-news artifacts."""
     rows: list[HumanReviewRow] = []
+    articles_by_date: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for article in report.article_groups:
+        date_text = _optional_str(article.get("date"))
+        if date_text:
+            articles_by_date[date_text].append(dict(article))
+    semantic_by_date: dict[str, list[dict[str, object]]] = defaultdict(list)
+    for row in report.semantic_aggregate_rows:
+        date_text = _optional_str(row.get("date"))
+        if date_text:
+            semantic_by_date[date_text].append(dict(row))
+
     for date_text in trading_date_list:
         stage_run_id = f"{run_id}-{date_text}"
         score_key = layer1_sentiment_score_path(date_text, stage_run_id)
@@ -3215,6 +3262,61 @@ def _build_human_review_rows(
             frame = pd.DataFrame()
         first_row = frame.iloc[0] if not frame.empty else {}
         row_source = first_row.to_dict() if hasattr(first_row, "to_dict") else {}
+
+        target_rows = [
+            dict(row)
+            for article in articles_by_date.get(date_text, [])
+            for row in _json_list(article.get("relevance_gate_rows"))
+            if isinstance(row, Mapping)
+        ]
+        target_rows = sorted(
+            target_rows,
+            key=lambda row: (
+                not _target_row_included_in_signal(row),
+                -(_maybe_float(row.get("target_context_score")) or -1.0),
+                -(_maybe_float(row.get("article_contribution_weight")) or -1.0),
+                str(row.get("article_id") or ""),
+                str(row.get("sentence_index") or ""),
+            ),
+        )
+        target_summary = _target_impact_summary(target_rows)
+
+        semantic_rows = semantic_by_date.get(date_text, [])
+        semantic_row = semantic_rows[0] if semantic_rows else {}
+        semantic_features = _json_mapping(semantic_row.get("features"))
+        semantic_warning_codes = _json_string_list(semantic_row.get("semantic_warning_codes"))
+        if not semantic_warning_codes:
+            semantic_warning_codes = _json_string_list(semantic_features.get("nlp_semantic_warning_codes"))
+        source_weight_summary = _json_list(semantic_row.get("source_weight_summary"))
+        source_count = _maybe_int(semantic_features.get("nlp_source_count"))
+        dominant_source_weight_share = _maybe_float(semantic_features.get("nlp_dominant_source_weight_share"))
+        if source_weight_summary:
+            source_entries = [entry for entry in source_weight_summary if isinstance(entry, Mapping)]
+            if source_entries:
+                source_count = source_count or len(
+                    {
+                        str(entry.get("source") or "").strip()
+                        for entry in source_entries
+                        if str(entry.get("source") or "").strip()
+                    }
+                )
+                dominant_source_weight_share = dominant_source_weight_share or max(
+                    (
+                        _maybe_float(entry.get("weight_share"))
+                        for entry in source_entries
+                    ),
+                    default=None,
+                )
+        if source_count == 1 and "single_source_concentration" not in semantic_warning_codes:
+            semantic_warning_codes.append("single_source_concentration")
+        if not _optional_str(target_summary.get("target_company_impact_direction")):
+            semantic_warning_codes.append("unclear_target_company_impact_direction")
+        if not target_rows:
+            semantic_warning_codes.append("missing_target_impact_evidence")
+
+        notes_parts = ["FinBERT, topic-model, and HMM semantic correctness is a human decision."]
+        if semantic_warning_codes:
+            notes_parts.append(f"Warnings: {', '.join(sorted(set(semantic_warning_codes)))}.")
         rows.append(
             HumanReviewRow(
                 date=date_text,
@@ -3234,7 +3336,30 @@ def _build_human_review_rows(
                 finbert_score=_maybe_float(row_source.get("sentiment_score")),
                 relevance_score=_maybe_float(row_source.get("relevance_score")),
                 regime=None,
-                notes="FinBERT, topic-model, and HMM semantic correctness is a human decision.",
+                relationship_to_target=_optional_str(target_summary.get("relationship_to_target")),
+                target_context_score=_maybe_float(target_summary.get("target_context_score")),
+                document_sentiment=_optional_str(target_summary.get("document_sentiment")),
+                target_company_impact_direction=_optional_str(
+                    target_summary.get("target_company_impact_direction")
+                ),
+                target_company_impact_magnitude=_optional_str(
+                    target_summary.get("target_company_impact_magnitude")
+                ),
+                impact_horizon=_optional_str(target_summary.get("impact_horizon")),
+                causal_channel=_optional_str(target_summary.get("causal_channel")),
+                target_impact_confidence=_maybe_float(target_summary.get("target_impact_confidence")),
+                included_in_signal=bool(target_summary.get("included_in_signal")),
+                final_contribution=_maybe_float(target_summary.get("final_contribution")),
+                final_signal_contribution=_maybe_float(target_summary.get("final_signal_contribution")),
+                target_impact_missing_flags=list(target_summary.get("target_impact_missing_flags", [])),
+                article_signal_count=_maybe_int(target_summary.get("article_signal_count")),
+                article_contamination_ratio=_maybe_float(
+                    target_summary.get("article_contamination_ratio")
+                ),
+                semantic_warning_codes=sorted(set(semantic_warning_codes)),
+                source_count=source_count,
+                dominant_source_weight_share=dominant_source_weight_share,
+                notes=" ".join(notes_parts),
             )
         )
     return rows

--- a/core/features/semantic_review_dashboard.py
+++ b/core/features/semantic_review_dashboard.py
@@ -465,15 +465,71 @@ def build_layer1_semantic_aggregate_review(
         for row in _json_list(sections.get("semantic_aggregate_rows"))
         if isinstance(row, Mapping)
     ]
-    return {
-        "summary": {
-            "row_count": len(rows),
-            "date_count": len({str(row.get("date")) for row in rows if row.get("date") is not None}),
-            "reviewable": bool(rows),
-            "review_focus": "ticker-date NLP summary consumed by later model layers",
-        },
-        "rows": rows,
+    direction_counts: dict[str, int] = {}
+    warning_codes: list[str] = []
+    single_source_concentration_count = 0
+    dominant_source_weight_share = None
+    for row in rows:
+        direction = _optional_str(row.get("target_company_impact_direction"))
+        if direction:
+            direction_counts[direction] = direction_counts.get(direction, 0) + 1
+        warning_codes.extend(_json_string_list(row.get("semantic_warning_codes")))
+        if bool(row.get("single_source_concentration")):
+            single_source_concentration_count += 1
+        share = _maybe_float(row.get("dominant_source_weight_share"))
+        if share is not None:
+            dominant_source_weight_share = (
+                share
+                if dominant_source_weight_share is None
+                else max(dominant_source_weight_share, share)
+            )
+    summary = {
+        "row_count": len(rows),
+        "date_count": len({str(row.get("date")) for row in rows if row.get("date") is not None}),
+        "reviewable": bool(rows),
+        "review_focus": "ticker-date NLP summary consumed by later model layers",
+        "target_impact_direction": _first_text(
+            row.get("target_company_impact_direction") for row in rows
+        ),
+        "target_impact_magnitude": _first_text(
+            row.get("target_company_impact_magnitude") for row in rows
+        ),
+        "target_impact_confidence": _first_float(
+            row.get("target_impact_confidence") for row in rows
+        ),
+        "causal_channel": _first_text(row.get("causal_channel") for row in rows),
+        "impact_horizon": _first_text(row.get("impact_horizon") for row in rows),
+        "single_source_concentration": single_source_concentration_count > 0,
+        "single_source_concentration_count": single_source_concentration_count,
+        "dominant_source_weight_share": dominant_source_weight_share,
+        "semantic_warning_codes": _dedupe_preserve_order(warning_codes),
+        "target_impact_review_status": (
+            "derived"
+            if any(
+                _optional_str(row.get("target_company_impact_direction"))
+                or _optional_str(row.get("target_company_impact_magnitude"))
+                or _optional_str(row.get("causal_channel"))
+                or _optional_str(row.get("impact_horizon"))
+                or _maybe_float(row.get("target_impact_confidence")) is not None
+                for row in rows
+            )
+            else "unclear"
+        ),
+        "target_impact_warning": (
+            None
+            if any(
+                _optional_str(row.get("target_company_impact_direction"))
+                or _optional_str(row.get("target_company_impact_magnitude"))
+                or _optional_str(row.get("causal_channel"))
+                or _optional_str(row.get("impact_horizon"))
+                or _maybe_float(row.get("target_impact_confidence")) is not None
+                for row in rows
+            )
+            else "No row-level target-impact evidence was available, so the aggregate review remains unclear."
+        ),
+        "target_impact_direction_counts": direction_counts,
     }
+    return {"summary": summary, "rows": rows}
 
 
 def build_layer1_semantic_review_readiness_summary(
@@ -482,12 +538,15 @@ def build_layer1_semantic_review_readiness_summary(
     """Return stable run-readiness and gate-card fields for dashboard consumers."""
     summary = _json_mapping(payload.get("summary"))
     smoke = _json_mapping(payload.get("smoke"))
+    semantic_aggregate_review = _json_mapping(payload.get("semantic_aggregate_review"))
+    semantic_aggregate_summary = _json_mapping(semantic_aggregate_review.get("summary"))
     topic_relevance_review = _json_mapping(payload.get("topic_relevance_review"))
     topic_relevance_summary = _json_mapping(topic_relevance_review.get("summary"))
     topic_review_state = _json_mapping(topic_relevance_summary.get("topic_review_state"))
     relevance_state = _json_mapping(topic_relevance_summary.get("relevance_informativeness_state"))
     embedding_state = _json_mapping(topic_relevance_summary.get("embedding_coverage_state"))
     hmm_chart_state = _hmm_chart_auditability_state(payload)
+    hmm_feature_state = _hmm_feature_set_summary(payload)
     failures = [dict(item) for item in _json_list(smoke.get("failures")) if isinstance(item, Mapping)]
     failure_map = _failures_by_stage(failures)
     gate_cards = [
@@ -546,6 +605,7 @@ def build_layer1_semantic_review_readiness_summary(
         "relevance_informativeness": relevance_state,
         "embedding_coverage": embedding_state,
         "hmm_chart_auditability": hmm_chart_state,
+        "hmm_feature_set": hmm_feature_state,
         "overall_state": _diagnostic_worst_state(
             diagnostic_states["topic_review"],
             diagnostic_states["relevance_informativeness"],
@@ -565,6 +625,21 @@ def build_layer1_semantic_review_readiness_summary(
         "human_review_status": human_review_status,
         "human_review_can_start": ready_for_final_acceptance,
         "ready_for_final_human_acceptance": ready_for_final_acceptance,
+        "single_source_concentration": bool(semantic_aggregate_summary.get("single_source_concentration")),
+        "single_source_concentration_count": _first_int(
+            [semantic_aggregate_summary.get("single_source_concentration_count")]
+        )
+        or 0,
+        "target_impact_review_status": semantic_aggregate_summary.get("target_impact_review_status") or "unclear",
+        "target_impact_warning": semantic_aggregate_summary.get("target_impact_warning"),
+        "target_impact_direction": semantic_aggregate_summary.get("target_impact_direction"),
+        "target_impact_magnitude": semantic_aggregate_summary.get("target_impact_magnitude"),
+        "target_impact_confidence": semantic_aggregate_summary.get("target_impact_confidence"),
+        "causal_channel": semantic_aggregate_summary.get("causal_channel"),
+        "impact_horizon": semantic_aggregate_summary.get("impact_horizon"),
+        "hmm_feature_set_state": hmm_feature_state["state"],
+        "hmm_feature_set_warning": hmm_feature_state["reason"],
+        "hmm_feature_set_reviewable": hmm_feature_state["reviewable"],
         "smoke_status": smoke.get("status") or "unknown",
         "sentence_row_count": int(summary.get("row_count") or 0),
         "article_count": int(summary.get("article_count") or 0),
@@ -582,6 +657,11 @@ def build_layer1_semantic_review_readiness_summary(
         "hmm_chart_auditability_state": hmm_chart_state,
         "status_reason": _readiness_status_reason(ready_for_final_acceptance, diagnostic_blocker_reasons),
     }
+    if hmm_feature_state.get("state") == "WARN":
+        run_readiness["status_reason"] = (
+            f"{run_readiness['status_reason']} HMM feature set is degraded but non-blocking: "
+            f"{hmm_feature_state.get('reason')}"
+        )
     return {
         "run_readiness": run_readiness,
         "summary_cards": _summary_cards(run_readiness),
@@ -1315,11 +1395,13 @@ def _topic_relevance_reviewability_summary(
 
 def _semantic_aggregate_review_row(row: Mapping[str, object]) -> dict[str, object]:
     features = _json_mapping(row.get("features"))
+    target_summary = _semantic_aggregate_target_impact_summary(features)
     sentiment_score = _maybe_float(features.get("nlp_sentiment_score"))
     sentiment_label = _sentiment_label_from_score(sentiment_score)
     cards = _semantic_aggregate_review_cards(features)
     return {
         **dict(row),
+        **target_summary,
         "sentiment_label": sentiment_label,
         "human_review_summary": _semantic_aggregate_human_summary(
             sentiment_label=sentiment_label,
@@ -1328,6 +1410,124 @@ def _semantic_aggregate_review_row(row: Mapping[str, object]) -> dict[str, objec
             sentence_count=_maybe_float(features.get("nlp_sentence_count")),
         ),
         "review_value_cards": cards,
+    }
+
+
+def _semantic_aggregate_target_impact_summary(features: Mapping[str, object]) -> dict[str, object]:
+    """Return target-impact fields and warnings for one semantic aggregate row."""
+    relationship_to_target = _first_text(
+        [
+            features.get("nlp_relevance_category"),
+            features.get("relevance_category"),
+        ]
+    )
+    target_context_score = _first_float(
+        [features.get("nlp_target_context_score"), features.get("target_context_score")]
+    )
+    document_sentiment = _first_text(
+        [features.get("nlp_document_sentiment"), features.get("document_sentiment")]
+    )
+    target_company_impact_direction = _first_text(
+        [features.get("nlp_target_impact_direction"), features.get("target_company_impact_direction")]
+    )
+    target_company_impact_magnitude = _first_text(
+        [features.get("nlp_target_impact_magnitude"), features.get("target_company_impact_magnitude")]
+    )
+    impact_horizon = _first_text([features.get("nlp_target_impact_horizon"), features.get("impact_horizon")])
+    causal_channel = _first_text([features.get("nlp_causal_channel"), features.get("causal_channel")])
+    target_impact_confidence = _first_float(
+        [features.get("nlp_target_impact_confidence"), features.get("target_impact_confidence")]
+    )
+    included_in_signal = _maybe_bool(features.get("included_in_signal"))
+    final_contribution = _first_float([features.get("final_contribution"), features.get("final_signal_contribution")])
+    final_signal_contribution = _first_float([features.get("final_signal_contribution"), features.get("final_contribution")])
+    target_impact_missing_flags: list[str] = []
+    for field_name, value in (
+        ("relationship_to_target", relationship_to_target),
+        ("target_context_score", target_context_score),
+        ("document_sentiment", document_sentiment),
+        ("target_company_impact_direction", target_company_impact_direction),
+        ("target_company_impact_magnitude", target_company_impact_magnitude),
+        ("impact_horizon", impact_horizon),
+        ("causal_channel", causal_channel),
+        ("target_impact_confidence", target_impact_confidence),
+    ):
+        if value is None:
+            target_impact_missing_flags.append(f"missing_{field_name}")
+    source_count = _first_int([features.get("nlp_source_count"), features.get("source_count")])
+    dominant_source_weight_share = _first_float(
+        [features.get("nlp_dominant_source_weight_share"), features.get("dominant_source_weight_share")]
+    )
+    single_source_concentration = bool(
+        source_count == 1 or (dominant_source_weight_share is not None and dominant_source_weight_share >= 0.99)
+    )
+    semantic_warning_codes = _dedupe_preserve_order(
+        _json_string_list(features.get("nlp_semantic_warning_codes"))
+    )
+    if single_source_concentration and "single_source_concentration" not in semantic_warning_codes:
+        semantic_warning_codes.append("single_source_concentration")
+    target_impact_status = "derived" if target_company_impact_direction or target_context_score is not None else "unclear"
+    target_impact_warning = (
+        None
+        if target_impact_status == "derived"
+        else "All row-level target-impact evidence is unclear or missing for this aggregate row."
+    )
+    if target_impact_warning and "unclear_target_company_impact_direction" not in semantic_warning_codes:
+        semantic_warning_codes.append("unclear_target_company_impact_direction")
+    if target_impact_confidence is None and "missing_target_impact_confidence" not in semantic_warning_codes:
+        semantic_warning_codes.append("missing_target_impact_confidence")
+    return {
+        "relationship_to_target": relationship_to_target,
+        "target_context_score": target_context_score,
+        "document_sentiment": document_sentiment,
+        "target_company_impact_direction": target_company_impact_direction,
+        "target_company_impact_magnitude": target_company_impact_magnitude,
+        "impact_horizon": impact_horizon,
+        "causal_channel": causal_channel,
+        "target_impact_confidence": target_impact_confidence,
+        "included_in_signal": included_in_signal,
+        "final_contribution": final_contribution,
+        "final_signal_contribution": final_signal_contribution,
+        "target_impact_missing_flags": target_impact_missing_flags,
+        "source_count": source_count,
+        "dominant_source_weight_share": dominant_source_weight_share,
+        "single_source_concentration": single_source_concentration,
+        "semantic_warning_codes": semantic_warning_codes,
+        "target_impact_status": target_impact_status,
+        "target_impact_warning": target_impact_warning,
+    }
+
+
+def _hmm_feature_set_summary(payload: Mapping[str, object]) -> dict[str, object]:
+    """Return a human-readable HMM feature-set degradation summary."""
+    context = _json_mapping(payload.get("hmm_evaluation_context"))
+    warning_codes = _dedupe_preserve_order(_json_string_list(context.get("warnings")))
+    feature_set_blocking = _maybe_bool(context.get("feature_set_blocking"))
+    if feature_set_blocking is None:
+        feature_set_blocking = "incomplete_hmm_feature_set" in warning_codes
+    degraded = bool(warning_codes)
+    if not degraded:
+        return {
+            "state": "PASS",
+            "reason": "HMM feature set is ready.",
+            "reviewable": True,
+            "warning_codes": [],
+            "blocking": bool(feature_set_blocking),
+        }
+    if feature_set_blocking:
+        return {
+            "state": "WARN",
+            "reason": "HMM feature set is degraded and blocks readiness.",
+            "reviewable": False,
+            "warning_codes": warning_codes,
+            "blocking": True,
+        }
+    return {
+        "state": "WARN",
+        "reason": "HMM feature set is degraded but non-blocking.",
+        "reviewable": True,
+        "warning_codes": warning_codes,
+        "blocking": False,
     }
 
 
@@ -1358,6 +1558,55 @@ def _semantic_aggregate_human_summary(
 
 def _semantic_aggregate_review_cards(features: Mapping[str, object]) -> list[dict[str, object]]:
     cards: list[dict[str, object]] = []
+    target_direction = _first_text(
+        [features.get("nlp_target_impact_direction"), features.get("target_company_impact_direction")]
+    )
+    if target_direction is not None:
+        cards.append(
+            {
+                "label": "Target impact direction",
+                "value": target_direction,
+                "field": "features.nlp_target_impact_direction",
+            }
+        )
+    target_magnitude = _first_text(
+        [features.get("nlp_target_impact_magnitude"), features.get("target_company_impact_magnitude")]
+    )
+    if target_magnitude is not None:
+        cards.append(
+            {
+                "label": "Target impact magnitude",
+                "value": target_magnitude,
+                "field": "features.nlp_target_impact_magnitude",
+            }
+        )
+    target_confidence = _first_float([features.get("nlp_target_impact_confidence"), features.get("target_impact_confidence")])
+    if target_confidence is not None:
+        cards.append(
+            {
+                "label": "Target impact confidence",
+                "value": _display_number(target_confidence, 3),
+                "field": "features.nlp_target_impact_confidence",
+            }
+        )
+    target_channel = _first_text([features.get("nlp_causal_channel"), features.get("causal_channel")])
+    if target_channel is not None:
+        cards.append(
+            {
+                "label": "Causal channel",
+                "value": target_channel,
+                "field": "features.nlp_causal_channel",
+            }
+        )
+    target_horizon = _first_text([features.get("nlp_target_impact_horizon"), features.get("impact_horizon")])
+    if target_horizon is not None:
+        cards.append(
+            {
+                "label": "Impact horizon",
+                "value": target_horizon,
+                "field": "features.nlp_target_impact_horizon",
+            }
+        )
     sentiment_score = _maybe_float(features.get("nlp_sentiment_score"))
     if sentiment_score is not None:
         cards.append(
@@ -1400,6 +1649,21 @@ def _semantic_aggregate_review_cards(features: Mapping[str, object]) -> list[dic
                 "label": "Relevance score",
                 "value": _display_number(relevance_score, 3),
                 "field": "features.nlp_relevance_score",
+            }
+        )
+    source_count = _first_int([features.get("nlp_source_count"), features.get("source_count")])
+    dominant_share = _first_float(
+        [features.get("nlp_dominant_source_weight_share"), features.get("dominant_source_weight_share")]
+    )
+    if source_count is not None or dominant_share is not None:
+        cards.append(
+            {
+                "label": "Source concentration",
+                "value": (
+                    f"{source_count if source_count is not None else 'n/a'} source(s) / "
+                    f"{_display_number(dominant_share, 3)} share"
+                ),
+                "field": "features.nlp_source_count / features.nlp_dominant_source_weight_share",
             }
         )
     return cards
@@ -1629,6 +1893,23 @@ def _optional_str(value: Any) -> str | None:
         return None
     text = str(value).strip()
     return text or None
+
+
+def _maybe_bool(value: Any) -> bool | None:
+    """Return a bool when the input is clearly boolean-like."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    text = _optional_str(value)
+    if text is None:
+        return None
+    lowered = text.lower()
+    if lowered in {"true", "1", "yes"}:
+        return True
+    if lowered in {"false", "0", "no"}:
+        return False
+    return None
 
 
 def _dedupe_preserve_order(items: Sequence[str]) -> list[str]:

--- a/core/features/text_topics.py
+++ b/core/features/text_topics.py
@@ -308,8 +308,9 @@ def build_topic_review_payload(
             topic_labeler=topic_labeler,
             total_rows=len(frame),
         )
-        invalid_summary["topic_label"] = "Outlier / Unassigned"
-        invalid_summary["topic_keywords"] = []
+        invalid_summary["topic_label_source"] = "fallback_text_evidence"
+        invalid_summary["topic_fallback_used"] = True
+        invalid_summary["topic_diversity_status"] = "insufficient_diversity"
         row_payloads.extend(_topic_rows_with_summary(invalid_rows, invalid_summary))
 
     dominant_topic_id: int | None = None
@@ -346,6 +347,7 @@ def build_topic_review_payload(
         "dominant_topic_share": dominant_topic_share,
         "topics": topic_summaries,
         "rows": row_payloads,
+        "topic_fallback_used": diversity_status != "diverse",
     }
     if generation_mode is not None:
         payload["generation_mode"] = generation_mode
@@ -583,12 +585,26 @@ def _summarize_topic_group(
 ) -> dict[str, object]:
     """Summarize one topic group for review output."""
     texts = [str(text or "") for text in group["text"].tolist() if str(text or "").strip()]
+    headlines = [
+        str(text or "")
+        for text in group["normalized_headline"].tolist()
+        if str(text or "").strip()
+    ] if "normalized_headline" in group.columns else []
+    evidence_texts = texts + [headline for headline in headlines if headline not in texts]
     first_row = group.iloc[0] if len(group) else None
-    explicit_label = _optional_str(first_row["topic_label"]) if first_row is not None and "topic_label" in group.columns else None
-    explicit_keywords = _coerce_string_list(first_row["topic_keywords"]) if first_row is not None and "topic_keywords" in group.columns else []
+    explicit_label = (
+        _optional_str(first_row["topic_label"])
+        if first_row is not None and "topic_label" in group.columns
+        else None
+    )
+    explicit_keywords = (
+        _coerce_string_list(first_row["topic_keywords"])
+        if first_row is not None and "topic_keywords" in group.columns
+        else []
+    )
     keywords = explicit_keywords or _topic_keywords_for_group(
         topic_id=topic_id,
-        texts=texts,
+        texts=evidence_texts,
         topic_labeler=topic_labeler,
         topic_name=topic_info.get(topic_id),
     )
@@ -604,13 +620,17 @@ def _summarize_topic_group(
     primary_text = str(representative_row.iloc[0]["text"] or "") if len(representative_row) else ""
     example_texts = _representative_texts(group)
     row_count = int(len(group))
+    label_source = "explicit_topic_label" if explicit_label else (
+        "topic_model_name" if topic_info.get(topic_id) else "fallback_text_evidence"
+    )
+    label = explicit_label or _format_topic_label(
+        topic_id=topic_id,
+        keywords=keywords,
+        topic_name=topic_info.get(topic_id),
+    )
     return {
         "topic_id": topic_id,
-        "topic_label": explicit_label or _format_topic_label(
-            topic_id=topic_id,
-            keywords=keywords,
-            topic_name=topic_info.get(topic_id),
-        ),
+        "topic_label": label,
         "topic_keywords": keywords,
         "topic_keyword_text": ", ".join(keywords),
         "topic_example_text": primary_text,
@@ -619,6 +639,8 @@ def _summarize_topic_group(
         "topic_row_share": row_count / max(1, total_rows),
         "topic_probability_mean": float(group["topic_probability"].mean()),
         "topic_probability_max": float(group["topic_probability"].max()),
+        "topic_label_source": label_source,
+        "topic_fallback_used": label_source == "fallback_text_evidence" or topic_id < 0,
     }
 
 
@@ -648,6 +670,8 @@ def _topic_rows_with_summary(
                 "topic_example_texts": list(summary.get("topic_example_texts", [])),
                 "topic_row_count": _optional_int(summary.get("topic_row_count")),
                 "topic_row_share": _optional_float(summary.get("topic_row_share")),
+                "topic_label_source": str(summary.get("topic_label_source", "fallback_text_evidence")),
+                "topic_fallback_used": bool(summary.get("topic_fallback_used", False)),
             }
         )
     return rows

--- a/tests/unit/test_aapl_pilot_evidence.py
+++ b/tests/unit/test_aapl_pilot_evidence.py
@@ -68,6 +68,27 @@ def test_build_aapl_pilot_evidence_bundle_separates_machine_and_human_review(
     assert bundle.human_semantic_review_status == "pending"
     assert bundle.recommendation_for_issue_202 == "needs_human_review"
     assert len(bundle.human_review_rows) == 3
+    row_dict = bundle.human_review_rows[0].to_dict()
+    assert {
+        "relationship_to_target",
+        "target_context_score",
+        "document_sentiment",
+        "target_company_impact_direction",
+        "target_company_impact_magnitude",
+        "impact_horizon",
+        "causal_channel",
+        "target_impact_confidence",
+        "included_in_signal",
+        "final_contribution",
+        "final_signal_contribution",
+        "target_impact_missing_flags",
+        "article_signal_count",
+        "article_contamination_ratio",
+        "semantic_warning_codes",
+        "source_count",
+        "dominant_source_weight_share",
+    }.issubset(row_dict)
+    assert any("semantic_warning_codes" in row.to_dict() for row in bundle.human_review_rows)
     assert "FinBERT, topic-model, and HMM semantic correctness is a human decision" in markdown
     assert "Market update." in csv_text
     assert bundle.artifact_keys["raw_price"] == "raw/prices/AAPL.parquet"

--- a/tests/unit/test_semantic_review_dashboard.py
+++ b/tests/unit/test_semantic_review_dashboard.py
@@ -430,16 +430,78 @@ def test_semantic_review_payload_adds_human_focused_aggregate_review(
         writer=fixture["writer"],
     )
 
-    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report))
+    report_dict = cast(dict[str, Any], report.to_dict())
+    semantic_rows = cast(list[dict[str, Any]], report_dict["semantic_aggregate_rows"])
+    first_row = semantic_rows[0]
+    first_features = cast(dict[str, Any], first_row["features"])
+    first_features["nlp_target_impact_direction"] = "positive"
+    first_features["nlp_target_impact_magnitude"] = "high"
+    first_features["nlp_target_impact_confidence"] = 0.91
+    first_features["nlp_causal_channel"] = "product_device"
+    first_features["nlp_target_impact_horizon"] = "short_term"
+    first_features["nlp_source_count"] = 1
+    first_features["nlp_dominant_source_weight_share"] = 1.0
+    first_row["source_weight_summary"] = [{"source": "Benzinga", "weight_share": 1.0}]
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report_dict))
     review = cast(dict[str, Any], payload["semantic_aggregate_review"])
     rows = cast(list[dict[str, Any]], review["rows"])
 
     assert review["summary"]["row_count"] == 2
+    assert rows[0]["target_company_impact_direction"] == "positive"
+    assert rows[0]["target_company_impact_magnitude"] == "high"
+    assert rows[0]["target_impact_confidence"] == 0.91
+    assert rows[0]["causal_channel"] == "product_device"
+    assert rows[0]["impact_horizon"] == "short_term"
+    assert rows[0]["single_source_concentration"] is True
+    assert rows[0]["source_count"] == 1
+    assert rows[0]["dominant_source_weight_share"] == 1.0
+    assert "single_source_concentration" in rows[0]["semantic_warning_codes"]
     assert rows[0]["sentiment_label"] in {"positive", "negative", "neutral"}
     assert rows[0]["human_review_summary"].startswith("Overall NLP sentiment is")
     card_labels = {str(card["label"]) for card in cast(list[dict[str, Any]], rows[0]["review_value_cards"])}
-    assert {"Overall sentiment", "Positive / negative / neutral mix", "Articles / sentences", "Relevance score"}.issubset(card_labels)
-    assert "Source weight mean / sum" not in card_labels
+    assert {
+        "Target impact direction",
+        "Target impact magnitude",
+        "Target impact confidence",
+        "Causal channel",
+        "Impact horizon",
+        "Source concentration",
+        "Overall sentiment",
+        "Positive / negative / neutral mix",
+        "Articles / sentences",
+        "Relevance score",
+    }.issubset(card_labels)
+    assert review["summary"]["target_impact_direction"] == "positive"
+    assert review["summary"]["single_source_concentration"] is True
+    assert payload["run_readiness"]["single_source_concentration"] is True
+    assert payload["run_readiness"]["target_impact_direction"] == "positive"
+
+
+def test_semantic_review_payload_marks_degraded_hmm_feature_set_without_blocking(
+    tmp_path: Path,
+) -> None:
+    """A degraded HMM feature set should be explained even if it does not block readiness."""
+    fixture = seed_semantic_review_fixture(local_root=tmp_path / "r2")
+    report = build_layer1_aapl_evidence_report(
+        run_id=str(fixture["run_id"]),
+        from_date="2026-05-21",
+        to_date="2026-05-22",
+        ticker="AAPL",
+        writer=fixture["writer"],
+    )
+    report_dict = cast(dict[str, Any], report.to_dict())
+    hmm_context = cast(dict[str, Any], report_dict["hmm_evaluation_context"])
+    hmm_context["warnings"] = ["incomplete_hmm_feature_set"]
+    hmm_context["feature_set_blocking"] = False
+
+    payload = cast(dict[str, Any], build_layer1_semantic_review_dashboard_payload(report_dict))
+    readiness = cast(dict[str, Any], payload["run_readiness"])
+
+    assert readiness["hmm_feature_set_state"] == "WARN"
+    assert readiness["hmm_feature_set_reviewable"] is True
+    assert "degraded but non-blocking" in readiness["hmm_feature_set_warning"]
+    assert "degraded but non-blocking" in readiness["status_reason"]
 
 
 def test_semantic_review_topic_relevance_tab_flags_default_relevance(

--- a/tests/unit/test_text_topics.py
+++ b/tests/unit/test_text_topics.py
@@ -134,6 +134,8 @@ def test_compute_text_topics_builds_human_readable_topic_review() -> None:
     assert review["dominant_topic_share"] == 1.0
     assert review["topics"][0]["topic_keywords"] == ["earnings", "guidance", "revenue"]
     assert review["topics"][0]["topic_example_text"]
+    assert review["topics"][0]["topic_label_source"] == "topic_model_name"
+    assert review["topics"][0]["topic_fallback_used"] is False
     assert review["rows"][0]["topic_row_count"] == 1
     assert review["rows"][0]["topic_row_share"] == 1.0
 
@@ -174,6 +176,10 @@ def test_compute_text_topics_falls_back_for_tiny_corpora(document_count: int) ->
     assert "spectral initialization" in str(result.topic_review["generation_reason"])
     assert result.topic_review["dominant_topic_id"] == 0
     assert result.topic_review["dominant_topic_share"] == 1.0
+    assert result.topic_review["rows"][0]["topic_label"]
+    assert result.topic_review["rows"][0]["topic_keywords"]
+    assert result.topic_review["rows"][0]["topic_label_source"] == "fallback_text_evidence"
+    assert result.topic_review["rows"][0]["topic_fallback_used"] is True
 
 
 def test_bertopic_labeler_uses_bertopic_path_for_sufficient_corpora(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

Refs #281.

This PR repairs the semantic-acceptance review gaps found after the fresh post-PR286 AAPL pilot packet:

- Adds human-readable fallback topic labels/keywords for insufficient-diversity / tiny-corpus / outlier-heavy topic-review rows while preserving explicit fallback/degraded metadata.
- Enriches top-level AAPL pilot `human_review_rows` with target-conditioned evidence fields from PR #286:
  - relationship / target context
  - document sentiment
  - target impact direction/magnitude/horizon/channel/confidence
  - included-in-signal and final contribution fields
  - article signal/contamination metrics
  - source concentration / semantic warnings
- Surfaces semantic aggregate target-impact status instead of silently leaving aggregate impact review as null when row-level evidence exists or all evidence is unclear.
- Makes single-source concentration visible in review/readiness output.
- Clarifies HMM degraded-vs-ready semantics without treating optional `high_yield_spread` as a hard blocker.

## Verification

Worker-reported gates:

```text
/home/juyoungoh/venv/bin/python -m py_compile ... passed
/home/juyoungoh/venv/bin/python -m pytest ...
90 passed, 2 warnings
/home/juyoungoh/venv/bin/ruff check ... passed
git diff --check passed
```

Hermes/trading will run independent PR gates and CI audit before merge.

## Guardrails

- #202 broad PIT historical backfill was not started.
- #203 cleanup was not started.
- This is a semantic-acceptance review/evidence repair slice only; #202 should remain blocked until a fresh post-merge packet is regenerated and semantically reviewed.