### PR TITLE
Make nightly Layer 0→1 refresh holiday-aware and Modal 1.x compatible

### DIFF
--- a/app/lab/data_pipelines/run_daily_layer1.py
+++ b/app/lab/data_pipelines/run_daily_layer1.py
@@ -1771,7 +1771,7 @@ def modal_main(
     hmm_train_start_date: str | None = None,
     hmm_max_iterations: int = 100,
     hmm_min_training_rows: int = 30,
-    tickers: Sequence[str] = (),
+    tickers: str = "",
 ) -> dict[str, object]:
     """Submit the single-date Layer 1 flow using stage-specific Modal runners."""
     if _modal_run_daily_layer1 is None:
@@ -2205,13 +2205,14 @@ def _load_completed_stage_output(
     return manifest.output_path
 
 
-def _normalize_ticker_scope(tickers: Sequence[object]) -> tuple[str, ...]:
+def _normalize_ticker_scope(tickers: str | Sequence[object]) -> tuple[str, ...]:
     """Return sorted uppercase ticker symbols for optional scoped stage runs."""
+    values: Sequence[object] = tickers.split(",") if isinstance(tickers, str) else tickers
     return tuple(
         sorted(
             {
                 str(ticker).strip().upper()
-                for ticker in tickers
+                for ticker in values
                 if str(ticker).strip()
             }
         )

--- a/app/lab/data_pipelines/run_finbert_sentiment.py
+++ b/app/lab/data_pipelines/run_finbert_sentiment.py
@@ -489,7 +489,7 @@ def modal_main(
     run_id: str,
     as_of_date: str,
     preprocessed_news_key: str,
-    tickers: Sequence[str] | None = None,
+    tickers: str = "",
     embedding_key: str | None = None,
     topic_label_key: str | None = None,
 ) -> None:
@@ -503,8 +503,7 @@ def modal_main(
         remote_kwargs["embedding_key"] = embedding_key
     if topic_label_key is not None:
         remote_kwargs["topic_label_key"] = topic_label_key
-    normalized_tickers = [str(ticker).strip().upper() for ticker in (tickers or ())]
-    normalized_tickers = [ticker for ticker in normalized_tickers if ticker]
+    normalized_tickers = sorted({ticker.strip().upper() for ticker in tickers.split(",") if ticker.strip()})
     if normalized_tickers:
         remote_kwargs["tickers"] = normalized_tickers
     globals()["modal_run_finbert_sentiment"].remote(**remote_kwargs)

--- a/app/lab/data_pipelines/run_news_preprocessing.py
+++ b/app/lab/data_pipelines/run_news_preprocessing.py
@@ -375,7 +375,7 @@ def modal_main(
     run_id: str,
     as_of_date: str,
     min_sentence_chars: int = 2,
-    tickers: Sequence[str] | None = None,
+    tickers: str = "",
 ) -> None:
     """Submit a news preprocessing run to Modal from the local CLI."""
     remote_kwargs: dict[str, object] = {
@@ -383,8 +383,7 @@ def modal_main(
         "as_of_date": as_of_date,
         "min_sentence_chars": min_sentence_chars,
     }
-    normalized_tickers = [str(ticker).strip().upper() for ticker in (tickers or ())]
-    normalized_tickers = [ticker for ticker in normalized_tickers if ticker]
+    normalized_tickers = sorted({ticker.strip().upper() for ticker in tickers.split(",") if ticker.strip()})
     if normalized_tickers:
         remote_kwargs["tickers"] = normalized_tickers
     globals()["modal_run_news_preprocessing"].remote(**remote_kwargs)

--- a/app/lab/data_pipelines/run_text_topics.py
+++ b/app/lab/data_pipelines/run_text_topics.py
@@ -518,7 +518,7 @@ def modal_main(
     run_id: str,
     as_of_date: str,
     preprocessed_news_key: str,
-    tickers: Sequence[str] | None = None,
+    tickers: str = "",
 ) -> None:
     """Submit a text-topic run to Modal from the local CLI."""
     remote_kwargs: dict[str, object] = {
@@ -526,8 +526,7 @@ def modal_main(
         "as_of_date": as_of_date,
         "preprocessed_news_key": preprocessed_news_key,
     }
-    normalized_tickers = [str(ticker).strip().upper() for ticker in (tickers or ())]
-    normalized_tickers = [ticker for ticker in normalized_tickers if ticker]
+    normalized_tickers = sorted({ticker.strip().upper() for ticker in tickers.split(",") if ticker.strip()})
     if normalized_tickers:
         remote_kwargs["tickers"] = normalized_tickers
     globals()["modal_run_text_topics"].remote(**remote_kwargs)

--- a/app/pi/run_layer0_layer1_refresh.py
+++ b/app/pi/run_layer0_layer1_refresh.py
@@ -40,8 +40,10 @@ _CREDENTIAL_QUERY_RE = re.compile(
     r"password|passwd|credential|signature|x-amz-credential|x-amz-signature|"
     r"x-amz-security-token)=)[^&#\s]+"
 )
-_URL_USERINFO_RE = re.compile(r"(?i)(https?://)([^/@\s]+)@")
-_SENSITIVE_ENV_RE = re.compile(r"(?i)(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|SIGNATURE)")
+_URL_USERINFO_RE = re.compile(r"(?i)([a-z][a-z0-9+.-]*://)([^/@\s?#]+)@")
+_SENSITIVE_ENV_RE = re.compile(
+    r"(?i)(?:^|[_-])(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|SIGNATURE)(?:$|[_-])"
+)
 
 
 class PipelineError(RuntimeError):

--- a/app/pi/run_layer0_layer1_refresh.py
+++ b/app/pi/run_layer0_layer1_refresh.py
@@ -1,0 +1,341 @@
+"""Holiday-aware, data-only Layer 0 to Layer 1 refresh for the Pi runtime."""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Any, Callable, Protocol, Sequence
+from zoneinfo import ZoneInfo
+
+from loguru import logger
+
+from core.common.trading_calendar import (
+    is_us_equity_trading_session,
+    previous_trading_day,
+    trading_dates,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+REPORT_RE = re.compile(
+    r"layer1_archive_validation_(?P<run_id>.+)_(?P<from>\d{4}-\d{2}-\d{2})_to_"
+    r"(?P<to>\d{4}-\d{2}-\d{2})\.json$"
+)
+LOCK_STALE_AFTER = timedelta(hours=6)
+ENV_NAMES = ("r2.env", "alpaca.env", "fred.env", "simfin.env")
+
+
+class PipelineError(RuntimeError):
+    """Raised when a refresh cannot safely complete."""
+
+
+class R2Client(Protocol):
+    """Small R2 surface required by this orchestrator."""
+
+    def list_keys(self, prefix: str) -> list[str]: ...
+    def get_object(self, key: str) -> bytes: ...
+    def exists(self, key: str) -> bool: ...
+
+
+@dataclass(frozen=True)
+class RefreshConfig:
+    """Filesystem, timeout, and environment configuration for one refresh."""
+
+    repo_root: Path = REPO_ROOT
+    home: Path = field(default_factory=Path.home)
+    log_dir: Path | None = None
+    lock_dir: Path | None = None
+    env_files: tuple[Path, ...] | None = None
+    max_days: int = 30
+    layer0_timeout: int = 7200
+    layer1_timeout: int = 21600
+    validator_timeout: int = 1800
+
+    def __post_init__(self) -> None:
+        if self.log_dir is None:
+            object.__setattr__(self, "log_dir", self.home / ".hermes" / "profiles" / "trading" / "logs" / "ai-stock-trader-data-pipeline")
+        if self.lock_dir is None:
+            object.__setattr__(self, "lock_dir", self.home / ".hermes" / "profiles" / "trading" / "state" / "ai-stock-trader-layer0-layer1-daily.lock")
+        if self.env_files is None:
+            object.__setattr__(self, "env_files", tuple(self.repo_root / "config" / name for name in ENV_NAMES))
+
+    @property
+    def effective_log_dir(self) -> Path:
+        """Return the configured log directory."""
+        assert self.log_dir is not None
+        return self.log_dir
+
+    @property
+    def effective_lock_dir(self) -> Path:
+        """Return the configured lock directory."""
+        assert self.lock_dir is not None
+        return self.lock_dir
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    """Result of one bounded subprocess invocation."""
+
+    command: list[str]
+    returncode: int
+    output_tail: str = ""
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    """Parse the stable refresh CLI options."""
+    parser = argparse.ArgumentParser(description="Refresh Layer 0 and Layer 1 data.")
+    parser.add_argument("--target-date")
+    parser.add_argument("--from-date")
+    parser.add_argument("--max-days", type=int, default=int(os.getenv("AI_STOCK_TRADER_MAX_DAILY_CATCHUP_DAYS", "30")))
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def load_env(config: RefreshConfig) -> dict[str, str]:
+    """Load repository env files without logging their values."""
+    env = os.environ.copy()
+    env["HOME"] = str(config.home)
+    env["PYTHONPATH"] = str(config.repo_root) + (os.pathsep + env["PYTHONPATH"] if env.get("PYTHONPATH") else "")
+    env["AI_STOCK_TRADER_REPO_ROOT"] = str(config.repo_root)
+    for path in config.env_files or ():
+        if not path.exists():
+            continue
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            key = key.strip()
+            if key:
+                env[key] = value.strip().strip('"').strip("'")
+    return env
+
+
+def _pid_is_active(pid: int) -> bool:
+    """Return whether a process id is live and not a zombie."""
+    try:
+        stat = Path(f"/proc/{pid}/stat")
+        if stat.exists() and len(stat.read_text().split()) >= 3 and stat.read_text().split()[2] == "Z":
+            return False
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+def _lock_detail(lock_dir: Path) -> str:
+    """Read lock metadata for diagnostics without exposing environment values."""
+    info = lock_dir / "info.txt"
+    return info.read_text(encoding="utf-8") if info.exists() else "no lock info"
+
+
+def _lock_pid(detail: str) -> int | None:
+    """Extract a recorded PID from lock metadata."""
+    for line in detail.splitlines():
+        if line.startswith("pid="):
+            try:
+                return int(line.split("=", 1)[1])
+            except ValueError:
+                return None
+    return None
+
+
+def acquire_lock(config: RefreshConfig) -> None:
+    """Acquire the stale-aware single-run lock."""
+    lock_dir = config.effective_lock_dir
+    lock_dir.parent.mkdir(parents=True, exist_ok=True)
+    while True:
+        try:
+            lock_dir.mkdir()
+            (lock_dir / "info.txt").write_text(
+                f"owner=os-cron\nstarted_at={datetime.now().isoformat()}\npid={os.getpid()}\n",
+                encoding="utf-8",
+            )
+            return
+        except FileExistsError as exc:
+            detail = _lock_detail(lock_dir)
+            pid = _lock_pid(detail)
+            if pid is not None:
+                stale = not _pid_is_active(pid)
+                reason = f"recorded pid {pid} is not active" if stale else f"recorded pid {pid} is still active"
+            else:
+                try:
+                    stale = datetime.now() - datetime.fromtimestamp(lock_dir.stat().st_mtime) > LOCK_STALE_AFTER
+                except OSError:
+                    stale = True
+                reason = "lock has no recorded pid and is stale" if stale else "lock has no recorded pid but is recent"
+            if not stale:
+                raise PipelineError(f"another refresh is already running ({reason})") from exc
+            try:
+                shutil.rmtree(lock_dir)
+            except OSError as cleanup_exc:
+                logger.error("stale refresh lock cleanup failed: {}", type(cleanup_exc).__name__)
+                raise PipelineError("stale refresh lock cleanup failed") from cleanup_exc
+            logger.warning("removed stale refresh lock: {}", reason)
+
+
+def release_lock(config: RefreshConfig) -> None:
+    """Release the run lock and log cleanup failures."""
+    lock_dir = config.effective_lock_dir
+    try:
+        shutil.rmtree(lock_dir)
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.error("refresh lock cleanup failed: {}", type(exc).__name__)
+
+
+def install_signal_handlers(config: RefreshConfig) -> None:
+    """Ensure termination signals release the lock before exiting."""
+    def handle(signum: int, _frame: object) -> None:
+        release_lock(config)
+        raise SystemExit(128 + signum)
+    signal.signal(signal.SIGTERM, handle)
+    signal.signal(signal.SIGINT, handle)
+
+
+def latest_target(now: datetime | None = None) -> str:
+    """Return the latest eligible regular session in New York time."""
+    current = (now or datetime.now(ZoneInfo("America/New_York"))).astimezone(ZoneInfo("America/New_York"))
+    today = current.date()
+    if current.hour < 18 or not is_us_equity_trading_session(today):
+        return previous_trading_day(today.isoformat())
+    return today.isoformat()
+
+
+def ready_reports(client: R2Client) -> dict[str, dict[str, Any]]:
+    """Return only durable validation reports explicitly ready for Layer 2."""
+    reports: dict[str, dict[str, Any]] = {}
+    for key in client.list_keys("artifacts/reports/integration/"):
+        match = REPORT_RE.search(Path(key).name)
+        if match is None:
+            continue
+        try:
+            payload = json.loads(client.get_object(key).decode("utf-8"))
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError):
+            continue
+        if payload.get("ready_for_layer2") is not True:
+            continue
+        target = str(payload.get("to_date") or match.group("to"))
+        if target not in reports or str(payload.get("manifest_finished_at", "")) > str(reports[target].get("manifest_finished_at", "")):
+            payload["report_key"] = key
+            reports[target] = payload
+    return reports
+
+
+def build_plan(start: str, target: str, ready: set[str], max_days: int) -> tuple[list[str], list[str], list[str]]:
+    """Build valid sessions, skipped requested dates, and max-day remainder."""
+    if date.fromisoformat(start) > date.fromisoformat(target):
+        return [], [], []
+    all_dates = trading_dates(start, target)
+    cursor = date.fromisoformat(start)
+    end = date.fromisoformat(target)
+    skipped: list[str] = []
+    while cursor <= end:
+        if not is_us_equity_trading_session(cursor):
+            skipped.append(cursor.isoformat())
+        cursor += timedelta(days=1)
+    missing = [day for day in all_dates if day not in ready]
+    selected = missing if max_days <= 0 else missing[:max_days]
+    return selected, skipped, missing[len(selected):]
+
+
+def run_command(command: list[str], env: dict[str, str], config: RefreshConfig, log_path: Path, timeout: int) -> CommandResult:
+    """Run one command with a watchdog and append output to the run log."""
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    with log_path.open("a", encoding="utf-8") as log:
+        log.write("\n$ " + " ".join(command) + f"\n[timeout_seconds={timeout}]\n")
+        try:
+            proc = subprocess.run(command, cwd=config.repo_root, env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout)
+            output = proc.stdout or ""
+            code = proc.returncode
+        except subprocess.TimeoutExpired as exc:
+            raw_output = exc.stdout or ""
+            output = raw_output.decode(errors="replace") if isinstance(raw_output, bytes) else raw_output
+            output += f"\ncommand timed out after {timeout} seconds\n"
+            code = 124
+        log.write(output)
+        log.write(f"\n[exit_code={code}]\n")
+    return CommandResult(command, code, "\n".join(output.splitlines()[-40:]))
+
+
+def _commands(config: RefreshConfig, day: str) -> tuple[list[str], list[str], list[str]]:
+    """Construct the exact three commands for one session."""
+    layer0 = f"layer0-daily-{day}"
+    layer1 = f"layer1-daily-{day}"
+    python = str(config.repo_root / ".venv/bin/python")
+    modal = str(config.repo_root / ".venv/bin/modal")
+    return (
+        [python, "app/lab/data_pipelines/backfill_layer0.py", "--from-date", day, "--to-date", day, "--run-id", layer0],
+        [modal, "run", "app/lab/data_pipelines/run_daily_layer1.py::app.modal_main", "--run-id", layer1, "--as-of-date", day, "--layer0-run-id", layer0],
+        [python, "app/lab/data_pipelines/validate_layer1_archive.py", "--run-id", layer1, "--from-date", day, "--to-date", day, "--use-r2-universe"],
+    )
+
+
+def verify_ready(client: R2Client, day: str) -> dict[str, Any]:
+    """Require the exact durable report for a completed session."""
+    run_id = f"layer1-daily-{day}"
+    key = f"artifacts/reports/integration/layer1_archive_validation_{run_id}_{day}_to_{day}.json"
+    if not client.exists(key):
+        raise PipelineError("missing final Layer 1 validation report")
+    try:
+        payload = json.loads(client.get_object(key).decode("utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
+        raise PipelineError("final Layer 1 validation report is unreadable") from exc
+    if payload.get("ready_for_layer2") is not True:
+        raise PipelineError("final Layer 1 validation report is not ready")
+    return payload
+
+
+def refresh(args: argparse.Namespace, config: RefreshConfig, client_factory: Callable[[dict[str, str]], R2Client], now: datetime | None = None) -> int:
+    """Execute or dry-run a bounded, fail-closed refresh plan."""
+    env = load_env(config)
+    client = client_factory(env)
+    ready = ready_reports(client)
+    target = args.target_date or latest_target(now)
+    start = args.from_date or (max(ready) if ready else target)
+    if not args.from_date and ready:
+        start = (date.fromisoformat(start) + timedelta(days=1)).isoformat()
+    selected, skipped, remaining = build_plan(start, target, set(ready), args.max_days)
+    logger.info("Layer 0->1 refresh target={} skipped={} sessions={} remaining={}", target, skipped, selected, remaining)
+    if args.dry_run or not selected:
+        return 0
+    log_path = config.effective_log_dir / f"refresh-{datetime.now().strftime('%Y%m%d-%H%M%S')}.log"
+    for day in selected:
+        for command, timeout in zip(_commands(config, day), (config.layer0_timeout, config.layer1_timeout, config.validator_timeout)):
+            result = run_command(command, env, config, log_path, timeout)
+            if result.returncode != 0:
+                raise PipelineError(f"refresh command failed for {day} with exit code {result.returncode}")
+        verify_ready(client_factory(env), day)
+        logger.info("completed {} with ready_for_layer2=true", day)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CLI with lock and fail-closed error handling."""
+    args = parse_args(argv)
+    config = RefreshConfig(max_days=args.max_days)
+    install_signal_handlers(config)
+    acquire_lock(config)
+    try:
+        from services.r2.client import CloudflareR2Client
+        return refresh(args, config, lambda _env: CloudflareR2Client.from_env())
+    finally:
+        release_lock(config)
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except PipelineError as exc:
+        logger.error("Layer 0->1 refresh failed: {}", exc)
+        raise SystemExit(1) from exc

--- a/app/pi/run_layer0_layer1_refresh.py
+++ b/app/pi/run_layer0_layer1_refresh.py
@@ -35,6 +35,13 @@ TIMEOUT_ENV_NAMES = (
     "AI_STOCK_TRADER_LAYER1_COMMAND_TIMEOUT_SECONDS",
     "AI_STOCK_TRADER_VALIDATE_COMMAND_TIMEOUT_SECONDS",
 )
+_CREDENTIAL_QUERY_RE = re.compile(
+    r"(?i)([?&](?:token|api[-_]key|apikey|access[-_]key(?:[-_]id)?|secret(?:[-_]access[-_]key)?|"
+    r"password|passwd|credential|signature|x-amz-credential|x-amz-signature|"
+    r"x-amz-security-token)=)[^&#\s]+"
+)
+_URL_USERINFO_RE = re.compile(r"(?i)(https?://)([^/@\s]+)@")
+_SENSITIVE_ENV_RE = re.compile(r"(?i)(?:TOKEN|KEY|SECRET|PASSWORD|PASSWD|CREDENTIAL|SIGNATURE)")
 
 
 class PipelineError(RuntimeError):
@@ -281,11 +288,21 @@ def build_plan(start: str, target: str, ready: set[str], max_days: int) -> tuple
     return selected, skipped, missing[len(selected):]
 
 
+def _sanitize_output(value: str, env: dict[str, str]) -> str:
+    """Redact URL credentials and inherited credential values from child output."""
+    sanitized = _URL_USERINFO_RE.sub(r"\1<redacted>@", value)
+    sanitized = _CREDENTIAL_QUERY_RE.sub(r"\1<redacted>", sanitized)
+    secrets = {raw for name, raw in env.items() if _SENSITIVE_ENV_RE.search(name) and len(raw) >= 4}
+    for secret in sorted(secrets, key=len, reverse=True):
+        sanitized = sanitized.replace(secret, "<redacted>")
+    return sanitized
+
+
 def run_command(command: list[str], env: dict[str, str], config: RefreshConfig, log_path: Path, timeout: int) -> CommandResult:
     """Run one command with a watchdog and append output to the run log."""
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a", encoding="utf-8") as log:
-        log.write("\n$ " + " ".join(command) + f"\n[timeout_seconds={timeout}]\n")
+        log.write("\n$ " + _sanitize_output(" ".join(command), env) + f"\n[timeout_seconds={timeout}]\n")
         try:
             proc = subprocess.run(command, cwd=config.repo_root, env=env, text=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, timeout=timeout)
             output = proc.stdout or ""
@@ -295,6 +312,7 @@ def run_command(command: list[str], env: dict[str, str], config: RefreshConfig, 
             output = raw_output.decode(errors="replace") if isinstance(raw_output, bytes) else raw_output
             output += f"\ncommand timed out after {timeout} seconds\n"
             code = 124
+        output = _sanitize_output(output, env)
         log.write(output)
         log.write(f"\n[exit_code={code}]\n")
     return CommandResult(command, code, "\n".join(output.splitlines()[-40:]))
@@ -348,8 +366,19 @@ def refresh(args: argparse.Namespace, config: RefreshConfig, client_factory: Cal
     client = client_factory(env)
     ready = ready_reports(client)
     target = args.target_date or latest_target(now)
-    start = args.from_date or (max(ready) if ready else target)
-    if not args.from_date and ready:
+    if args.from_date:
+        start = args.from_date
+    elif not ready:
+        start = target
+    else:
+        ready_dates = sorted(ready)
+        missing_frontier = sorted(set(trading_dates(ready_dates[0], ready_dates[-1])) - set(ready_dates))
+        if missing_frontier:
+            raise PipelineError(
+                "default ready history is non-contiguous; missing regular sessions: "
+                + ", ".join(missing_frontier)
+            )
+        start = ready_dates[-1]
         start = (date.fromisoformat(start) + timedelta(days=1)).isoformat()
     selected, skipped, remaining = build_plan(start, target, set(ready), args.max_days)
     logger.info("Layer 0->1 refresh target={} skipped={} sessions={} remaining={}", target, skipped, selected, remaining)

--- a/app/pi/run_layer0_layer1_refresh.py
+++ b/app/pi/run_layer0_layer1_refresh.py
@@ -8,11 +8,11 @@ import re
 import shutil
 import signal
 import subprocess
-import sys
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from pathlib import Path
-from typing import Any, Callable, Protocol, Sequence
+from typing import Any, Protocol
 from zoneinfo import ZoneInfo
 
 from loguru import logger
@@ -30,6 +30,11 @@ REPORT_RE = re.compile(
 )
 LOCK_STALE_AFTER = timedelta(hours=6)
 ENV_NAMES = ("r2.env", "alpaca.env", "fred.env", "simfin.env")
+TIMEOUT_ENV_NAMES = (
+    "AI_STOCK_TRADER_LAYER0_COMMAND_TIMEOUT_SECONDS",
+    "AI_STOCK_TRADER_LAYER1_COMMAND_TIMEOUT_SECONDS",
+    "AI_STOCK_TRADER_VALIDATE_COMMAND_TIMEOUT_SECONDS",
+)
 
 
 class PipelineError(RuntimeError):
@@ -149,6 +154,25 @@ def _lock_pid(detail: str) -> int | None:
     return None
 
 
+def _timeouts(config: RefreshConfig) -> tuple[int, int, int]:
+    """Resolve positive command timeout overrides without exposing values."""
+    defaults = (config.layer0_timeout, config.layer1_timeout, config.validator_timeout)
+    resolved: list[int] = []
+    for name, default in zip(TIMEOUT_ENV_NAMES, defaults):
+        raw = os.getenv(name)
+        if raw is None:
+            resolved.append(default)
+            continue
+        try:
+            value = int(raw)
+        except ValueError as exc:
+            raise PipelineError(f"invalid timeout configuration for {name}") from exc
+        if value <= 0:
+            raise PipelineError(f"invalid timeout configuration for {name}")
+        resolved.append(value)
+    return (resolved[0], resolved[1], resolved[2])
+
+
 def acquire_lock(config: RefreshConfig) -> None:
     """Acquire the stale-aware single-run lock."""
     lock_dir = config.effective_lock_dir
@@ -164,15 +188,16 @@ def acquire_lock(config: RefreshConfig) -> None:
         except FileExistsError as exc:
             detail = _lock_detail(lock_dir)
             pid = _lock_pid(detail)
-            if pid is not None:
-                stale = not _pid_is_active(pid)
-                reason = f"recorded pid {pid} is not active" if stale else f"recorded pid {pid} is still active"
-            else:
+            if pid is None:
                 try:
-                    stale = datetime.now() - datetime.fromtimestamp(lock_dir.stat().st_mtime) > LOCK_STALE_AFTER
-                except OSError:
-                    stale = True
-                reason = "lock has no recorded pid and is stale" if stale else "lock has no recorded pid but is recent"
+                    age = datetime.now() - datetime.fromtimestamp(lock_dir.stat().st_mtime)
+                except OSError as stat_exc:
+                    raise PipelineError("refresh lock metadata is malformed or unsafe") from stat_exc
+                if age <= LOCK_STALE_AFTER:
+                    raise PipelineError("another refresh is already running (lock metadata is incomplete)") from exc
+                raise PipelineError("refresh lock metadata is malformed or unsafe") from exc
+            stale = not _pid_is_active(pid)
+            reason = f"recorded pid {pid} is not active" if stale else f"recorded pid {pid} is still active"
             if not stale:
                 raise PipelineError(f"another refresh is already running ({reason})") from exc
             try:
@@ -184,7 +209,7 @@ def acquire_lock(config: RefreshConfig) -> None:
 
 
 def release_lock(config: RefreshConfig) -> None:
-    """Release the run lock and log cleanup failures."""
+    """Release the run lock, failing when cleanup cannot be confirmed."""
     lock_dir = config.effective_lock_dir
     try:
         shutil.rmtree(lock_dir)
@@ -192,6 +217,7 @@ def release_lock(config: RefreshConfig) -> None:
         return
     except OSError as exc:
         logger.error("refresh lock cleanup failed: {}", type(exc).__name__)
+        raise PipelineError("refresh lock cleanup failed") from exc
 
 
 def install_signal_handlers(config: RefreshConfig) -> None:
@@ -223,9 +249,15 @@ def ready_reports(client: R2Client) -> dict[str, dict[str, Any]]:
             payload = json.loads(client.get_object(key).decode("utf-8"))
         except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError):
             continue
-        if payload.get("ready_for_layer2") is not True:
+        if (
+            not isinstance(payload, dict)
+            or payload.get("ready_for_layer2") is not True
+            or payload.get("run_id") != match.group("run_id")
+            or payload.get("from_date") != match.group("from")
+            or payload.get("to_date") != match.group("to")
+        ):
             continue
-        target = str(payload.get("to_date") or match.group("to"))
+        target = match.group("to")
         if target not in reports or str(payload.get("manifest_finished_at", "")) > str(reports[target].get("manifest_finished_at", "")):
             payload["report_key"] = key
             reports[target] = payload
@@ -291,14 +323,28 @@ def verify_ready(client: R2Client, day: str) -> dict[str, Any]:
         payload = json.loads(client.get_object(key).decode("utf-8"))
     except (OSError, UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
         raise PipelineError("final Layer 1 validation report is unreadable") from exc
-    if payload.get("ready_for_layer2") is not True:
+    if (
+        not isinstance(payload, dict)
+        or payload.get("ready_for_layer2") is not True
+        or payload.get("run_id") != run_id
+        or payload.get("from_date") != day
+        or payload.get("to_date") != day
+    ):
         raise PipelineError("final Layer 1 validation report is not ready")
     return payload
 
 
 def refresh(args: argparse.Namespace, config: RefreshConfig, client_factory: Callable[[dict[str, str]], R2Client], now: datetime | None = None) -> int:
     """Execute or dry-run a bounded, fail-closed refresh plan."""
+    timeouts = _timeouts(config)
     env = load_env(config)
+    if args.dry_run:
+        if args.from_date is None:
+            raise PipelineError("dry-run requires explicit --from-date to avoid durable R2 discovery")
+        target = args.target_date or latest_target(now)
+        selected, skipped, remaining = build_plan(args.from_date, target, set(), args.max_days)
+        logger.info("Layer 0->1 dry-run target={} skipped={} sessions={} remaining={}", target, skipped, selected, remaining)
+        return 0
     client = client_factory(env)
     ready = ready_reports(client)
     target = args.target_date or latest_target(now)
@@ -307,11 +353,11 @@ def refresh(args: argparse.Namespace, config: RefreshConfig, client_factory: Cal
         start = (date.fromisoformat(start) + timedelta(days=1)).isoformat()
     selected, skipped, remaining = build_plan(start, target, set(ready), args.max_days)
     logger.info("Layer 0->1 refresh target={} skipped={} sessions={} remaining={}", target, skipped, selected, remaining)
-    if args.dry_run or not selected:
+    if not selected:
         return 0
     log_path = config.effective_log_dir / f"refresh-{datetime.now().strftime('%Y%m%d-%H%M%S')}.log"
     for day in selected:
-        for command, timeout in zip(_commands(config, day), (config.layer0_timeout, config.layer1_timeout, config.validator_timeout)):
+        for command, timeout in zip(_commands(config, day), timeouts):
             result = run_command(command, env, config, log_path, timeout)
             if result.returncode != 0:
                 raise PipelineError(f"refresh command failed for {day} with exit code {result.returncode}")
@@ -325,12 +371,23 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = parse_args(argv)
     config = RefreshConfig(max_days=args.max_days)
     install_signal_handlers(config)
+    if args.dry_run:
+        return refresh(args, config, lambda _env: (_ for _ in ()).throw(PipelineError("dry-run R2 access")))
     acquire_lock(config)
+    primary: BaseException | None = None
     try:
         from services.r2.client import CloudflareR2Client
         return refresh(args, config, lambda _env: CloudflareR2Client.from_env())
+    except BaseException as exc:
+        primary = exc
+        raise
     finally:
-        release_lock(config)
+        try:
+            release_lock(config)
+        except PipelineError:
+            if primary is None:
+                raise
+            logger.error("refresh lock cleanup failed after primary failure")
 
 
 if __name__ == "__main__":

--- a/core/data/layer0_pipeline.py
+++ b/core/data/layer0_pipeline.py
@@ -515,7 +515,14 @@ def run_historical_layer0_backfill(
             metadata=metadata,
         )
     except Exception as exc:
-        logger.exception("Layer 0 historical backfill failed: {}", exc)
+        sanitized_message = _sanitize_error_message(str(exc))
+        try:
+            sanitized_exc = type(exc)(sanitized_message)
+        except Exception:
+            sanitized_exc = Exception(sanitized_message)
+        logger.opt(exception=(type(sanitized_exc), sanitized_exc, exc.__traceback__)).error(
+            "Layer 0 historical backfill failed: {}", sanitized_message
+        )
         manifest_key = _write_failure_manifest(
             writer=cached_writer,
             run_id=run_id,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,6 +70,14 @@ The design principle is:
 - long-only execution first, with contracts and risk policy kept compatible with later
   hedge overlays and long-short expansion
 
+### Pi data-only refresh entrypoint
+
+The version-controlled `app/pi/run_layer0_layer1_refresh.py` is the bounded Pi cron
+orchestrator for catching up Layer 0 and Layer 1 archives without entering Layer 2 or
+later trading stages. It selects only regular US equity sessions using
+`core.common.trading_calendar`, applies the New York 18:00 readiness cutoff, and fails
+closed unless each date has its durable `ready_for_layer2=true` validation report.
+
 ---
 
 ## Portfolio posture and expansion roadmap

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -45,6 +45,20 @@ Expected execution chain:
 6. Pi runtime waits on the Layer 1 manifest in R2 before continuing to inference
 7. Runtime emits deterministic manifests and reports
 
+### Nightly data-only refresh command
+
+After integration, the Pi wrapper should execute from the repository root:
+
+```bash
+./.venv/bin/python app/pi/run_layer0_layer1_refresh.py
+```
+
+`--target-date`, `--from-date`, `--max-days`, and `--dry-run` are supported for bounded
+operations. The command loads the four repository env files without logging values,
+holds a stale-aware lock, and uses 7200s, 21600s, and 1800s watchdog defaults for Layer
+0, Modal Layer 1, and validation respectively. It must be dry-run tested before any
+production catch-up; it does not invoke Layer 2+, broker execution, or dashboard stages.
+
 ## Baseline rollout order
 
 1. Build and validate the complete Layer 0 historical backfill in R2:

--- a/docs/runtime_flow.md
+++ b/docs/runtime_flow.md
@@ -63,6 +63,15 @@ consume their R2 outputs.
 
 ## Phase 1 - Daily loop (automated, Pi cron)
 
+For the data-only nightly refresh or bounded catch-up, Pi cron invokes
+`./.venv/bin/python app/pi/run_layer0_layer1_refresh.py`. The entrypoint ignores weekends
+and full-day US equity holidays (including Juneteenth), uses the prior regular session
+before 18:00 America/New_York, and logs skipped dates, selected sessions, and any
+max-days remainder. It runs Layer 0, the Modal Layer 1 app, and archive validation in
+that order for one session at a time. A nonzero/timeout command or missing, unreadable,
+false, or wrong-date durable validation report stops the refresh and leaves that date
+incomplete; it never silently advances to another date.
+
 Execution chain:
 1. Cron starts the Pi runtime container on the host.
 2. OpenClaw/Hermes runs the Pi daily entrypoint inside that container.

--- a/requirements/modal.txt
+++ b/requirements/modal.txt
@@ -6,10 +6,7 @@
 -r base.txt
 
 # Modal SDK — for defining and running cloud jobs
-modal>=0.64,<1
-# Modal 0.77 runs on Click 8.1; Typer 0.16+ is outside this project's verified ceiling,
-# while 0.26+ also vendors a distinct Click exception hierarchy.
-typer>=0.9,<0.16
+modal>=1.5,<2
 
 # Data handling
 pandas>=2.2,<3

--- a/requirements/modal.txt
+++ b/requirements/modal.txt
@@ -7,8 +7,9 @@
 
 # Modal SDK — for defining and running cloud jobs
 modal>=0.64,<1
-# Typer 0.26+ vendors a distinct Click exception hierarchy incompatible with Modal 0.77 generated commands.
-typer>=0.9,<0.26
+# Modal 0.77 runs on Click 8.1; Typer 0.16+ is outside this project's verified ceiling,
+# while 0.26+ also vendors a distinct Click exception hierarchy.
+typer>=0.9,<0.16
 
 # Data handling
 pandas>=2.2,<3

--- a/requirements/modal.txt
+++ b/requirements/modal.txt
@@ -7,6 +7,8 @@
 
 # Modal SDK — for defining and running cloud jobs
 modal>=0.64,<1
+# Typer 0.26+ vendors a distinct Click exception hierarchy incompatible with Modal 0.77 generated commands.
+typer>=0.9,<0.26
 
 # Data handling
 pandas>=2.2,<3

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -13,8 +13,7 @@ polygon-api-client>=1.14,<2
 
 # Object storage — Cloudflare R2 (S3-compatible)
 boto3>=1.35,<2
-modal>=0.64,<1         # lightweight client/CLI used to submit Layer 1 jobs to Modal
-typer>=0.9,<0.16       # Modal 0.77 uses Click 8.1; Typer 0.16+ is outside the verified ceiling, and 0.26+ vendors a distinct Click hierarchy
+modal>=1.5,<2          # lightweight client/CLI used to submit Layer 1 jobs to Modal
 
 # Data handling
 pandas>=2.2,<3

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -14,7 +14,7 @@ polygon-api-client>=1.14,<2
 # Object storage — Cloudflare R2 (S3-compatible)
 boto3>=1.35,<2
 modal>=0.64,<1         # lightweight client/CLI used to submit Layer 1 jobs to Modal
-typer>=0.9,<0.26       # Typer 0.26+ vendors Click exceptions incompatible with Modal 0.77 generated commands
+typer>=0.9,<0.16       # Modal 0.77 uses Click 8.1; Typer 0.16+ is outside the verified ceiling, and 0.26+ vendors a distinct Click hierarchy
 
 # Data handling
 pandas>=2.2,<3

--- a/requirements/pi.txt
+++ b/requirements/pi.txt
@@ -14,6 +14,7 @@ polygon-api-client>=1.14,<2
 # Object storage — Cloudflare R2 (S3-compatible)
 boto3>=1.35,<2
 modal>=0.64,<1         # lightweight client/CLI used to submit Layer 1 jobs to Modal
+typer>=0.9,<0.26       # Typer 0.26+ vendors Click exceptions incompatible with Modal 0.77 generated commands
 
 # Data handling
 pandas>=2.2,<3

--- a/services/r2/client.py
+++ b/services/r2/client.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import os
+from collections.abc import Iterable
 from io import BytesIO
 from pathlib import Path
-from typing import Protocol
+from typing import Protocol, TypedDict
 
 from dotenv import load_dotenv
 
@@ -28,10 +29,48 @@ class ReadableBody(Protocol):
         """Read the full object body."""
 
 
+class ObjectStorePage(TypedDict, total=False):
+    """Subset of a list-objects page consumed by this wrapper."""
+
+    Contents: list[dict[str, object]]
+
+
+class ObjectStorePaginator(Protocol):
+    """Protocol for the boto paginator used to enumerate object keys."""
+
+    def paginate(self, **kwargs: str) -> Iterable[ObjectStorePage]:
+        """Return pages for a bucket/prefix listing."""
+        ...
+
+
+class ObjectStoreClient(Protocol):
+    """Minimal boto-style client surface used by the R2 wrapper."""
+
+    def put_object(self, **kwargs: object) -> object:
+        """Store an object."""
+        ...
+
+    def get_object(self, **kwargs: str) -> dict[str, ReadableBody]:
+        """Retrieve an object response."""
+        ...
+
+    def delete_object(self, **kwargs: str) -> object:
+        """Delete an object."""
+        ...
+
+    def head_object(self, **kwargs: str) -> object:
+        """Read object metadata."""
+        ...
+
+    def get_paginator(self, operation_name: str) -> ObjectStorePaginator:
+        """Return an object listing paginator."""
+        ...
+
+
 class CloudflareR2Client:
     """Thin Cloudflare R2 client wrapper over boto3."""
 
-    def __init__(self, bucket_name: str, s3_client: object) -> None:
+    def __init__(self, bucket_name: str, s3_client: ObjectStoreClient) -> None:
         """Store the configured bucket and boto-compatible client."""
         self.bucket_name = bucket_name
         self._client = s3_client
@@ -132,7 +171,7 @@ def _build_s3_client(
     endpoint_url: str,
     access_key_id: str,
     secret_access_key: str,
-) -> object:
+) -> ObjectStoreClient:
     """Build the boto3 S3 client used for Cloudflare R2 access."""
     try:
         import boto3

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Repository-owned test package."""

--- a/tests/unit/test_layer0_pipeline.py
+++ b/tests/unit/test_layer0_pipeline.py
@@ -8,6 +8,8 @@ from datetime import date, datetime
 from typing import Any
 
 import pytest
+from loguru import logger
+from requests import HTTPError
 
 from core.contracts.schemas import OHLCVRecord, RunStatus
 from core.data.layer0_pipeline import (
@@ -225,6 +227,15 @@ class _EmptyFundamentalsFetcher:
             }
         )
         return []
+
+
+class _FailingMacroFetcher:
+    """Macro fetcher that raises a provider-style URL error."""
+
+    def fetch_all_macro_observations(self, **kwargs: object) -> list[dict[str, object]]:
+        raise HTTPError(
+            "GET https://fred.test/series?api_key=" + "synthetic-" + "secret" + "&series_id=DGS10"
+        )
 
 
 class _MacroFetcher:
@@ -1545,3 +1556,44 @@ def test_layer0_config_rejects_empty_inputs() -> None:
             to_date=date(2024, 1, 3),
             fred_series_ids=(),
         )
+
+
+def test_historical_backfill_redacts_provider_key_in_log_and_manifest() -> None:
+    """Historical provider failures preserve traceback while redacting URL secrets."""
+    writer = _Writer()
+    messages: list[str] = []
+    handler_id = logger.add(lambda message: messages.append(str(message)))
+    try:
+        with pytest.raises(HTTPError, match="synthetic-secret"):
+            run_historical_layer0_backfill(
+                config=HistoricalLayer0Config(
+                    from_date=date(2024, 1, 2),
+                    to_date=date(2024, 1, 2),
+                    fred_series_ids=("DGS10",),
+                    run_id="redaction-test",
+                    quality_config=QualityFilterConfig(rolling_window_days=1),
+                ),
+                universe_provider=_UniverseProvider(),
+                price_fetcher=_HistoricalPriceFetcher(),
+                security_master=_SecurityMaster(),
+                news_fetcher=_NewsFetcher(),
+                fundamentals_fetcher=_FundamentalsFetcher(),
+                macro_fetcher=_FailingMacroFetcher(),
+                writer=writer,
+                price_serializer=_bytes_serializer,
+                price_deserializer=_bytes_deserializer,
+                news_serializer=_bytes_serializer,
+                fundamentals_serializer=_bytes_serializer,
+                macro_serializer=_bytes_serializer,
+            )
+    finally:
+        logger.remove(handler_id)
+    logged = "".join(messages)
+    assert "synthetic-secret" not in logged
+    assert "<redacted>" in logged
+    manifest = json.loads(writer.get_object(pipeline_manifest_path("layer0", "redaction-test")))
+    assert manifest["status"] == RunStatus.FAILED
+    assert manifest["metadata"]["error"] == {
+        "type": "HTTPError",
+        "message": "GET https://fred.test/series?api_key=<redacted>&series_id=DGS10",
+    }

--- a/tests/unit/test_modal_runner_entrypoints.py
+++ b/tests/unit/test_modal_runner_entrypoints.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+import importlib.metadata
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -738,16 +739,79 @@ def test_daily_ticker_scope_normalizes_comma_separated_input() -> None:
     assert run_daily_layer1._normalize_ticker_scope(" aapl,MSFT, aapl , ") == ("AAPL", "MSFT")
 
 
-def test_modal_and_pi_requirements_pin_compatible_typer_range() -> None:
-    """Modal and Pi dependency surfaces use the same Modal-compatible Typer range."""
+def test_modal_and_pi_requirements_use_supported_modal_sdk_without_direct_typer() -> None:
+    """Modal and Pi dependency surfaces share the supported SDK contract."""
     repo_root = Path(__file__).resolve().parents[2]
-    expected_constraint = "typer>=0.9,<0.16"
-
-    constraints = []
     for requirements_name in ("requirements/modal.txt", "requirements/pi.txt"):
         requirements = (repo_root / requirements_name).read_text(encoding="utf-8").splitlines()
-        constraints.append(
-            [line.split("#", 1)[0].strip() for line in requirements if line.strip().startswith("typer")]
-        )
+        active_requirements = [line.split("#", 1)[0].strip() for line in requirements]
+        assert "modal>=1.5,<2" in active_requirements
+        assert not any(line.lower().startswith("typer") for line in active_requirements)
 
-    assert constraints == [[expected_constraint], [expected_constraint]]
+
+@pytest.mark.parametrize(
+    ("module", "args", "remote_name"),
+    [
+        (run_news_preprocessing, ("real-news", "2024-01-02", 2, " aapl,MSFT, aapl , "), "modal_run_news_preprocessing"),
+        (run_text_topics, ("real-topics", "2024-01-02", "input", " aapl,MSFT, aapl , "), "modal_run_text_topics"),
+        (run_finbert_sentiment, ("real-finbert", "2024-01-02", "input", " aapl,MSFT, aapl , "), "modal_run_finbert_sentiment"),
+        (run_hmm_regime_detection, ("real-hmm", "2024-01-31", "2024-02-01", None, " aapl ", 10, 5), "modal_run_hmm_regime_detection"),
+    ],
+)
+def test_real_modal_sdk_registers_layer1_entrypoints_without_remote_side_effects(
+    monkeypatch: pytest.MonkeyPatch, module, args: tuple[object, ...], remote_name: str
+) -> None:
+    """The resolved Modal SDK registers each stage and scopes its local CLI safely."""
+    pytest.importorskip("modal")
+    app = module._define_modal_app()
+    assert app is not None
+    assert "modal_main" in getattr(app, "registered_entrypoints")
+
+    calls: list[dict[str, object]] = []
+
+    class _NoRemote:
+        def remote(self, **kwargs: object) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr(module, remote_name, _NoRemote())
+    module.modal_main(*args)
+    assert calls
+    if module is run_hmm_regime_detection:
+        assert calls[-1]["benchmark_ticker"] == "AAPL"
+    else:
+        assert calls[-1]["tickers"] == ["AAPL", "MSFT"]
+
+
+def test_real_modal_sdk_registers_daily_layer1_entrypoint_without_remote_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The resolved Modal SDK registers the daily CLI and accepts a ticker scope."""
+    pytest.importorskip("modal")
+    app = run_daily_layer1._define_modal_app()
+    assert app is not None
+    assert "modal_main" in getattr(app, "registered_entrypoints")
+
+    calls: list[dict[str, object]] = []
+
+    class _NoRemote:
+        def remote(self, **kwargs: object) -> None:
+            calls.append(kwargs)
+
+    monkeypatch.setattr(run_daily_layer1, "_modal_run_batched_layer1", _NoRemote())
+    run_daily_layer1.modal_range_main(
+        "real-daily",
+        "2024-01-02",
+        "2024-01-03",
+        "layer0",
+        tickers=(" aapl ", "MSFT", " aapl "),
+    )
+    assert calls[-1]["tickers"] == ["AAPL", "MSFT"]
+
+
+def test_real_modal_dependency_versions_are_supported() -> None:
+    """The compatibility test runs against Modal 1.5.x and its Click dependency."""
+    pytest.importorskip("modal")
+    modal_version = importlib.metadata.version("modal")
+    click_version = importlib.metadata.version("click")
+    assert modal_version.startswith("1.5.")
+    assert click_version

--- a/tests/unit/test_modal_runner_entrypoints.py
+++ b/tests/unit/test_modal_runner_entrypoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from typing import get_type_hints
 
 import pytest
 
@@ -701,3 +702,36 @@ def test_daily_layer1_modal_range_main_dispatches_batched_remote_call(
     assert logged_messages == [
         ("artifacts/manifests/layer1/smoke-range.json", True)
     ]
+
+
+@pytest.mark.parametrize(
+    "module",
+    [run_daily_layer1, run_news_preprocessing, run_text_topics, run_finbert_sentiment],
+)
+def test_registered_local_entrypoints_use_modal_parseable_scalar_annotations(module) -> None:
+    """Registered local entrypoints expose only scalar CLI parameter annotations."""
+    assert get_type_hints(module.modal_main)["tickers"] is str
+
+
+@pytest.mark.parametrize(
+    ("module", "args", "function_name"),
+    [
+        (run_news_preprocessing, ("run", "2024-01-02", 2, " aapl,MSFT, aapl , "), "modal_run_news_preprocessing"),
+        (run_text_topics, ("run", "2024-01-02", "input", " aapl,MSFT, aapl , "), "modal_run_text_topics"),
+        (run_finbert_sentiment, ("run", "2024-01-02", "input", " aapl,MSFT, aapl , "), "modal_run_finbert_sentiment"),
+    ],
+)
+def test_sibling_modal_entrypoints_normalize_comma_separated_tickers(
+    monkeypatch: pytest.MonkeyPatch, module, args, function_name: str
+) -> None:
+    """Sibling local entrypoints pass a deterministic ticker list to Modal."""
+    _install_fake_modal(monkeypatch)
+    app = module._define_modal_app()
+    module.modal_main(*args)
+    registered = next(iter(app.functions.values()))
+    assert registered.remote_calls[-1]["tickers"] == ["AAPL", "MSFT"]
+
+
+def test_daily_ticker_scope_normalizes_comma_separated_input() -> None:
+    """Daily orchestration normalizes scalar ticker scope before dispatch."""
+    assert run_daily_layer1._normalize_ticker_scope(" aapl,MSFT, aapl , ") == ("AAPL", "MSFT")

--- a/tests/unit/test_modal_runner_entrypoints.py
+++ b/tests/unit/test_modal_runner_entrypoints.py
@@ -741,7 +741,7 @@ def test_daily_ticker_scope_normalizes_comma_separated_input() -> None:
 def test_modal_and_pi_requirements_pin_compatible_typer_range() -> None:
     """Modal and Pi dependency surfaces use the same Modal-compatible Typer range."""
     repo_root = Path(__file__).resolve().parents[2]
-    expected_constraint = "typer>=0.9,<0.26"
+    expected_constraint = "typer>=0.9,<0.16"
 
     constraints = []
     for requirements_name in ("requirements/modal.txt", "requirements/pi.txt"):

--- a/tests/unit/test_modal_runner_entrypoints.py
+++ b/tests/unit/test_modal_runner_entrypoints.py
@@ -793,18 +793,49 @@ def test_real_modal_sdk_registers_daily_layer1_entrypoint_without_remote_side_ef
 
     calls: list[dict[str, object]] = []
 
-    class _NoRemote:
-        def remote(self, **kwargs: object) -> None:
-            calls.append(kwargs)
+    class _NoExternalR2Writer:
+        """Fail if the real daily CLI reaches an R2 operation."""
 
-    monkeypatch.setattr(run_daily_layer1, "_modal_run_batched_layer1", _NoRemote())
-    run_daily_layer1.modal_range_main(
+        def __init__(self) -> None:
+            self.operations: list[str] = []
+
+        def exists(self, key: str) -> bool:
+            self.operations.append(f"exists:{key}")
+            raise AssertionError("real Modal daily compatibility test touched R2")
+
+        def get_object(self, key: str) -> bytes:
+            self.operations.append(f"get_object:{key}")
+            raise AssertionError("real Modal daily compatibility test touched R2")
+
+    class _NoRemote:
+        """Record final dispatch without contacting Modal or running the pipeline."""
+
+        def remote(self, **kwargs: object) -> dict[str, object]:
+            calls.append(kwargs)
+            return {}
+
+    writer = _NoExternalR2Writer()
+
+    monkeypatch.setattr(run_daily_layer1, "R2Writer", lambda: writer)
+    monkeypatch.setattr(
+        run_daily_layer1,
+        "_load_completed_stage_output",
+        lambda **kwargs: {
+            run_daily_layer1.NLP_PREPROCESSING_STAGE: "news.parquet",
+            run_daily_layer1.TEXT_TOPICS_STAGE: "topics.parquet",
+            run_daily_layer1.FINBERT_SENTIMENT_STAGE: "sentiment.parquet",
+            run_daily_layer1.REGIME_STAGE: "regime.parquet",
+        }[kwargs["stage"]],
+    )
+    monkeypatch.setattr(run_daily_layer1, "_modal_run_daily_layer1", _NoRemote())
+
+    run_daily_layer1.modal_main(
         "real-daily",
         "2024-01-02",
-        "2024-01-03",
         "layer0",
-        tickers=(" aapl ", "MSFT", " aapl "),
+        tickers=" aapl,MSFT, aapl , ",
     )
+    assert writer.operations == []
     assert calls[-1]["tickers"] == ["AAPL", "MSFT"]
 
 

--- a/tests/unit/test_modal_runner_entrypoints.py
+++ b/tests/unit/test_modal_runner_entrypoints.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import importlib
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import get_type_hints
 
 import pytest
@@ -735,3 +736,18 @@ def test_sibling_modal_entrypoints_normalize_comma_separated_tickers(
 def test_daily_ticker_scope_normalizes_comma_separated_input() -> None:
     """Daily orchestration normalizes scalar ticker scope before dispatch."""
     assert run_daily_layer1._normalize_ticker_scope(" aapl,MSFT, aapl , ") == ("AAPL", "MSFT")
+
+
+def test_modal_and_pi_requirements_pin_compatible_typer_range() -> None:
+    """Modal and Pi dependency surfaces use the same Modal-compatible Typer range."""
+    repo_root = Path(__file__).resolve().parents[2]
+    expected_constraint = "typer>=0.9,<0.26"
+
+    constraints = []
+    for requirements_name in ("requirements/modal.txt", "requirements/pi.txt"):
+        requirements = (repo_root / requirements_name).read_text(encoding="utf-8").splitlines()
+        constraints.append(
+            [line.split("#", 1)[0].strip() for line in requirements if line.strip().startswith("typer")]
+        )
+
+    assert constraints == [[expected_constraint], [expected_constraint]]

--- a/tests/unit/test_run_layer0_layer1_refresh.py
+++ b/tests/unit/test_run_layer0_layer1_refresh.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from app.pi.run_layer0_layer1_refresh import (
+    PipelineError,
+    RefreshConfig,
+    _commands,
+    acquire_lock,
+    build_plan,
+    latest_target,
+    load_env,
+    ready_reports,
+    refresh,
+    release_lock,
+    verify_ready,
+)
+
+
+class FakeR2:
+    def __init__(self, objects: dict[str, bytes] | None = None) -> None:
+        self.objects = objects or {}
+        self.calls: list[str] = []
+
+    def list_keys(self, prefix: str) -> list[str]:
+        self.calls.append(f"list:{prefix}")
+        return [key for key in self.objects if key.startswith(prefix)]
+
+    def get_object(self, key: str) -> bytes:
+        self.calls.append(f"get:{key}")
+        return self.objects[key]
+
+    def exists(self, key: str) -> bool:
+        self.calls.append(f"exists:{key}")
+        return key in self.objects
+
+
+def test_latest_target_holiday_weekend_and_cutoff() -> None:
+    assert latest_target(datetime.fromisoformat("2026-06-19T19:00:00-04:00")) == "2026-06-18"
+    assert latest_target(datetime.fromisoformat("2026-06-20T12:00:00-04:00")) == "2026-06-18"
+    assert latest_target(datetime.fromisoformat("2026-06-22T17:59:00-04:00")) == "2026-06-18"
+    assert latest_target(datetime.fromisoformat("2026-06-22T18:00:00-04:00")) == "2026-06-22"
+
+
+def test_build_plan_skips_holiday_weekend_filters_ready_and_caps() -> None:
+    selected, skipped, remaining = build_plan("2026-06-18", "2026-06-22", set(), 1)
+    assert selected == ["2026-06-18"]
+    assert skipped == ["2026-06-19", "2026-06-20", "2026-06-21"]
+    assert remaining == ["2026-06-22"]
+    assert build_plan("2026-06-18", "2026-06-22", {"2026-06-18"}, 0)[0] == ["2026-06-22"]
+
+
+def test_ready_reports_requires_boolean_true_and_uses_latest() -> None:
+    key = "artifacts/reports/integration/layer1_archive_validation_x_2026-06-18_to_2026-06-18.json"
+    client = FakeR2({key: json.dumps({"to_date": "2026-06-18", "ready_for_layer2": True}).encode()})
+    assert set(ready_reports(client)) == {"2026-06-18"}
+    false = FakeR2({key: b'{"ready_for_layer2": false}'})
+    assert ready_reports(false) == {}
+
+
+def test_load_env_is_injected_and_does_not_log_values(tmp_path: Path) -> None:
+    env_file = tmp_path / "r2.env"
+    env_file.write_text("SECRET_TOKEN='not-logged'\n# comment\n")
+    config = RefreshConfig(repo_root=tmp_path, home=tmp_path, env_files=(env_file,))
+    assert load_env(config)["SECRET_TOKEN"] == "not-logged"
+    assert load_env(config)["HOME"] == str(tmp_path)
+
+
+def test_lock_live_and_stale_behavior(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    config = RefreshConfig(repo_root=tmp_path, home=tmp_path)
+    acquire_lock(config)
+    with pytest.raises(PipelineError):
+        acquire_lock(config)
+    release_lock(config)
+    lock_dir = config.effective_lock_dir
+    lock_dir.mkdir(parents=True)
+    (lock_dir / "info.txt").write_text("pid=999999\n")
+    acquire_lock(config)
+    release_lock(config)
+
+
+def test_commands_preserve_exact_run_ids_and_paths(tmp_path: Path) -> None:
+    commands = _commands(RefreshConfig(repo_root=tmp_path, home=tmp_path), "2026-06-18")
+    assert commands[0][-6:] == ["--from-date", "2026-06-18", "--to-date", "2026-06-18", "--run-id", "layer0-daily-2026-06-18"]
+    assert commands[1][0].endswith("/.venv/bin/modal")
+    assert commands[1][2] == "app/lab/data_pipelines/run_daily_layer1.py::app.modal_main"
+    assert commands[2][-7:] == ["--run-id", "layer1-daily-2026-06-18", "--from-date", "2026-06-18", "--to-date", "2026-06-18", "--use-r2-universe"]
+
+
+def test_refresh_dry_run_has_zero_subprocess_or_r2_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeR2()
+    calls: list[list[str]] = []
+    monkeypatch.setattr("app.pi.run_layer0_layer1_refresh.subprocess.run", lambda *a, **k: calls.append(a[0]))
+    args = type("Args", (), {"target_date": "2026-06-22", "from_date": "2026-06-18", "max_days": 0, "dry_run": True})()
+    assert refresh(args, RefreshConfig(repo_root=tmp_path, home=tmp_path), lambda _env: client) == 0
+    assert calls == []
+    assert all(not call.startswith("put") for call in client.calls)
+
+
+def test_verify_ready_missing_or_false_fails() -> None:
+    client = FakeR2()
+    with pytest.raises(PipelineError, match="missing"):
+        verify_ready(client, "2026-06-18")
+    key = "artifacts/reports/integration/layer1_archive_validation_layer1-daily-2026-06-18_2026-06-18_to_2026-06-18.json"
+    client.objects[key] = b'{"ready_for_layer2": false}'
+    with pytest.raises(PipelineError, match="not ready"):
+        verify_ready(client, "2026-06-18")

--- a/tests/unit/test_run_layer0_layer1_refresh.py
+++ b/tests/unit/test_run_layer0_layer1_refresh.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from app.pi.run_layer0_layer1_refresh import (
+    CommandResult,
     PipelineError,
     RefreshConfig,
     _commands,
@@ -14,6 +15,7 @@ from app.pi.run_layer0_layer1_refresh import (
     build_plan,
     latest_target,
     load_env,
+    main,
     ready_reports,
     refresh,
     release_lock,
@@ -56,7 +58,7 @@ def test_build_plan_skips_holiday_weekend_filters_ready_and_caps() -> None:
 
 def test_ready_reports_requires_boolean_true_and_uses_latest() -> None:
     key = "artifacts/reports/integration/layer1_archive_validation_x_2026-06-18_to_2026-06-18.json"
-    client = FakeR2({key: json.dumps({"to_date": "2026-06-18", "ready_for_layer2": True}).encode()})
+    client = FakeR2({key: json.dumps({"run_id": "x", "from_date": "2026-06-18", "to_date": "2026-06-18", "ready_for_layer2": True}).encode()})
     assert set(ready_reports(client)) == {"2026-06-18"}
     false = FakeR2({key: b'{"ready_for_layer2": false}'})
     assert ready_reports(false) == {}
@@ -109,3 +111,48 @@ def test_verify_ready_missing_or_false_fails() -> None:
     client.objects[key] = b'{"ready_for_layer2": false}'
     with pytest.raises(PipelineError, match="not ready"):
         verify_ready(client, "2026-06-18")
+
+
+def test_verify_ready_requires_exact_identity() -> None:
+    key = "artifacts/reports/integration/layer1_archive_validation_layer1-daily-2026-06-18_2026-06-18_to_2026-06-18.json"
+    client = FakeR2({key: json.dumps({"ready_for_layer2": True}).encode()})
+    with pytest.raises(PipelineError, match="not ready"):
+        verify_ready(client, "2026-06-18")
+    client.objects[key] = json.dumps({"run_id": "layer1-daily-2026-06-18", "from_date": "2026-06-18", "to_date": "2026-06-18", "ready_for_layer2": True}).encode()
+    assert verify_ready(client, "2026-06-18")["ready_for_layer2"] is True
+
+
+def test_timeout_overrides_require_positive_integers(monkeypatch: pytest.MonkeyPatch) -> None:
+    from app.pi.run_layer0_layer1_refresh import _timeouts
+    config = RefreshConfig()
+    assert _timeouts(config) == (7200, 21600, 1800)
+    monkeypatch.setenv("AI_STOCK_TRADER_LAYER0_COMMAND_TIMEOUT_SECONDS", "11")
+    monkeypatch.setenv("AI_STOCK_TRADER_LAYER1_COMMAND_TIMEOUT_SECONDS", "22")
+    monkeypatch.setenv("AI_STOCK_TRADER_VALIDATE_COMMAND_TIMEOUT_SECONDS", "33")
+    assert _timeouts(config) == (11, 22, 33)
+    monkeypatch.setenv("AI_STOCK_TRADER_LAYER0_COMMAND_TIMEOUT_SECONDS", "0")
+    with pytest.raises(PipelineError, match="timeout"):
+        _timeouts(config)
+
+
+def test_refresh_stops_after_first_failed_stage(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeR2()
+    calls: list[list[str]] = []
+
+    def fake_run(command: list[str], *args: object, **kwargs: object) -> CommandResult:
+        calls.append(command)
+        return CommandResult(command, 9)
+
+    monkeypatch.setattr("app.pi.run_layer0_layer1_refresh.run_command", fake_run)
+    args = type("Args", (), {"target_date": "2026-06-18", "from_date": "2026-06-18", "max_days": 1, "dry_run": False})()
+    with pytest.raises(PipelineError, match="failed"):
+        refresh(args, RefreshConfig(repo_root=tmp_path, home=tmp_path), lambda _env: client)
+    assert len(calls) == 1
+
+
+def test_main_dry_run_does_not_create_lock_or_construct_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr("app.pi.run_layer0_layer1_refresh.RefreshConfig", lambda **kwargs: RefreshConfig(repo_root=tmp_path, home=tmp_path, **kwargs))
+    monkeypatch.setattr("app.pi.run_layer0_layer1_refresh.install_signal_handlers", lambda _config: None)
+    assert main(["--from-date", "2026-06-18", "--target-date", "2026-06-18", "--dry-run"]) == 0
+    assert not (tmp_path / ".hermes").exists()

--- a/tests/unit/test_run_layer0_layer1_refresh.py
+++ b/tests/unit/test_run_layer0_layer1_refresh.py
@@ -12,6 +12,7 @@ from app.pi.run_layer0_layer1_refresh import (
     PipelineError,
     RefreshConfig,
     _commands,
+    _sanitize_output,
     acquire_lock,
     build_plan,
     latest_target,
@@ -72,6 +73,35 @@ def test_load_env_is_injected_and_does_not_log_values(tmp_path: Path) -> None:
     config = RefreshConfig(repo_root=tmp_path, home=tmp_path, env_files=(env_file,))
     assert load_env(config)["SECRET_TOKEN"] == "not-logged"
     assert load_env(config)["HOME"] == str(tmp_path)
+
+
+def test_sanitizer_redacts_arbitrary_uri_userinfo_and_token_aware_env_values() -> None:
+    env = {
+        "R2_TOKEN": "FAKE-r2-secret-12345",
+        "AWS_SECRET_ACCESS_KEY": "FAKE-aws-access-12345",
+        "API_KEY": "FAKE-api-key-12345",
+        "X-AMZ-SIGNATURE": "FAKE-signature-12345",
+        "MONKEY": "banana",
+    }
+    value = (
+        "s3://user:password@bucket/path?token=FAKE-r2-secret-12345&monkey=banana "
+        "AWS_SECRET_ACCESS_KEY=FAKE-aws-access-12345 API_KEY=FAKE-api-key-12345 "
+        "X-AMZ-SIGNATURE=FAKE-signature-12345 monkey=banana"
+    )
+
+    sanitized = _sanitize_output(value, env)
+
+    assert sanitized == (
+        "s3://<redacted>@bucket/path?token=<redacted>&monkey=banana "
+        "AWS_SECRET_ACCESS_KEY=<redacted> API_KEY=<redacted> "
+        "X-AMZ-SIGNATURE=<redacted> monkey=banana"
+    )
+
+
+def test_sanitizer_retains_http_uri_structure() -> None:
+    value = "https://user:password@host:443/path?x=1#fragment"
+
+    assert _sanitize_output(value, {}) == "https://<redacted>@host:443/path?x=1#fragment"
 
 
 def test_lock_live_and_stale_behavior(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/test_run_layer0_layer1_refresh.py
+++ b/tests/unit/test_run_layer0_layer1_refresh.py
@@ -248,6 +248,35 @@ def test_run_command_redacts_normal_output_and_command_display(tmp_path: Path) -
     assert "monkey=banana" in content and "<redacted>" in content
 
 
+def test_run_command_redacts_s3_userinfo_and_query_credentials_in_log_and_tail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    secret = "FAKE-r2-secret-12345"
+    uri = f"s3://user:password@bucket/path?token={secret}&monkey=banana"
+    command = ["fake-refresh", uri]
+    monkeypatch.setattr(
+        "app.pi.run_layer0_layer1_refresh.subprocess.run",
+        lambda *args, **kwargs: type("Result", (), {"stdout": uri, "returncode": 0})(),
+    )
+
+    result = run_command(
+        command,
+        {"R2_TOKEN": secret},
+        RefreshConfig(repo_root=tmp_path, home=tmp_path),
+        tmp_path / "run.log",
+        10,
+    )
+
+    content = (tmp_path / "run.log").read_text()
+    expected = "s3://<redacted>@bucket/path?token=<redacted>&monkey=banana"
+    assert result.command == command
+    assert result.returncode == 0
+    assert expected in content and expected in result.output_tail
+    assert "user:password" not in content and "user:password" not in result.output_tail
+    assert secret not in content and secret not in result.output_tail
+    assert "monkey=banana" in content and "monkey=banana" in result.output_tail
+
+
 @pytest.mark.parametrize("payload", ["timeout-secret", b"timeout-secret"])
 def test_run_command_redacts_timeout_output_str_and_bytes(tmp_path: Path, payload: str | bytes, monkeypatch: pytest.MonkeyPatch) -> None:
     secret = "timeout-secret"

--- a/tests/unit/test_run_layer0_layer1_refresh.py
+++ b/tests/unit/test_run_layer0_layer1_refresh.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import datetime
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from app.pi.run_layer0_layer1_refresh import (
     ready_reports,
     refresh,
     release_lock,
+    run_command,
     verify_ready,
 )
 
@@ -148,6 +150,86 @@ def test_refresh_stops_after_first_failed_stage(tmp_path: Path, monkeypatch: pyt
     with pytest.raises(PipelineError, match="failed"):
         refresh(args, RefreshConfig(repo_root=tmp_path, home=tmp_path), lambda _env: client)
     assert len(calls) == 1
+
+
+def _ready_objects(days: list[str]) -> dict[str, bytes]:
+    return {
+        f"artifacts/reports/integration/layer1_archive_validation_x_{day}_to_{day}.json": json.dumps(
+            {"run_id": "x", "from_date": day, "to_date": day, "ready_for_layer2": True}
+        ).encode()
+        for day in days
+    }
+
+
+def test_refresh_default_history_crosses_holiday_and_weekend(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeR2(_ready_objects(["2026-06-18", "2026-06-22", "2026-06-23"]))
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "app.pi.run_layer0_layer1_refresh.run_command",
+        lambda command, *args, **kwargs: (calls.append(command) or CommandResult(command, 0)),
+    )
+    monkeypatch.setattr("app.pi.run_layer0_layer1_refresh.verify_ready", lambda *_args: {})
+    args = type("Args", (), {"target_date": "2026-06-24", "from_date": None, "max_days": 0, "dry_run": False})()
+    assert refresh(args, RefreshConfig(repo_root=tmp_path, home=tmp_path), lambda _env: client) == 0
+    assert [command[5] for command in calls[::3]] == ["2026-06-24"]
+
+
+def test_refresh_default_history_gap_fails_before_log_or_subprocess(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeR2(_ready_objects(["2026-06-18", "2026-06-23"]))
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "app.pi.run_layer0_layer1_refresh.run_command",
+        lambda command, *args, **kwargs: (calls.append(command) or CommandResult(command, 0)),
+    )
+    args = type("Args", (), {"target_date": "2026-06-24", "from_date": None, "max_days": 0, "dry_run": False})()
+    with pytest.raises(PipelineError, match="2026-06-22"):
+        refresh(args, RefreshConfig(repo_root=tmp_path, home=tmp_path), lambda _env: client)
+    assert calls == []
+    assert not (tmp_path / ".hermes").exists()
+
+
+def test_refresh_explicit_from_date_selects_gap_oldest_first(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    client = FakeR2(_ready_objects(["2026-06-18", "2026-06-23"]))
+    calls: list[list[str]] = []
+    monkeypatch.setattr(
+        "app.pi.run_layer0_layer1_refresh.run_command",
+        lambda command, *args, **kwargs: (calls.append(command) or CommandResult(command, 0)),
+    )
+    monkeypatch.setattr("app.pi.run_layer0_layer1_refresh.verify_ready", lambda *_args: {})
+    args = type("Args", (), {"target_date": "2026-06-24", "from_date": "2026-06-18", "max_days": 1, "dry_run": False})()
+    assert refresh(args, RefreshConfig(repo_root=tmp_path, home=tmp_path), lambda _env: client) == 0
+    assert calls[0][3] == "2026-06-22"
+
+
+def test_run_command_redacts_normal_output_and_command_display(tmp_path: Path) -> None:
+    secret = "provider-secret-value"
+    env = {"R2_TOKEN": secret}
+    command = ["https://user:password@host/path?token=" + secret + "&monkey=banana"]
+    output = "https://user:password@host/path?api_key=" + secret + "&monkey=banana env=" + secret
+    original = subprocess.run
+    try:
+        subprocess.run = lambda *args, **kwargs: type("Result", (), {"stdout": output, "returncode": 0})()  # type: ignore[method-assign]
+        result = run_command(command, env, RefreshConfig(repo_root=tmp_path, home=tmp_path), tmp_path / "run.log", 10)
+    finally:
+        subprocess.run = original
+    content = (tmp_path / "run.log").read_text()
+    assert result.command == command
+    assert secret not in content and secret not in result.output_tail
+    assert "monkey=banana" in content and "<redacted>" in content
+
+
+@pytest.mark.parametrize("payload", ["timeout-secret", b"timeout-secret"])
+def test_run_command_redacts_timeout_output_str_and_bytes(tmp_path: Path, payload: str | bytes, monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = "timeout-secret"
+    monkeypatch.setattr(
+        "app.pi.run_layer0_layer1_refresh.subprocess.run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(subprocess.TimeoutExpired(["cmd"], 10, output=payload)),
+    )
+    result = run_command(["cmd"], {"TOKEN": secret}, RefreshConfig(repo_root=tmp_path, home=tmp_path), tmp_path / "run.log", 10)
+    content = (tmp_path / "run.log").read_text()
+    assert result.returncode == 124
+    assert secret not in content and secret not in result.output_tail
+    assert "command timed out" in result.output_tail
 
 
 def test_main_dry_run_does_not_create_lock_or_construct_client(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## What this PR does
Adds the version-controlled, holiday-aware Pi Layer 0→Layer 1 refresh orchestrator; modernizes the supported Modal dependency contract to 1.5.x-compatible semantics; preserves ticker CLI propagation and secret redaction; and adds regression coverage and canonical runtime/deployment documentation. The refresh remains data-only, fail-closed on durable `ready_for_layer2=true` evidence, and does not run Layer 2+, execution, dashboard work, or a backfill.

## Outcome and execution links
- GitHub outcome issue: #292
- Root HQ Kanban task ID: `t_8914085f`
- Kanban tenant: `trading`
- Root graph URL: not exposed by the local Kanban tool

## Issue relation
Advances #292

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [x] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by code-monkey — reviewed and approved by me

## Governance evidence
- Independent review task/profile and verdict: `t_6eea8916`, `trading-code-reviewer`, PASS at exact head `0b5ebbc6bd3f13afc594b7cfa7c6288e05ea2b86`, zero Blocking findings.
- Domain acceptance (semantic/backend scope): Trading acceptance task `t_1259b245`; exact safe dry-run selected sessions `2026-06-18` and `2026-06-22` and skipped `2026-06-19`, `2026-06-20`, and `2026-06-21`, proving Juneteenth 2026 plus the weekend are excluded before any provider or Modal command. Full unit suite under Python 3.11.15 / Modal 1.5.3: 817 passed, 1 skipped; focused refresh: 21 passed; four relevant files: 100 passed; Ruff and mypy passed.
- Exceptional human gate decision, if applicable: none. No schema migration, Stock-tab/dashboard change, consequential broad backfill, production data mutation, or Layer 2+ run is included or authorized.
- Current-head merge gates: exact reviewed SHA is pushed unchanged; GitHub required CI/checks and current-head mergeable/CLEAN status must be confirmed before merge. Repository deployment follow-up (installed wrapper switch and bounded current-session verification) remains outside this PR and Issue #292 stays open until that operational acceptance is completed.

---

## code-monkey checklist

### Correctness
- [x] Output matches existing repository contracts; no output schema change
- [x] No logic added to forbidden files
- [x] No hardcoded credentials, API keys, or user-specific absolute paths
- [x] No production `print()` statements; repository logger used
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] `PYTHONPATH="/tmp/issue292-modal153:$PWD" ./.venv/bin/python -m pytest tests/unit/ -q` equivalent passed in the reviewed worktree: 817 passed, 1 skipped
- [x] New public behavior has unit coverage
- [x] Boundary, holiday/weekend, cutoff, empty/current state, max-days, failure/timeout, locking, dry-run, readiness, and sanitizer paths are covered
- [x] Unit tests make no live provider/R2/Modal calls

### Code quality
- [x] New public functions have type hints and docstrings where applicable
- [x] Imports and unused imports pass Ruff

### Project hygiene
- [x] Domain owner recorded the issue's current milestone: no milestone assigned
- [x] PR references Issue #292 and root task `t_8914085f`
- [x] Cumulative diff is issue-scoped
- [x] Modal dependency changes are declared in `requirements/modal.txt` and `requirements/pi.txt`

---

## New dependencies
No new package family. The existing Modal dependency is moved from the obsolete 0.x range to `modal>=1.5,<2`; obsolete direct Typer constraints are removed.

## Sample dry-run evidence
```text
Layer 0->1 dry-run target=2026-06-22 skipped=['2026-06-19', '2026-06-20', '2026-06-21'] sessions=['2026-06-18', '2026-06-22'] remaining=[]
```

## Notes for reviewer
The immutable reviewed head is `0b5ebbc6bd3f13afc594b7cfa7c6288e05ea2b86`. Do not infer deployment or backfill authorization from this PR. The post-merge installed-wrapper switch and bounded current-session operational verification remain a separate gate before Issue #292 is closed.
