### PR TITLE
fix: harden Wikipedia universe cache recovery

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -159,8 +159,14 @@ Current baseline omission:
   existing-stack provider is adopted and documented end-to-end
 
 ### Universe construction note
-Wikipedia's S&P 500 page revision history provides historical constituent changes at no cost.
-The revision history — not the current page — must be scraped to obtain point-in-time membership.
+Wikipedia publishes current constituents and historical S&P 500 components on separate pages.
+Layer 0 fetches both pages as one source generation: the current page supplies the
+`table#constituents` table and the historical-components page supplies `table#changes`.
+The combined payload is parsed and structurally validated before atomic cache publication.
+The last-known-good combined cache may be used stale when a complete refresh fails; if no
+validated generation exists, Layer 0 fails closed rather than substituting today's
+constituents for point-in-time history.
+The historical page — not the current page alone — must be used to obtain point-in-time membership.
 This approach is accurate enough for personal-system backtesting but may have gaps around
 spinoffs and rapid constituent changes. Alpaca's delayed SIP archive provides consolidated
 historical OHLCV for the active ticker symbols in the backfill universe from 2017 onward.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,10 @@ This document describes deployment surfaces and responsibilities.
 
 ## External dependency roles
 
-- Wikipedia revision history: point-in-time S&P 500 membership source
+- Wikipedia current constituents plus the separate historical-components page: point-in-time
+  S&P 500 membership source. Layer 0 validates both responses as one generation and atomically
+  publishes a combined cache; it uses a validated stale cache with a warning when refresh fails,
+  and fails closed when no validated cache exists.
 - Alpaca delayed SIP market data:
   canonical historical adjusted OHLCV archives from 2017-01-01 onward
 - Alpaca News: Layer 0 raw Benzinga-sourced news archive used by Layer 1 text features

--- a/services/wikipedia/sp500_universe.py
+++ b/services/wikipedia/sp500_universe.py
@@ -147,7 +147,7 @@ def _validate_combined_html(html: str) -> None:
     events = parse_change_log(html)
     if not current or not events:
         raise ValueError("Wikipedia source contains an empty current or historical set")
-    if len(current) > 1000 or len(events) > 10000:
+    if not 400 <= len(current) <= 600 or len(events) > 10000:
         raise ValueError("Wikipedia source contains implausibly large sets")
     ticker_pattern = re.compile(r"^[A-Z]{1,5}(?:-[A-Z])?$")
     if any(not ticker_pattern.fullmatch(ticker) for ticker in current):
@@ -270,8 +270,7 @@ def parse_change_log(html: str) -> list[ChangeEvent]:
         # Normalize date to YYYY-MM-DD
         date = _normalize_date(raw_date)
         if date is None:
-            logger.warning("Skipping unparseable date: {!r}", raw_date)
-            continue
+            raise ValueError(f"Wikipedia historical event has an unparseable date: {raw_date!r}")
 
         if date not in raw_events:
             raw_events[date] = {"added": {}, "removed": {}}

--- a/services/wikipedia/sp500_universe.py
+++ b/services/wikipedia/sp500_universe.py
@@ -25,6 +25,13 @@ WIKIPEDIA_URL = WIKIPEDIA_CURRENT_URL
 DEFAULT_CACHE_PATH = Path("data/cache/sp500_wikipedia.html")
 CACHE_MAX_AGE_HOURS = 24
 
+# Conservative source-contract floors protect the cache boundary from publishing a
+# syntactically valid but historically truncated Wikipedia generation. These are
+# coverage floors, not assertions about the current live event count or latest date.
+MIN_HISTORICAL_EVENT_COUNT = 100
+MIN_HISTORICAL_EVENT_DATE = "1980-01-01"
+MAX_HISTORICAL_EVENT_DATE = "2017-01-01"
+
 # Conflict-free historical/current symbol aliases. Ambiguous symbols that map to
 # different securities across time are handled separately with date-bounded
 # resolution rules.
@@ -149,6 +156,13 @@ def _validate_combined_html(html: str) -> None:
         raise ValueError("Wikipedia source contains an empty current or historical set")
     if not 400 <= len(current) <= 600 or len(events) > 10000:
         raise ValueError("Wikipedia source contains implausibly large sets")
+    event_dates = {event.date for event in events}
+    if (
+        len(event_dates) < MIN_HISTORICAL_EVENT_COUNT
+        or min(event_dates) > MIN_HISTORICAL_EVENT_DATE
+        or max(event_dates) < MAX_HISTORICAL_EVENT_DATE
+    ):
+        raise ValueError("Wikipedia source fails historical coverage plausibility floors")
     ticker_pattern = re.compile(r"^[A-Z]{1,5}(?:-[A-Z])?$")
     if any(not ticker_pattern.fullmatch(ticker) for ticker in current):
         raise ValueError("Wikipedia source contains an invalid current ticker identity")
@@ -196,6 +210,7 @@ def fetch_html(cache_path: Path = DEFAULT_CACHE_PATH) -> str:
         except (OSError, ValueError) as exc:
             stale_state = f"invalid cache ({type(exc).__name__})"
 
+    temporary_path: Path | None = None
     try:
         logger.info("Fetching Wikipedia S&P 500 source generation")
         combined = _combine_source_pages(
@@ -206,8 +221,8 @@ def fetch_html(cache_path: Path = DEFAULT_CACHE_PATH) -> str:
         with tempfile.NamedTemporaryFile(
             mode="w", encoding="utf-8", dir=cache_path.parent, prefix=f".{cache_path.name}.", delete=False
         ) as temporary:
-            temporary.write(combined)
             temporary_path = Path(temporary.name)
+            temporary.write(combined)
         temporary_path.replace(cache_path)
         logger.debug("Atomically cached validated Wikipedia generation to {}", cache_path)
         return combined
@@ -221,6 +236,16 @@ def fetch_html(cache_path: Path = DEFAULT_CACHE_PATH) -> str:
         if isinstance(exc, requests.RequestException):
             raise
         raise RuntimeError("No valid Wikipedia universe source generation is available") from exc
+    finally:
+        if temporary_path is not None and temporary_path.exists():
+            try:
+                temporary_path.unlink()
+            except OSError as cleanup_exc:
+                logger.warning(
+                    "Wikipedia temporary cache cleanup failed ({}; exists={})",
+                    type(cleanup_exc).__name__,
+                    temporary_path.exists(),
+                )
 
 
 def parse_current_tickers(html: str) -> set[str]:

--- a/services/wikipedia/sp500_universe.py
+++ b/services/wikipedia/sp500_universe.py
@@ -7,6 +7,8 @@ Never use the current constituent table alone — it causes survivorship bias.
 """
 from __future__ import annotations
 
+import re
+import tempfile
 import time
 from dataclasses import dataclass
 from datetime import datetime
@@ -16,7 +18,10 @@ import requests
 from bs4 import BeautifulSoup
 from loguru import logger
 
-WIKIPEDIA_URL = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+WIKIPEDIA_CURRENT_URL = "https://en.wikipedia.org/wiki/List_of_S%26P_500_companies"
+WIKIPEDIA_HISTORICAL_URL = "https://en.wikipedia.org/wiki/Historical_components_of_the_S%26P_500"
+# Backward-compatible name for callers that only need the canonical current page.
+WIKIPEDIA_URL = WIKIPEDIA_CURRENT_URL
 DEFAULT_CACHE_PATH = Path("data/cache/sp500_wikipedia.html")
 CACHE_MAX_AGE_HOURS = 24
 
@@ -78,7 +83,8 @@ def _canonicalize_ticker(ticker: str) -> str:
 
 def _normalize_ticker(ticker: str) -> str:
     """Normalize ticker formatting without applying identity-alias logic."""
-    return ticker.strip().upper().replace(".", "-")
+    normalized = re.sub(r"\s*\|\s*$", "", ticker.strip())
+    return normalized.upper().replace(".", "-")
 
 
 def _resolve_change_event_ticker(
@@ -126,23 +132,95 @@ def _resolve_current_table_ticker(ticker: str) -> str:
     return _canonicalize_ticker(normalized)
 
 
+def _extract_table(html: str, table_id: str) -> str:
+    """Extract one required table from a provider response."""
+    soup = BeautifulSoup(html, "lxml")
+    table = soup.find("table", {"id": table_id})
+    if table is None:
+        raise ValueError(f"Wikipedia response is missing table#{table_id}")
+    return str(table)
+
+
+def _validate_combined_html(html: str) -> None:
+    """Validate required tables and parsed content before cache use/publication."""
+    current = parse_current_tickers(html)
+    events = parse_change_log(html)
+    if not current or not events:
+        raise ValueError("Wikipedia source contains an empty current or historical set")
+    if len(current) > 1000 or len(events) > 10000:
+        raise ValueError("Wikipedia source contains implausibly large sets")
+    ticker_pattern = re.compile(r"^[A-Z]{1,5}(?:-[A-Z])?$")
+    if any(not ticker_pattern.fullmatch(ticker) for ticker in current):
+        raise ValueError("Wikipedia source contains an invalid current ticker identity")
+    dates = [event.date for event in events]
+    if dates != sorted(set(dates)):
+        raise ValueError("Wikipedia historical events are not unique and chronological")
+    for event in events:
+        if not event.added and not event.removed:
+            raise ValueError("Wikipedia historical event has no ticker identities")
+        if any(not ticker_pattern.fullmatch(ticker) for ticker in event.added | event.removed):
+            raise ValueError("Wikipedia source contains an invalid historical ticker identity")
+
+
+def _combine_source_pages(current_html: str, historical_html: str) -> str:
+    """Build the deterministic cache representation from one remote generation."""
+    combined = "<html><body>{}{}</body></html>".format(
+        _extract_table(current_html, "constituents"),
+        _extract_table(historical_html, "changes"),
+    )
+    _validate_combined_html(combined)
+    return combined
+
+
+def _fetch_page(url: str) -> str:
+    """Fetch one Wikipedia page for a source generation."""
+    response = requests.get(url, timeout=30, headers={"User-Agent": "sp500-universe-builder/1.0"})
+    response.raise_for_status()
+    return response.text
+
+
 def fetch_html(cache_path: Path = DEFAULT_CACHE_PATH) -> str:
-    """Return Wikipedia HTML from cache if fresh, otherwise fetch and cache it."""
+    """Return a validated split-page generation, retaining valid stale cache on failure."""
+    stale_html: str | None = None
+    stale_state = "no cache"
     if cache_path.exists():
-        age_hours = (time.time() - cache_path.stat().st_mtime) / 3600
-        if age_hours < CACHE_MAX_AGE_HOURS:
-            logger.debug("Using cached Wikipedia HTML (age={:.1f}h)", age_hours)
-            return cache_path.read_text(encoding="utf-8")
+        try:
+            candidate = cache_path.read_text(encoding="utf-8")
+            _validate_combined_html(candidate)
+            age_hours = (time.time() - cache_path.stat().st_mtime) / 3600
+            if age_hours < CACHE_MAX_AGE_HOURS:
+                logger.debug("Using validated cached Wikipedia HTML (age={:.1f}h)", age_hours)
+                return candidate
+            stale_html = candidate
+            stale_state = "valid stale cache"
+        except (OSError, ValueError) as exc:
+            stale_state = f"invalid cache ({type(exc).__name__})"
 
-    logger.info("Fetching Wikipedia S&P 500 page from {}", WIKIPEDIA_URL)
-    resp = requests.get(WIKIPEDIA_URL, timeout=30, headers={"User-Agent": "sp500-universe-builder/1.0"})
-    resp.raise_for_status()
-    html = resp.text
-
-    cache_path.parent.mkdir(parents=True, exist_ok=True)
-    cache_path.write_text(html, encoding="utf-8")
-    logger.debug("Cached Wikipedia HTML to {}", cache_path)
-    return html
+    try:
+        logger.info("Fetching Wikipedia S&P 500 source generation")
+        combined = _combine_source_pages(
+            _fetch_page(WIKIPEDIA_CURRENT_URL),
+            _fetch_page(WIKIPEDIA_HISTORICAL_URL),
+        )
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(
+            mode="w", encoding="utf-8", dir=cache_path.parent, prefix=f".{cache_path.name}.", delete=False
+        ) as temporary:
+            temporary.write(combined)
+            temporary_path = Path(temporary.name)
+        temporary_path.replace(cache_path)
+        logger.debug("Atomically cached validated Wikipedia generation to {}", cache_path)
+        return combined
+    except (OSError, ValueError, requests.RequestException) as exc:
+        if stale_html is not None:
+            logger.warning(
+                "Wikipedia refresh failed; using {} ({})", stale_state, type(exc).__name__
+            )
+            return stale_html
+        logger.error("Wikipedia refresh failed with no valid cache ({})", type(exc).__name__)
+        if isinstance(exc, requests.RequestException):
+            raise
+        raise RuntimeError("No valid Wikipedia universe source generation is available") from exc
 
 
 def parse_current_tickers(html: str) -> set[str]:

--- a/services/wikipedia/sp500_universe.py
+++ b/services/wikipedia/sp500_universe.py
@@ -7,6 +7,7 @@ Never use the current constituent table alone — it causes survivorship bias.
 """
 from __future__ import annotations
 
+import os
 import re
 import tempfile
 import time
@@ -30,7 +31,7 @@ CACHE_MAX_AGE_HOURS = 24
 # coverage floors, not assertions about the current live event count or latest date.
 MIN_HISTORICAL_EVENT_COUNT = 100
 MIN_HISTORICAL_EVENT_DATE = "1980-01-01"
-MAX_HISTORICAL_EVENT_DATE = "2017-01-01"
+MIN_LATEST_HISTORICAL_EVENT_DATE = "2025-01-01"
 
 # Conflict-free historical/current symbol aliases. Ambiguous symbols that map to
 # different securities across time are handled separately with date-bounded
@@ -160,7 +161,7 @@ def _validate_combined_html(html: str) -> None:
     if (
         len(event_dates) < MIN_HISTORICAL_EVENT_COUNT
         or min(event_dates) > MIN_HISTORICAL_EVENT_DATE
-        or max(event_dates) < MAX_HISTORICAL_EVENT_DATE
+        or max(event_dates) < MIN_LATEST_HISTORICAL_EVENT_DATE
     ):
         raise ValueError("Wikipedia source fails historical coverage plausibility floors")
     ticker_pattern = re.compile(r"^[A-Z]{1,5}(?:-[A-Z])?$")
@@ -223,6 +224,8 @@ def fetch_html(cache_path: Path = DEFAULT_CACHE_PATH) -> str:
         ) as temporary:
             temporary_path = Path(temporary.name)
             temporary.write(combined)
+            temporary.flush()
+            os.fsync(temporary.fileno())
         temporary_path.replace(cache_path)
         logger.debug("Atomically cached validated Wikipedia generation to {}", cache_path)
         return combined

--- a/tests/unit/test_wikipedia_universe.py
+++ b/tests/unit/test_wikipedia_universe.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import os
+from datetime import date, timedelta
 from itertools import zip_longest
 from pathlib import Path
 from unittest.mock import Mock
@@ -85,10 +86,37 @@ def _build_html(fixture: dict) -> str:
 
 def _build_valid_source_html() -> str:
     """Build a conservatively sized source generation for cache-policy tests."""
+    current_tickers = [
+        f"{left}{right}A" for left in "ABCDEFGHIJKLMNOPQRST" for right in "ABCDEFGHIJKLMNOPQRST"
+    ][:500]
+    event_dates = [
+        (date(1979, 1, 1) + timedelta(days=145 * index)).isoformat() for index in range(100)
+    ]
     return _build_html(
         {
-            "current_tickers": [f"{left}{right}A" for left in "ABCDEFGHIJKLMNOPQRST" for right in "ABCDEFGHIJKLMNOPQRST"][:500],
-            "changes": [{"date": "2020-01-01", "added": ["ALLE |"], "removed": ["JCP |"]}],
+            "current_tickers": current_tickers,
+            "changes": [
+                {
+                    "date": event_date,
+                    "added": ["ALLE |" if index == 0 else current_tickers[index]],
+                    "removed": ["JCP |" if index == 0 else current_tickers[index + 1]],
+                }
+                for index, event_date in enumerate(event_dates)
+            ],
+        }
+    )
+
+
+def _build_truncated_source_html() -> str:
+    """Build a source with valid current syntax but implausibly short history."""
+    return _build_html(
+        {
+            "current_tickers": [
+                f"{left}{right}A"
+                for left in "ABCDEFGHIJKLMNOPQRST"
+                for right in "ABCDEFGHIJKLMNOPQRST"
+            ][:500],
+            "changes": [{"date": "2020-01-01", "added": ["ALLE"], "removed": ["JCP"]}],
         }
     )
 
@@ -126,7 +154,7 @@ def test_fetch_html_combines_split_pages_and_atomically_publishes(monkeypatch: p
     assert parse_current_tickers(result)
     assert parse_change_log(result)[0].added == {"ALLE"}
     assert cache_path.read_text() == result
-    assert not list(tmp_path.glob(".*.tmp"))
+    assert not list(tmp_path.glob(f".{cache_path.name}.*"))
 
 
 def test_fetch_html_uses_valid_fresh_cache_without_network(
@@ -153,6 +181,78 @@ def test_fetch_html_replaces_malformed_fresh_cache(monkeypatch: pytest.MonkeyPat
 
     assert result == cache_path.read_text()
     assert "table id=\"changes\"" in result
+
+
+def test_fetch_html_replaces_invalid_truncated_cache_with_complete_refresh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A fresh one-event cache is rejected and replaced by complete history."""
+    current, historical = _split_pages(_build_valid_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    cache_path = tmp_path / "sp500.html"
+    cache_path.write_text(_build_truncated_source_html())
+
+    result = fetch_html(cache_path)
+
+    assert len(parse_change_log(result)) == 100
+    assert cache_path.read_text() == result
+
+
+def test_fetch_html_uses_valid_stale_cache_when_remote_history_is_truncated(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A truncated HTTP-200 refresh falls back to and preserves valid stale bytes."""
+    cache_path = tmp_path / "sp500.html"
+    expected = _build_valid_source_html()
+    cache_path.write_text(expected)
+    old_time = cache_path.stat().st_mtime - 48 * 3600
+    os.utime(cache_path, (old_time, old_time))
+    current, historical = _split_pages(_build_truncated_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    warning = Mock()
+    monkeypatch.setattr(wikipedia.logger, "warning", warning)
+
+    assert fetch_html(cache_path) == expected
+    assert cache_path.read_text() == expected
+    assert warning.call_args.args[-1] == "ValueError"
+
+
+def test_fetch_html_fails_closed_for_truncated_remote_source_without_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A truncated HTTP-200 generation creates neither cache nor temporary sibling."""
+    current, historical = _split_pages(_build_truncated_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    cache_path = tmp_path / "sp500.html"
+
+    with pytest.raises(RuntimeError, match="No valid Wikipedia") as caught:
+        fetch_html(cache_path)
+
+    assert "historical coverage" in str(caught.value.__cause__)
+    assert not cache_path.exists()
+    assert not list(tmp_path.glob(f".{cache_path.name}.*"))
+
+
+def test_fetch_html_removes_temp_sibling_after_replace_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed atomic replacement preserves stale bytes and removes its temp sibling."""
+    cache_path = tmp_path / "sp500.html"
+    expected = _build_valid_source_html()
+    cache_path.write_text(expected)
+    old_time = cache_path.stat().st_mtime - 48 * 3600
+    os.utime(cache_path, (old_time, old_time))
+    current, historical = _split_pages(expected)
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    monkeypatch.setattr(Path, "replace", Mock(side_effect=OSError("replace failed")))
+
+    assert fetch_html(cache_path) == expected
+    assert cache_path.read_text() == expected
+    assert not list(tmp_path.glob(f".{cache_path.name}.*"))
 
 
 def test_fetch_html_falls_back_to_valid_stale_cache_on_refresh_failure(

--- a/tests/unit/test_wikipedia_universe.py
+++ b/tests/unit/test_wikipedia_universe.py
@@ -5,15 +5,21 @@ All tests use data/sample/sp500_changes_fixture.json — no live HTTP requests.
 from __future__ import annotations
 
 import json
+import os
 from itertools import zip_longest
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
+import requests
+from bs4 import BeautifulSoup
 
+import services.wikipedia.sp500_universe as wikipedia
 from services.wikipedia.sp500_universe import (
     ChangeEvent,
     _canonicalize_ticker,
     _normalize_date,
+    fetch_html,
     get_all_historical_tickers,
     get_constituents,
     parse_change_log,
@@ -75,6 +81,128 @@ def _build_html(fixture: dict) -> str:
     )
 
     return f"<html><body>{constituents_table}{changes_table}</body></html>"
+
+
+def _build_valid_source_html() -> str:
+    """Build a conservatively sized source generation for cache-policy tests."""
+    return _build_html(
+        {
+            "current_tickers": [f"{left}{right}A" for left in "ABCDEFGHIJKLMNOPQRST" for right in "ABCDEFGHIJKLMNOPQRST"][:500],
+            "changes": [{"date": "2020-01-01", "added": ["ALLE |"], "removed": ["JCP |"]}],
+        }
+    )
+
+
+def _split_pages(html: str) -> tuple[str, str]:
+    """Return independent current and historical page bodies from combined fixture HTML."""
+    soup = BeautifulSoup(html, "lxml")
+    return (
+        f"<html><body>{soup.find('table', id='constituents')}</body></html>",
+        f"<html><body>{soup.find('table', id='changes')}</body></html>",
+    )
+
+
+class _Response:
+    """Minimal requests response test double."""
+
+    def __init__(self, text: str = "", error: Exception | None = None) -> None:
+        self.text = text
+        self._error = error
+
+    def raise_for_status(self) -> None:
+        if self._error is not None:
+            raise self._error
+
+
+def test_fetch_html_combines_split_pages_and_atomically_publishes(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A refresh must fetch both pages and publish one parseable generation."""
+    current, historical = _split_pages(_build_valid_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    cache_path = tmp_path / "sp500.html"
+
+    result = fetch_html(cache_path)
+
+    assert parse_current_tickers(result)
+    assert parse_change_log(result)[0].added == {"ALLE"}
+    assert cache_path.read_text() == result
+    assert not list(tmp_path.glob(".*.tmp"))
+
+
+def test_fetch_html_uses_valid_fresh_cache_without_network(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A valid fresh combined cache is used without contacting Wikipedia."""
+    cache_path = tmp_path / "sp500.html"
+    expected = _build_valid_source_html()
+    cache_path.write_text(expected)
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: pytest.fail("network"))
+
+    assert fetch_html(cache_path) == expected
+
+
+def test_fetch_html_replaces_malformed_fresh_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A fresh malformed cache is rejected and replaced by a complete refresh."""
+    current, historical = _split_pages(_build_valid_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    cache_path = tmp_path / "sp500.html"
+    cache_path.write_text("<html><table id='constituents'></table></html>")
+
+    result = fetch_html(cache_path)
+
+    assert result == cache_path.read_text()
+    assert "table id=\"changes\"" in result
+
+
+def test_fetch_html_falls_back_to_valid_stale_cache_on_refresh_failure(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A failed refresh retains and returns the last-known-good stale generation."""
+    cache_path = tmp_path / "sp500.html"
+    expected = _build_valid_source_html()
+    cache_path.write_text(expected)
+    old_time = cache_path.stat().st_mtime - 48 * 3600
+    os.utime(cache_path, (old_time, old_time))
+    monkeypatch.setattr(
+        wikipedia.requests,
+        "get",
+        lambda *args, **kwargs: _Response(error=requests.RequestException("offline")),
+    )
+    warning = Mock()
+    monkeypatch.setattr(wikipedia.logger, "warning", warning)
+
+    assert fetch_html(cache_path) == expected
+    warning.assert_called_once()
+
+
+def test_fetch_html_keeps_cache_when_second_source_fetch_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A partial generation never replaces the previous valid cache."""
+    current, _ = _split_pages(_build_valid_source_html())
+    expected = _build_valid_source_html()
+    cache_path = tmp_path / "sp500.html"
+    cache_path.write_text(expected)
+    old_time = cache_path.stat().st_mtime - 48 * 3600
+    os.utime(cache_path, (old_time, old_time))
+    responses = iter([_Response(current), _Response(error=requests.RequestException("offline"))])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+
+    assert fetch_html(cache_path) == expected
+    assert cache_path.read_text() == expected
+
+
+def test_fetch_html_fails_closed_without_valid_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A failed refresh with no valid cache raises instead of returning partial data."""
+    monkeypatch.setattr(
+        wikipedia.requests,
+        "get",
+        lambda *args, **kwargs: _Response(error=requests.RequestException("offline")),
+    )
+
+    with pytest.raises(requests.RequestException):
+        fetch_html(tmp_path / "missing.html")
 
 
 def _build_identity_transition_html() -> str:

--- a/tests/unit/test_wikipedia_universe.py
+++ b/tests/unit/test_wikipedia_universe.py
@@ -178,6 +178,21 @@ class TestParseCurrentTickers:
 # ---------------------------------------------------------------------------
 
 class TestParseChangeLog:
+    def test_trailing_pipe_in_ticker_cell_is_removed(self) -> None:
+        html = _build_html(
+            {
+                "current_tickers": ["AAPL", "MSFT"],
+                "changes": [
+                    {"date": "2020-01-01", "added": ["ALLE |"], "removed": ["JCP |"]},
+                ],
+            }
+        )
+
+        event = parse_change_log(html)[0]
+
+        assert event.added == {"ALLE"}
+        assert event.removed == {"JCP"}
+
     def test_returns_correct_event_count(self, html: str, fixture: dict) -> None:
         events = parse_change_log(html)
         # One ChangeEvent per unique date in the fixture

--- a/tests/unit/test_wikipedia_universe.py
+++ b/tests/unit/test_wikipedia_universe.py
@@ -90,7 +90,7 @@ def _build_valid_source_html() -> str:
         f"{left}{right}A" for left in "ABCDEFGHIJKLMNOPQRST" for right in "ABCDEFGHIJKLMNOPQRST"
     ][:500]
     event_dates = [
-        (date(1979, 1, 1) + timedelta(days=145 * index)).isoformat() for index in range(100)
+        (date(1979, 1, 1) + timedelta(days=170 * index)).isoformat() for index in range(100)
     ]
     return _build_html(
         {
@@ -100,6 +100,29 @@ def _build_valid_source_html() -> str:
                     "date": event_date,
                     "added": ["ALLE |" if index == 0 else current_tickers[index]],
                     "removed": ["JCP |" if index == 0 else current_tickers[index + 1]],
+                }
+                for index, event_date in enumerate(event_dates)
+            ],
+        }
+    )
+
+
+def _build_historically_truncated_source_html() -> str:
+    """Build a syntactically valid source whose history ends before the recency floor."""
+    current_tickers = [
+        f"{left}{right}A" for left in "ABCDEFGHIJKLMNOPQRST" for right in "ABCDEFGHIJKLMNOPQRST"
+    ][:500]
+    event_dates = [
+        (date(1979, 1, 1) + timedelta(days=145 * index)).isoformat() for index in range(100)
+    ]
+    return _build_html(
+        {
+            "current_tickers": current_tickers,
+            "changes": [
+                {
+                    "date": event_date,
+                    "added": [current_tickers[index]],
+                    "removed": [current_tickers[index + 1]],
                 }
                 for index, event_date in enumerate(event_dates)
             ],
@@ -154,6 +177,99 @@ def test_fetch_html_combines_split_pages_and_atomically_publishes(monkeypatch: p
     assert parse_current_tickers(result)
     assert parse_change_log(result)[0].added == {"ALLE"}
     assert cache_path.read_text() == result
+    assert not list(tmp_path.glob(f".{cache_path.name}.*"))
+
+
+def test_fetch_html_flushes_and_fsyncs_before_replace(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Publication orders write/flush/fsync before same-directory replacement."""
+    current, historical = _split_pages(_build_valid_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    events: list[str] = []
+    original_factory = wikipedia.tempfile.NamedTemporaryFile
+    original_replace = Path.replace
+
+    class _InstrumentedTemporary:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            self._context = original_factory(*args, **kwargs)
+            self._file: object | None = None
+
+        def __enter__(self) -> _InstrumentedTemporary:
+            self._file = self._context.__enter__()
+            return self
+
+        @property
+        def name(self) -> str:
+            return self._file.name  # type: ignore[union-attr]
+
+        def __exit__(self, *args: object) -> object:
+            return self._context.__exit__(*args)
+
+        def write(self, value: str) -> int:
+            events.append("write")
+            return self._file.write(value)  # type: ignore[union-attr]
+
+        def flush(self) -> None:
+            events.append("flush")
+            self._file.flush()  # type: ignore[union-attr]
+
+        def fileno(self) -> int:
+            return self._file.fileno()  # type: ignore[union-attr]
+
+    monkeypatch.setattr(wikipedia.tempfile, "NamedTemporaryFile", _InstrumentedTemporary)
+    monkeypatch.setattr(wikipedia.os, "fsync", lambda fd: events.append("fsync"))
+    monkeypatch.setattr(
+        Path,
+        "replace",
+        lambda self, target: (events.append("replace"), original_replace(self, target))[1],
+    )
+
+    fetch_html(tmp_path / "sp500.html")
+
+    assert events == ["write", "flush", "fsync", "replace"]
+
+
+def test_fetch_html_preserves_stale_cache_when_fsync_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An fsync failure falls back to unchanged valid stale bytes and cleans the temp file."""
+    cache_path = tmp_path / "sp500.html"
+    expected = _build_valid_source_html()
+    cache_path.write_text(expected)
+    old_time = cache_path.stat().st_mtime - 48 * 3600
+    os.utime(cache_path, (old_time, old_time))
+    current, historical = _split_pages(expected)
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    monkeypatch.setattr(wikipedia.os, "fsync", Mock(side_effect=OSError("fsync failed")))
+    replace = Mock(wraps=Path.replace)
+    monkeypatch.setattr(Path, "replace", replace)
+
+    assert fetch_html(cache_path) == expected
+    assert cache_path.read_text() == expected
+    replace.assert_not_called()
+    assert not list(tmp_path.glob(f".{cache_path.name}.*"))
+
+
+def test_fetch_html_fails_closed_without_cache_when_fsync_fails(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An fsync failure without stale bytes publishes nothing and cleans the temp file."""
+    current, historical = _split_pages(_build_valid_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    monkeypatch.setattr(wikipedia.os, "fsync", Mock(side_effect=OSError("fsync failed")))
+    replace = Mock(wraps=Path.replace)
+    monkeypatch.setattr(Path, "replace", replace)
+    cache_path = tmp_path / "sp500.html"
+
+    with pytest.raises(RuntimeError, match="No valid Wikipedia"):
+        fetch_html(cache_path)
+
+    assert not cache_path.exists()
+    replace.assert_not_called()
     assert not list(tmp_path.glob(f".{cache_path.name}.*"))
 
 
@@ -224,6 +340,58 @@ def test_fetch_html_fails_closed_for_truncated_remote_source_without_cache(
 ) -> None:
     """A truncated HTTP-200 generation creates neither cache nor temporary sibling."""
     current, historical = _split_pages(_build_truncated_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+    cache_path = tmp_path / "sp500.html"
+
+    with pytest.raises(RuntimeError, match="No valid Wikipedia") as caught:
+        fetch_html(cache_path)
+
+    assert "historical coverage" in str(caught.value.__cause__)
+    assert not cache_path.exists()
+    assert not list(tmp_path.glob(f".{cache_path.name}.*"))
+
+
+def test_fetch_html_rejects_historically_truncated_remote_source_with_stale_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A 100-event source ending in 2018 cannot replace a valid stale generation."""
+    cache_path = tmp_path / "sp500.html"
+    expected = _build_valid_source_html()
+    cache_path.write_text(expected)
+    old_time = cache_path.stat().st_mtime - 48 * 3600
+    os.utime(cache_path, (old_time, old_time))
+    current, historical = _split_pages(_build_historically_truncated_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+
+    assert fetch_html(cache_path) == expected
+    assert cache_path.read_text() == expected
+    assert not list(tmp_path.glob(f".{cache_path.name}.*"))
+
+
+def test_fetch_html_replaces_historically_truncated_fresh_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A fresh 100-event source ending in 2018 is replaced by a complete refresh."""
+    cache_path = tmp_path / "sp500.html"
+    cache_path.write_text(_build_historically_truncated_source_html())
+    current, historical = _split_pages(_build_valid_source_html())
+    responses = iter([_Response(current), _Response(historical)])
+    monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
+
+    result = fetch_html(cache_path)
+
+    assert len(parse_change_log(result)) == 100
+    assert max(event.date for event in parse_change_log(result)) >= "2025-01-01"
+    assert cache_path.read_text() == result
+
+
+def test_fetch_html_fails_closed_for_historically_truncated_remote_source_without_cache(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A 100-event source ending in 2018 is rejected without publishing or temp leaks."""
+    current, historical = _split_pages(_build_historically_truncated_source_html())
     responses = iter([_Response(current), _Response(historical)])
     monkeypatch.setattr(wikipedia.requests, "get", lambda *args, **kwargs: next(responses))
     cache_path = tmp_path / "sp500.html"


### PR DESCRIPTION
## What this PR does
Hardens the Wikipedia S&P 500 universe cache path so cached HTML is validated before reuse, invalid/truncated cache content fails closed or is recovered from the live source according to the documented contract, and cache publication is atomic. The change also documents the cache boundary and adds focused regression coverage for cache corruption, live fallback, and point-in-time universe behavior.

## Outcome and execution links
- GitHub outcome issue: #293
- Root HQ Kanban task ID: `t_7a36af08`
- Kanban tenant: `trading`
- Root graph URL: HQ Kanban local task `t_7a36af08`

## Issue relation
Closes #293

## Layer(s) affected
- [x] Layer 0 — Data & universe
- [ ] Layer 1 — Features
- [ ] Layer 2 — Model
- [ ] Layer 3 — Portfolio
- [ ] Layer 4 — Risk
- [ ] Layer 5 — Execution
- [x] Infrastructure / services
- [ ] Tests only
- [x] Docs only

## Author
- [ ] Written by me
- [x] Generated by code-monkey — reviewed and approved by me

## Governance evidence
- Independent review task/profile and verdict: `t_e2ed3a4b`, `trading-code-reviewer`, PASS at exact head `01a04b3e530b502978bcf872f1677d19c02991b4` with zero Blocking findings.
- Domain acceptance (semantic/backend scope): `t_e545ca48`, Trading PASS at the exact reviewed head; evidence recorded in Issue #293 comment `issuecomment-5306824549`.
- Exceptional human gate decision, if applicable: none for this bounded cache-hardening code change. This PR does not authorize deployment, production cache mutation, canary, catch-up/backfill, Layer 2+, or Stock-tab evidence acceptance.
- Current-head merge gates: CI, live PR mergeability/CLEAN state, and fresh PR/current-base independent review are pending on this opened PR and must pass before merge.

---

## code-monkey checklist

### Correctness
- [x] Output matches schema defined in `core/contracts/schemas.py` (no schema change)
- [x] No logic added to forbidden files
- [x] No hardcoded credentials, API keys, or absolute file paths
- [x] No `print()` statements — logger used throughout
- [x] No bare `except:` or silent exception swallowing

### Tests
- [x] Focused candidate suite passed: 94 tests
- [x] Synthetic current-main integration full unit suite passed: 834 passed, 1 skipped
- [x] New behavior has focused regression coverage
- [x] No live API calls in unit tests

### Code quality
- [x] Public functions have type hints
- [x] Public functions have docstrings
- [x] Imports remain ordered
- [x] Ruff passed; focused mypy passed

### Project hygiene
- [x] Immutable reviewed branch preserved exactly (historical branch name retained; no rebase/amend)
- [x] Domain owner records GitHub lifecycle state
- [x] PR references both GitHub Issue #293 and root HQ task `t_7a36af08`
- [x] No unrelated files modified
- [x] No new dependency

---

## New dependencies
None

## Screenshots or sample output
N/A

## Notes for reviewer
The immutable PR head must remain `01a04b3e530b502978bcf872f1677d19c02991b4` (tree `d7669fae1e851cde9d652875746b1f8f4e425d89`). Review the complete four-file diff against current `main`; do not infer operational authorization from code-review or readiness results. Directory fsync remains outside Issue #293 scope. Project-wide `make typecheck` has an unchanged duplicate-module mapping baseline failure; focused service mypy passes.
